### PR TITLE
Run end-to-end tests only on the master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,5 +65,5 @@ workflows:
       - format_frontend
       - e2e:
           filters:
-            tags:
+            branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,4 +63,7 @@ workflows:
       - check_bash
       - build_python
       - format_frontend
-      - e2e
+      - e2e:
+          filters:
+            tags:
+              only: master


### PR DESCRIPTION
Our end-to-end tests are costly, but not very rigorous, so they rarely (if ever) catch any failures, but they slow down our development workflow. This change skips the end-to-end tests on pull requests and limits them to the master branch.

This has the downside that we'll notice build failures later, but I think this happens so infrequently that it's not a problem. We can revert it later if it becomes a problem.