### PR TITLE
Refactor keystroke processing

### DIFF
--- a/app/js_to_hid.py
+++ b/app/js_to_hid.py
@@ -9,7 +9,7 @@ class UnrecognizedKeyCodeError(Error):
     pass
 
 
-_MODIFIER_KEYCODES = [
+MODIFIER_KEYCODES = [
     'AltLeft',
     'AltRight',
     'ControlLeft',
@@ -156,32 +156,23 @@ def _map_modifier_keys(keystroke):
 
     if keystroke.left_ctrl_modifier:
         modifier_bitmask |= hid.MODIFIER_LEFT_CTRL
+    if keystroke.right_ctrl_modifier:
+        modifier_bitmask |= hid.MODIFIER_RIGHT_CTRL
+
     if keystroke.left_shift_modifier:
         modifier_bitmask |= hid.MODIFIER_LEFT_SHIFT
+    if keystroke.right_shift_modifier:
+        modifier_bitmask |= hid.MODIFIER_RIGHT_SHIFT
+
     if keystroke.left_alt_modifier:
         modifier_bitmask |= hid.MODIFIER_LEFT_ALT
-    if keystroke.left_meta_modifier:
-        modifier_bitmask |= hid.MODIFIER_LEFT_META
     if keystroke.right_alt_modifier:
         modifier_bitmask |= hid.MODIFIER_RIGHT_ALT
 
-    # This is a workaround for the fact that the frontend currently sends only
-    # limited information about which modifiers are pressed. We can't detect
-    # left + right, so if the current key press is a right modifier, we assume
-    # its righthand modifier is not also pressed.
-    # https://github.com/tiny-pilot/tinypilot/issues/364
-    if keystroke.code == 'ControlRight':
-        modifier_bitmask &= ~hid.MODIFIER_LEFT_CTRL
-        modifier_bitmask |= hid.MODIFIER_RIGHT_CTRL
-    elif keystroke.code == 'ShiftRight':
-        modifier_bitmask &= ~hid.MODIFIER_LEFT_SHIFT
-        modifier_bitmask |= hid.MODIFIER_RIGHT_SHIFT
-    elif keystroke.code == 'MetaRight':
-        modifier_bitmask &= ~hid.MODIFIER_RIGHT_META
+    if keystroke.left_meta_modifier:
+        modifier_bitmask |= hid.MODIFIER_LEFT_META
+    if keystroke.right_meta_modifier:
         modifier_bitmask |= hid.MODIFIER_RIGHT_META
-    elif keystroke.code == 'AltRight':
-        modifier_bitmask &= ~hid.MODIFIER_LEFT_ALT
-        modifier_bitmask |= hid.MODIFIER_RIGHT_ALT
 
     return modifier_bitmask
 
@@ -192,7 +183,7 @@ def _map_keycode(keystroke):
     # KEYCODE_NONE. This is based on a report that certain KVMs only recognize
     # a modifier keystroke if the HID code is KEYCODE_NONE, but we should verify
     # that it matches behavior from normal USB keyboards.
-    if (keystroke.code in _MODIFIER_KEYCODES and
+    if (keystroke.code in MODIFIER_KEYCODES and
             _count_modifiers(keystroke) == 1):
         return hid.KEYCODE_NONE
 
@@ -205,7 +196,10 @@ def _map_keycode(keystroke):
 
 def _count_modifiers(keystroke):
     return (int(keystroke.left_ctrl_modifier) +
+            int(keystroke.right_ctrl_modifier) +
             int(keystroke.left_shift_modifier) +
+            int(keystroke.right_shift_modifier) +
             int(keystroke.left_alt_modifier) +
+            int(keystroke.right_alt_modifier) +
             int(keystroke.left_meta_modifier) +
-            int(keystroke.right_alt_modifier))
+            int(keystroke.right_meta_modifier))

--- a/app/js_to_hid.py
+++ b/app/js_to_hid.py
@@ -9,7 +9,7 @@ class UnrecognizedKeyCodeError(Error):
     pass
 
 
-MODIFIER_KEYCODES = [
+_MODIFIER_KEYCODES = [
     'AltLeft',
     'AltRight',
     'ControlLeft',
@@ -183,7 +183,7 @@ def _map_keycode(keystroke):
     # KEYCODE_NONE. This is based on a report that certain KVMs only recognize
     # a modifier keystroke if the HID code is KEYCODE_NONE, but we should verify
     # that it matches behavior from normal USB keyboards.
-    if (keystroke.code in MODIFIER_KEYCODES and
+    if (keystroke.code in _MODIFIER_KEYCODES and
             _count_modifiers(keystroke) == 1):
         return hid.KEYCODE_NONE
 

--- a/app/js_to_hid_test.py
+++ b/app/js_to_hid_test.py
@@ -10,10 +10,13 @@ class ConvertJsToHIDTest(unittest.TestCase):
     def test_converts_simple_keystroke(self):
         modifier_bitmask, hid_keycode = js_to_hid.convert(
             keystroke.Keystroke(left_meta_modifier=False,
+                                right_meta_modifier=False,
                                 left_alt_modifier=False,
-                                left_shift_modifier=False,
-                                left_ctrl_modifier=False,
                                 right_alt_modifier=False,
+                                left_shift_modifier=False,
+                                right_shift_modifier=False,
+                                left_ctrl_modifier=False,
+                                right_ctrl_modifier=False,
                                 key='a',
                                 code='KeyA'))
         self.assertEqual(0, modifier_bitmask)
@@ -22,10 +25,13 @@ class ConvertJsToHIDTest(unittest.TestCase):
     def test_converts_shifted_keystroke(self):
         modifier_bitmask, hid_keycode = js_to_hid.convert(
             keystroke.Keystroke(left_meta_modifier=False,
+                                right_meta_modifier=False,
                                 left_alt_modifier=False,
-                                left_shift_modifier=True,
-                                left_ctrl_modifier=False,
                                 right_alt_modifier=False,
+                                left_shift_modifier=True,
+                                right_shift_modifier=False,
+                                left_ctrl_modifier=False,
+                                right_ctrl_modifier=False,
                                 key='A',
                                 code='KeyA'))
         self.assertEqual(hid.MODIFIER_LEFT_SHIFT, modifier_bitmask)
@@ -34,25 +40,32 @@ class ConvertJsToHIDTest(unittest.TestCase):
     def test_converts_keystroke_with_all_modifiers_pressed(self):
         modifier_bitmask, hid_keycode = js_to_hid.convert(
             keystroke.Keystroke(left_meta_modifier=True,
+                                right_meta_modifier=True,
                                 left_alt_modifier=True,
-                                left_shift_modifier=True,
-                                left_ctrl_modifier=True,
                                 right_alt_modifier=True,
+                                left_shift_modifier=True,
+                                right_shift_modifier=True,
+                                left_ctrl_modifier=True,
+                                right_ctrl_modifier=True,
                                 key='A',
                                 code='KeyA'))
         self.assertEqual(
-            hid.MODIFIER_LEFT_META | hid.MODIFIER_LEFT_ALT |
-            hid.MODIFIER_LEFT_SHIFT | hid.MODIFIER_LEFT_CTRL |
-            hid.MODIFIER_RIGHT_ALT, modifier_bitmask)
+            hid.MODIFIER_LEFT_META | hid.MODIFIER_RIGHT_META |
+            hid.MODIFIER_LEFT_ALT | hid.MODIFIER_RIGHT_ALT |
+            hid.MODIFIER_LEFT_SHIFT | hid.MODIFIER_RIGHT_SHIFT |
+            hid.MODIFIER_LEFT_CTRL | hid.MODIFIER_RIGHT_CTRL, modifier_bitmask)
         self.assertEqual(hid.KEYCODE_A, hid_keycode)
 
     def test_converts_left_ctrl_keystroke(self):
         modifier_bitmask, hid_keycode = js_to_hid.convert(
             keystroke.Keystroke(left_meta_modifier=False,
+                                right_meta_modifier=False,
                                 left_alt_modifier=False,
-                                left_shift_modifier=False,
-                                left_ctrl_modifier=True,
                                 right_alt_modifier=False,
+                                left_shift_modifier=False,
+                                right_shift_modifier=False,
+                                left_ctrl_modifier=True,
+                                right_ctrl_modifier=False,
                                 key='Control',
                                 code='ControlLeft'))
         self.assertEqual(hid.MODIFIER_LEFT_CTRL, modifier_bitmask)
@@ -61,10 +74,13 @@ class ConvertJsToHIDTest(unittest.TestCase):
     def test_converts_right_ctrl_keystroke(self):
         modifier_bitmask, hid_keycode = js_to_hid.convert(
             keystroke.Keystroke(left_meta_modifier=False,
+                                right_meta_modifier=False,
                                 left_alt_modifier=False,
-                                left_shift_modifier=False,
-                                left_ctrl_modifier=True,
                                 right_alt_modifier=False,
+                                left_shift_modifier=False,
+                                right_shift_modifier=False,
+                                left_ctrl_modifier=False,
+                                right_ctrl_modifier=True,
                                 key='Control',
                                 code='ControlRight'))
         self.assertEqual(hid.MODIFIER_RIGHT_CTRL, modifier_bitmask)
@@ -73,10 +89,13 @@ class ConvertJsToHIDTest(unittest.TestCase):
     def test_converts_left_ctrl_with_shift_left_keystroke(self):
         modifier_bitmask, hid_keycode = js_to_hid.convert(
             keystroke.Keystroke(left_meta_modifier=False,
+                                right_meta_modifier=False,
                                 left_alt_modifier=False,
-                                left_shift_modifier=True,
-                                left_ctrl_modifier=True,
                                 right_alt_modifier=False,
+                                left_shift_modifier=True,
+                                right_shift_modifier=False,
+                                left_ctrl_modifier=True,
+                                right_ctrl_modifier=False,
                                 key='Control',
                                 code='ControlLeft'))
         self.assertEqual(hid.MODIFIER_LEFT_CTRL | hid.MODIFIER_LEFT_SHIFT,

--- a/app/request_parsers/keystroke.py
+++ b/app/request_parsers/keystroke.py
@@ -23,11 +23,16 @@ class InvalidLocationError(Error):
 
 @dataclasses.dataclass
 class Keystroke:
+    # TODO(jotaen) Rename all modifiers to `ctrl_left_...` etc. instead of
+    #              `left_ctrl_...` to make the naming consistent.
     left_ctrl_modifier: bool
+    right_ctrl_modifier: bool
     left_shift_modifier: bool
+    right_shift_modifier: bool
     left_alt_modifier: bool
-    left_meta_modifier: bool
     right_alt_modifier: bool
+    left_meta_modifier: bool
+    right_meta_modifier: bool
     key: str
     code: str
 
@@ -39,22 +44,28 @@ def parse_keystroke(message):
     required_fields = (
         'key',
         'code',
-        'ctrlKey',
-        'shiftKey',
-        'altKey',
-        'metaKey',
-        'altGraphKey',
+        'ctrlLeft',
+        'ctrlRight',
+        'shiftLeft',
+        'shiftRight',
+        'altLeft',
+        'altRight',
+        'metaLeft',
+        'metaRight',
     )
     for field in required_fields:
         if field not in message:
             raise MissingFieldErrorError(
                 'Keystroke request is missing required field: %s' % field)
     return Keystroke(
-        left_ctrl_modifier=_parse_modifier_key(message['ctrlKey']),
-        left_shift_modifier=_parse_modifier_key(message['shiftKey']),
-        left_alt_modifier=_parse_modifier_key(message['altKey']),
-        left_meta_modifier=_parse_modifier_key(message['metaKey']),
-        right_alt_modifier=_parse_modifier_key(message['altGraphKey']),
+        left_ctrl_modifier=_parse_modifier_key(message['ctrlLeft']),
+        right_ctrl_modifier=_parse_modifier_key(message['ctrlRight']),
+        left_shift_modifier=_parse_modifier_key(message['shiftLeft']),
+        right_shift_modifier=_parse_modifier_key(message['shiftRight']),
+        left_alt_modifier=_parse_modifier_key(message['altLeft']),
+        right_alt_modifier=_parse_modifier_key(message['altRight']),
+        left_meta_modifier=_parse_modifier_key(message['metaLeft']),
+        right_meta_modifier=_parse_modifier_key(message['metaRight']),
         key=message['key'],
         code=_parse_code(message['code']))
 

--- a/app/request_parsers/keystroke_test.py
+++ b/app/request_parsers/keystroke_test.py
@@ -2,15 +2,10 @@ import unittest
 
 from request_parsers import keystroke
 
-_MODIFIER_PROPS = [
-    'metaLeft', 'metaRight', 'altLeft', 'altRight', 'shiftLeft', 'shiftRight',
-    'ctrlLeft', 'ctrlRight'
-]
-
 
 class KeystrokeTest(unittest.TestCase):
 
-    # Intentionally violating style conventions so that we can parallel the
+    # Intentionally violating style conventions sot hat we can parallel the
     # self.assertEqual method.
     # pylint: disable=no-self-use
     # pylint: disable=invalid-name
@@ -21,24 +16,18 @@ class KeystrokeTest(unittest.TestCase):
     def test_parses_valid_keystroke_message(self):
         self.assertKeystrokesEqual(
             keystroke.Keystroke(left_meta_modifier=False,
-                                right_meta_modifier=False,
                                 left_alt_modifier=False,
-                                right_alt_modifier=False,
                                 left_shift_modifier=False,
-                                right_shift_modifier=False,
                                 left_ctrl_modifier=False,
-                                right_ctrl_modifier=False,
+                                right_alt_modifier=False,
                                 key='A',
                                 code='KeyA'),
             keystroke.parse_keystroke({
-                'metaLeft': False,
-                'metaRight': False,
-                'altLeft': False,
-                'altRight': False,
-                'shiftLeft': False,
-                'shiftRight': False,
-                'ctrlLeft': False,
-                'ctrlRight': False,
+                'metaKey': False,
+                'altKey': False,
+                'shiftKey': False,
+                'ctrlKey': False,
+                'altGraphKey': False,
                 'key': 'A',
                 'code': 'KeyA',
             }))
@@ -46,24 +35,18 @@ class KeystrokeTest(unittest.TestCase):
     def test_parses_valid_keystroke_message_with_all_modifiers_pushed(self):
         self.assertKeystrokesEqual(
             keystroke.Keystroke(left_meta_modifier=True,
-                                right_meta_modifier=True,
                                 left_alt_modifier=True,
-                                right_alt_modifier=True,
                                 left_shift_modifier=True,
-                                right_shift_modifier=True,
                                 left_ctrl_modifier=True,
-                                right_ctrl_modifier=True,
+                                right_alt_modifier=True,
                                 key='A',
                                 code='KeyA'),
             keystroke.parse_keystroke({
-                'metaLeft': True,
-                'metaRight': True,
-                'altLeft': True,
-                'altRight': True,
-                'shiftLeft': True,
-                'shiftRight': True,
-                'ctrlLeft': True,
-                'ctrlRight': True,
+                'metaKey': True,
+                'altKey': True,
+                'shiftKey': True,
+                'ctrlKey': True,
+                'altGraphKey': True,
                 'key': 'A',
                 'code': 'KeyA',
             }))
@@ -71,117 +54,208 @@ class KeystrokeTest(unittest.TestCase):
     def test_parses_left_ctrl_key(self):
         self.assertKeystrokesEqual(
             keystroke.Keystroke(left_meta_modifier=False,
-                                right_meta_modifier=False,
                                 left_alt_modifier=False,
-                                right_alt_modifier=False,
                                 left_shift_modifier=False,
-                                right_shift_modifier=False,
                                 left_ctrl_modifier=True,
-                                right_ctrl_modifier=False,
+                                right_alt_modifier=False,
                                 key='Control',
                                 code='ControlLeft'),
             keystroke.parse_keystroke({
-                'metaLeft': False,
-                'metaRight': False,
-                'altLeft': False,
-                'altRight': False,
-                'shiftLeft': False,
-                'shiftRight': False,
-                'ctrlLeft': True,
-                'ctrlRight': False,
+                'metaKey': False,
+                'altKey': False,
+                'shiftKey': False,
+                'ctrlKey': True,
+                'altGraphKey': False,
                 'key': 'Control',
                 'code': 'ControlLeft',
             }))
 
     def test_parses_right_ctrl_key(self):
         self.assertKeystrokesEqual(
-            keystroke.Keystroke(left_meta_modifier=False,
-                                right_meta_modifier=False,
-                                left_alt_modifier=False,
-                                right_alt_modifier=False,
-                                left_shift_modifier=False,
-                                right_shift_modifier=False,
-                                left_ctrl_modifier=False,
-                                right_ctrl_modifier=True,
-                                key='Control',
-                                code='ControlRight'),
+            keystroke.Keystroke(
+                left_meta_modifier=False,
+                left_alt_modifier=False,
+                left_shift_modifier=False,
+                # For simplicity, we store right Ctrl modifier in
+                # left_ctrl_modifier since there's no right version in
+                # keystroke.Keystroke.
+                left_ctrl_modifier=True,
+                right_alt_modifier=False,
+                key='Control',
+                code='ControlRight'),
             keystroke.parse_keystroke({
-                'metaLeft': False,
-                'metaRight': False,
-                'altLeft': False,
-                'altRight': False,
-                'shiftLeft': False,
-                'shiftRight': False,
-                'ctrlLeft': False,
-                'ctrlRight': True,
+                'metaKey': False,
+                'altKey': False,
+                'shiftKey': False,
+                'ctrlKey': True,
+                'altGraphKey': False,
                 'key': 'Control',
                 'code': 'ControlRight',
             }))
 
-    def test_rejects_invalid_properties(self):
-        for invalid_prop in _MODIFIER_PROPS:
-            with self.subTest(invalid_prop), self.assertRaises(
-                    keystroke.InvalidModifierKeyError):
-                props = {
-                    'metaLeft': False,
-                    'metaRight': False,
-                    'altLeft': False,
-                    'altRight': False,
-                    'shiftLeft': False,
-                    'shiftRight': False,
-                    'ctrlLeft': False,
-                    'ctrlRight': False,
-                    'key': 'A',
-                    'code': 'KeyA'
-                }
-                props[invalid_prop] = 'banana'
-                keystroke.parse_keystroke(props)
-
     def test_rejects_float_keycode_value(self):
         with self.assertRaises(keystroke.InvalidKeyCodeError):
             keystroke.parse_keystroke({
-                'metaLeft': False,
-                'metaRight': False,
-                'altLeft': False,
-                'altRight': False,
-                'shiftLeft': False,
-                'shiftRight': False,
-                'ctrlLeft': False,
-                'ctrlRight': False,
+                'metaKey': False,
+                'altKey': False,
+                'shiftKey': False,
+                'ctrlKey': False,
+                'altGraphKey': False,
                 'key': 'A',
                 'code': 1.25,
             })
 
-    def test_rejects_missing_value(self):
-        for missing_prop in _MODIFIER_PROPS + ['code', 'key']:
-            with self.subTest(missing_prop), self.assertRaises(
-                    keystroke.MissingFieldErrorError):
-                props = {
-                    'metaLeft': False,
-                    'metaRight': False,
-                    'altLeft': False,
-                    'altRight': False,
-                    'shiftLeft': False,
-                    'shiftRight': False,
-                    'ctrlLeft': False,
-                    'ctrlRight': False,
-                    'key': 'A',
-                    'code': 'KeyA'
-                }
-                del props[missing_prop]
-                keystroke.parse_keystroke(props)
-
     def test_rejects_too_long_code_value(self):
         with self.assertRaises(keystroke.InvalidKeyCodeError):
             keystroke.parse_keystroke({
-                'metaLeft': False,
-                'metaRight': False,
-                'altLeft': False,
-                'altRight': False,
-                'shiftLeft': False,
-                'shiftRight': False,
-                'ctrlLeft': False,
-                'ctrlRight': False,
+                'metaKey': False,
+                'altKey': False,
+                'shiftKey': False,
+                'ctrlKey': False,
+                'altGraphKey': False,
                 'key': 'A',
                 'code': 'A' * 31,
+            })
+
+
+class KeystrokeWithInvalidValuesTest(unittest.TestCase):
+
+    def test_rejects_invalid_meta_modifier(self):
+        with self.assertRaises(keystroke.InvalidModifierKeyError):
+            keystroke.parse_keystroke({
+                'metaKey': 'banana',
+                'altKey': False,
+                'shiftKey': False,
+                'ctrlKey': False,
+                'altGraphKey': False,
+                'key': 'A',
+                'code': 'KeyA',
+            })
+
+    def test_rejects_invalid_alt_modifier(self):
+        with self.assertRaises(keystroke.InvalidModifierKeyError):
+            keystroke.parse_keystroke({
+                'metaKey': False,
+                'altKey': 'banana',
+                'shiftKey': False,
+                'ctrlKey': False,
+                'altGraphKey': False,
+                'key': 'A',
+                'code': 'KeyA',
+            })
+
+    def test_rejects_invalid_shift_modifier(self):
+        with self.assertRaises(keystroke.InvalidModifierKeyError):
+            keystroke.parse_keystroke({
+                'metaKey': False,
+                'altKey': False,
+                'shiftKey': 'banana',
+                'ctrlKey': False,
+                'altGraphKey': False,
+                'key': 'A',
+                'code': 'KeyA',
+            })
+
+    def test_rejects_invalid_ctrl_modifier(self):
+        with self.assertRaises(keystroke.InvalidModifierKeyError):
+            keystroke.parse_keystroke({
+                'metaKey': False,
+                'altKey': False,
+                'shiftKey': False,
+                'ctrlKey': 'banana',
+                'altGraphKey': False,
+                'key': 'A',
+                'code': 'KeyA',
+            })
+
+    def test_rejects_invalid_alt_graph_modifier(self):
+        with self.assertRaises(keystroke.InvalidModifierKeyError):
+            keystroke.parse_keystroke({
+                'metaKey': False,
+                'altKey': False,
+                'shiftKey': False,
+                'ctrlKey': False,
+                'altGraphKey': 'banana',
+                'key': 'A',
+                'code': 'KeyA',
+            })
+
+
+class KeystrokeWithMissingFieldsTest(unittest.TestCase):
+
+    def test_rejects_missing_meta_key_value(self):
+        with self.assertRaises(keystroke.MissingFieldErrorError):
+            keystroke.parse_keystroke({
+                'altKey': False,
+                'shiftKey': False,
+                'ctrlKey': False,
+                'altGraphKey': False,
+                'key': 'A',
+                'code': 'KeyA',
+            })
+
+    def test_rejects_missing_alt_key_value(self):
+        with self.assertRaises(keystroke.MissingFieldErrorError):
+            keystroke.parse_keystroke({
+                'metaKey': False,
+                'shiftKey': False,
+                'ctrlKey': False,
+                'altGraphKey': False,
+                'key': 'A',
+                'code': 'KeyA',
+            })
+
+    def test_rejects_missing_alt_graph_key_value(self):
+        with self.assertRaises(keystroke.MissingFieldErrorError):
+            keystroke.parse_keystroke({
+                'altKey': False,
+                'metaKey': False,
+                'shiftKey': False,
+                'ctrlKey': False,
+                'key': 'A',
+                'code': 'KeyA',
+            })
+
+    def test_rejects_missing_shift_key_value(self):
+        with self.assertRaises(keystroke.MissingFieldErrorError):
+            keystroke.parse_keystroke({
+                'metaKey': False,
+                'altKey': False,
+                'ctrlKey': False,
+                'altGraphKey': False,
+                'key': 'A',
+                'code': 'KeyA',
+            })
+
+    def test_rejects_missing_ctrl_key_value(self):
+        with self.assertRaises(keystroke.MissingFieldErrorError):
+            keystroke.parse_keystroke({
+                'metaKey': False,
+                'altKey': False,
+                'shiftKey': False,
+                'altGraphKey': False,
+                'key': 'A',
+                'code': 'KeyA',
+            })
+
+    def test_rejects_missing_key_value(self):
+        with self.assertRaises(keystroke.MissingFieldErrorError):
+            keystroke.parse_keystroke({
+                'metaKey': False,
+                'altKey': False,
+                'shiftKey': False,
+                'ctrlKey': False,
+                'altGraphKey': False,
+                'code': 'KeyA',
+            })
+
+    def test_rejects_missing_code_value(self):
+        with self.assertRaises(keystroke.MissingFieldErrorError):
+            keystroke.parse_keystroke({
+                'metaKey': False,
+                'altKey': False,
+                'shiftKey': False,
+                'ctrlKey': False,
+                'altGraphKey': False,
+                'key': 'A',
             })

--- a/app/request_parsers/keystroke_test.py
+++ b/app/request_parsers/keystroke_test.py
@@ -2,10 +2,15 @@ import unittest
 
 from request_parsers import keystroke
 
+_MODIFIER_PROPS = [
+    'metaLeft', 'metaRight', 'altLeft', 'altRight', 'shiftLeft', 'shiftRight',
+    'ctrlLeft', 'ctrlRight'
+]
+
 
 class KeystrokeTest(unittest.TestCase):
 
-    # Intentionally violating style conventions sot hat we can parallel the
+    # Intentionally violating style conventions so that we can parallel the
     # self.assertEqual method.
     # pylint: disable=no-self-use
     # pylint: disable=invalid-name
@@ -16,18 +21,24 @@ class KeystrokeTest(unittest.TestCase):
     def test_parses_valid_keystroke_message(self):
         self.assertKeystrokesEqual(
             keystroke.Keystroke(left_meta_modifier=False,
+                                right_meta_modifier=False,
                                 left_alt_modifier=False,
-                                left_shift_modifier=False,
-                                left_ctrl_modifier=False,
                                 right_alt_modifier=False,
+                                left_shift_modifier=False,
+                                right_shift_modifier=False,
+                                left_ctrl_modifier=False,
+                                right_ctrl_modifier=False,
                                 key='A',
                                 code='KeyA'),
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'ctrlLeft': False,
+                'ctrlRight': False,
                 'key': 'A',
                 'code': 'KeyA',
             }))
@@ -35,18 +46,24 @@ class KeystrokeTest(unittest.TestCase):
     def test_parses_valid_keystroke_message_with_all_modifiers_pushed(self):
         self.assertKeystrokesEqual(
             keystroke.Keystroke(left_meta_modifier=True,
+                                right_meta_modifier=True,
                                 left_alt_modifier=True,
-                                left_shift_modifier=True,
-                                left_ctrl_modifier=True,
                                 right_alt_modifier=True,
+                                left_shift_modifier=True,
+                                right_shift_modifier=True,
+                                left_ctrl_modifier=True,
+                                right_ctrl_modifier=True,
                                 key='A',
                                 code='KeyA'),
             keystroke.parse_keystroke({
-                'metaKey': True,
-                'altKey': True,
-                'shiftKey': True,
-                'ctrlKey': True,
-                'altGraphKey': True,
+                'metaLeft': True,
+                'metaRight': True,
+                'altLeft': True,
+                'altRight': True,
+                'shiftLeft': True,
+                'shiftRight': True,
+                'ctrlLeft': True,
+                'ctrlRight': True,
                 'key': 'A',
                 'code': 'KeyA',
             }))
@@ -54,202 +71,115 @@ class KeystrokeTest(unittest.TestCase):
     def test_parses_left_ctrl_key(self):
         self.assertKeystrokesEqual(
             keystroke.Keystroke(left_meta_modifier=False,
+                                right_meta_modifier=False,
                                 left_alt_modifier=False,
-                                left_shift_modifier=False,
-                                left_ctrl_modifier=True,
                                 right_alt_modifier=False,
+                                left_shift_modifier=False,
+                                right_shift_modifier=False,
+                                left_ctrl_modifier=True,
+                                right_ctrl_modifier=False,
                                 key='Control',
                                 code='ControlLeft'),
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': True,
-                'altGraphKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'ctrlLeft': True,
+                'ctrlRight': False,
                 'key': 'Control',
                 'code': 'ControlLeft',
             }))
 
     def test_parses_right_ctrl_key(self):
         self.assertKeystrokesEqual(
-            keystroke.Keystroke(
-                left_meta_modifier=False,
-                left_alt_modifier=False,
-                left_shift_modifier=False,
-                # For simplicity, we store right Ctrl modifier in
-                # left_ctrl_modifier since there's no right version in
-                # keystroke.Keystroke.
-                left_ctrl_modifier=True,
-                right_alt_modifier=False,
-                key='Control',
-                code='ControlRight'),
+            keystroke.Keystroke(left_meta_modifier=False,
+                                right_meta_modifier=False,
+                                left_alt_modifier=False,
+                                right_alt_modifier=False,
+                                left_shift_modifier=False,
+                                right_shift_modifier=False,
+                                left_ctrl_modifier=False,
+                                right_ctrl_modifier=True,
+                                key='Control',
+                                code='ControlRight'),
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': True,
-                'altGraphKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'ctrlLeft': False,
+                'ctrlRight': True,
                 'key': 'Control',
                 'code': 'ControlRight',
             }))
 
-    def test_rejects_invalid_meta_modifier(self):
-        with self.assertRaises(keystroke.InvalidModifierKeyError):
-            keystroke.parse_keystroke({
-                'metaKey': 'banana',
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
-                'key': 'A',
-                'code': 'KeyA',
-            })
-
-    def test_rejects_invalid_alt_modifier(self):
-        with self.assertRaises(keystroke.InvalidModifierKeyError):
-            keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': 'banana',
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
-                'key': 'A',
-                'code': 'KeyA',
-            })
-
-    def test_rejects_invalid_shift_modifier(self):
-        with self.assertRaises(keystroke.InvalidModifierKeyError):
-            keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': 'banana',
-                'ctrlKey': False,
-                'altGraphKey': False,
-                'key': 'A',
-                'code': 'KeyA',
-            })
-
-    def test_rejects_invalid_ctrl_modifier(self):
-        with self.assertRaises(keystroke.InvalidModifierKeyError):
-            keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': 'banana',
-                'altGraphKey': False,
-                'key': 'A',
-                'code': 'KeyA',
-            })
-
-    def test_rejects_invalid_alt_graph_modifier(self):
-        with self.assertRaises(keystroke.InvalidModifierKeyError):
-            keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': 'banana',
-                'key': 'A',
-                'code': 'KeyA',
-            })
+    def test_rejects_invalid_properties(self):
+        for invalid_prop in _MODIFIER_PROPS:
+            with self.assertRaises(keystroke.InvalidModifierKeyError):
+                props = {
+                    'metaLeft': False,
+                    'metaRight': False,
+                    'altLeft': False,
+                    'altRight': False,
+                    'shiftLeft': False,
+                    'shiftRight': False,
+                    'ctrlLeft': False,
+                    'ctrlRight': False,
+                    'key': 'A',
+                    'code': 'KeyA'
+                }
+                props[invalid_prop] = 'banana'
+                keystroke.parse_keystroke(props)
 
     def test_rejects_float_keycode_value(self):
         with self.assertRaises(keystroke.InvalidKeyCodeError):
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'ctrlLeft': False,
+                'ctrlRight': False,
                 'key': 'A',
                 'code': 1.25,
             })
 
-    def test_rejects_missing_meta_key_value(self):
-        with self.assertRaises(keystroke.MissingFieldErrorError):
-            keystroke.parse_keystroke({
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
-                'key': 'A',
-                'code': 'KeyA',
-            })
-
-    def test_rejects_missing_alt_key_value(self):
-        with self.assertRaises(keystroke.MissingFieldErrorError):
-            keystroke.parse_keystroke({
-                'metaKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
-                'key': 'A',
-                'code': 'KeyA',
-            })
-
-    def test_rejects_missing_alt_graph_key_value(self):
-        with self.assertRaises(keystroke.MissingFieldErrorError):
-            keystroke.parse_keystroke({
-                'altKey': False,
-                'metaKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'key': 'A',
-                'code': 'KeyA',
-            })
-
-    def test_rejects_missing_shift_key_value(self):
-        with self.assertRaises(keystroke.MissingFieldErrorError):
-            keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
-                'key': 'A',
-                'code': 'KeyA',
-            })
-
-    def test_rejects_missing_ctrl_key_value(self):
-        with self.assertRaises(keystroke.MissingFieldErrorError):
-            keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'altGraphKey': False,
-                'key': 'A',
-                'code': 'KeyA',
-            })
-
-    def test_rejects_missing_key_value(self):
-        with self.assertRaises(keystroke.MissingFieldErrorError):
-            keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
-                'code': 'KeyA',
-            })
-
-    def test_rejects_missing_code_value(self):
-        with self.assertRaises(keystroke.MissingFieldErrorError):
-            keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
-                'key': 'A',
-            })
+    def test_rejects_missing_value(self):
+        for missing_prop in _MODIFIER_PROPS + ['code', 'key']:
+            with self.assertRaises(keystroke.MissingFieldErrorError):
+                props = {
+                    'metaLeft': False,
+                    'metaRight': False,
+                    'altLeft': False,
+                    'altRight': False,
+                    'shiftLeft': False,
+                    'shiftRight': False,
+                    'ctrlLeft': False,
+                    'ctrlRight': False,
+                    'key': 'A',
+                    'code': 'KeyA'
+                }
+                del props[missing_prop]
+                keystroke.parse_keystroke(props)
 
     def test_rejects_too_long_code_value(self):
         with self.assertRaises(keystroke.InvalidKeyCodeError):
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'ctrlLeft': False,
+                'ctrlRight': False,
                 'key': 'A',
                 'code': 'A' * 31,
             })

--- a/app/request_parsers/keystroke_test.py
+++ b/app/request_parsers/keystroke_test.py
@@ -16,18 +16,24 @@ class KeystrokeTest(unittest.TestCase):
     def test_parses_valid_keystroke_message(self):
         self.assertKeystrokesEqual(
             keystroke.Keystroke(left_meta_modifier=False,
+                                right_meta_modifier=False,
                                 left_alt_modifier=False,
-                                left_shift_modifier=False,
-                                left_ctrl_modifier=False,
                                 right_alt_modifier=False,
+                                left_shift_modifier=False,
+                                right_shift_modifier=False,
+                                left_ctrl_modifier=False,
+                                right_ctrl_modifier=False,
                                 key='A',
                                 code='KeyA'),
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'ctrlLeft': False,
+                'ctrlRight': False,
                 'key': 'A',
                 'code': 'KeyA',
             }))
@@ -35,18 +41,24 @@ class KeystrokeTest(unittest.TestCase):
     def test_parses_valid_keystroke_message_with_all_modifiers_pushed(self):
         self.assertKeystrokesEqual(
             keystroke.Keystroke(left_meta_modifier=True,
+                                right_meta_modifier=True,
                                 left_alt_modifier=True,
-                                left_shift_modifier=True,
-                                left_ctrl_modifier=True,
                                 right_alt_modifier=True,
+                                left_shift_modifier=True,
+                                right_shift_modifier=True,
+                                left_ctrl_modifier=True,
+                                right_ctrl_modifier=True,
                                 key='A',
                                 code='KeyA'),
             keystroke.parse_keystroke({
-                'metaKey': True,
-                'altKey': True,
-                'shiftKey': True,
-                'ctrlKey': True,
-                'altGraphKey': True,
+                'metaLeft': True,
+                'metaRight': True,
+                'shiftLeft': True,
+                'shiftRight': True,
+                'altLeft': True,
+                'altRight': True,
+                'ctrlLeft': True,
+                'ctrlRight': True,
                 'key': 'A',
                 'code': 'KeyA',
             }))
@@ -54,53 +66,64 @@ class KeystrokeTest(unittest.TestCase):
     def test_parses_left_ctrl_key(self):
         self.assertKeystrokesEqual(
             keystroke.Keystroke(left_meta_modifier=False,
+                                right_meta_modifier=False,
                                 left_alt_modifier=False,
-                                left_shift_modifier=False,
-                                left_ctrl_modifier=True,
                                 right_alt_modifier=False,
+                                left_shift_modifier=False,
+                                right_shift_modifier=False,
+                                left_ctrl_modifier=True,
+                                right_ctrl_modifier=False,
                                 key='Control',
                                 code='ControlLeft'),
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': True,
-                'altGraphKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'ctrlLeft': True,
+                'ctrlRight': False,
                 'key': 'Control',
                 'code': 'ControlLeft',
             }))
 
     def test_parses_right_ctrl_key(self):
         self.assertKeystrokesEqual(
-            keystroke.Keystroke(
-                left_meta_modifier=False,
-                left_alt_modifier=False,
-                left_shift_modifier=False,
-                # For simplicity, we store right Ctrl modifier in
-                # left_ctrl_modifier since there's no right version in
-                # keystroke.Keystroke.
-                left_ctrl_modifier=True,
-                right_alt_modifier=False,
-                key='Control',
-                code='ControlRight'),
+            keystroke.Keystroke(left_meta_modifier=False,
+                                right_meta_modifier=False,
+                                left_alt_modifier=False,
+                                right_alt_modifier=False,
+                                left_shift_modifier=False,
+                                right_shift_modifier=False,
+                                left_ctrl_modifier=False,
+                                right_ctrl_modifier=True,
+                                key='Control',
+                                code='ControlLeft'),
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': True,
-                'altGraphKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'ctrlLeft': False,
+                'ctrlRight': True,
                 'key': 'Control',
-                'code': 'ControlRight',
+                'code': 'ControlLeft',
             }))
 
     def test_rejects_float_keycode_value(self):
         with self.assertRaises(keystroke.InvalidKeyCodeError):
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'ctrlLeft': False,
+                'ctrlRight': False,
                 'key': 'A',
                 'code': 1.25,
             })
@@ -108,11 +131,14 @@ class KeystrokeTest(unittest.TestCase):
     def test_rejects_too_long_code_value(self):
         with self.assertRaises(keystroke.InvalidKeyCodeError):
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'ctrlLeft': False,
+                'ctrlRight': False,
                 'key': 'A',
                 'code': 'A' * 31,
             })
@@ -123,11 +149,14 @@ class KeystrokeWithInvalidValuesTest(unittest.TestCase):
     def test_rejects_invalid_meta_modifier(self):
         with self.assertRaises(keystroke.InvalidModifierKeyError):
             keystroke.parse_keystroke({
-                'metaKey': 'banana',
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
+                'metaLeft': 'banana',
+                'metaRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'ctrlLeft': False,
+                'ctrlRight': False,
                 'key': 'A',
                 'code': 'KeyA',
             })
@@ -135,11 +164,14 @@ class KeystrokeWithInvalidValuesTest(unittest.TestCase):
     def test_rejects_invalid_alt_modifier(self):
         with self.assertRaises(keystroke.InvalidModifierKeyError):
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': 'banana',
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'altLeft': 'banana',
+                'altRight': False,
+                'ctrlLeft': False,
+                'ctrlRight': False,
                 'key': 'A',
                 'code': 'KeyA',
             })
@@ -147,11 +179,14 @@ class KeystrokeWithInvalidValuesTest(unittest.TestCase):
     def test_rejects_invalid_shift_modifier(self):
         with self.assertRaises(keystroke.InvalidModifierKeyError):
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': 'banana',
-                'ctrlKey': False,
-                'altGraphKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'shiftLeft': 'banana',
+                'shiftRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'ctrlLeft': False,
+                'ctrlRight': False,
                 'key': 'A',
                 'code': 'KeyA',
             })
@@ -159,23 +194,29 @@ class KeystrokeWithInvalidValuesTest(unittest.TestCase):
     def test_rejects_invalid_ctrl_modifier(self):
         with self.assertRaises(keystroke.InvalidModifierKeyError):
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': 'banana',
-                'altGraphKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'ctrlLeft': 'banana',
+                'ctrlRight': False,
                 'key': 'A',
                 'code': 'KeyA',
             })
 
-    def test_rejects_invalid_alt_graph_modifier(self):
+    def test_rejects_invalid_right_graph_modifier(self):
         with self.assertRaises(keystroke.InvalidModifierKeyError):
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': 'banana',
+                'metaLeft': False,
+                'metaRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'altLeft': False,
+                'altRight': 'banana',
+                'ctrlLeft': False,
+                'ctrlRight': False,
                 'key': 'A',
                 'code': 'KeyA',
             })
@@ -186,10 +227,13 @@ class KeystrokeWithMissingFieldsTest(unittest.TestCase):
     def test_rejects_missing_meta_key_value(self):
         with self.assertRaises(keystroke.MissingFieldErrorError):
             keystroke.parse_keystroke({
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
+                'metaRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'ctrlLeft': False,
+                'ctrlRight': False,
                 'key': 'A',
                 'code': 'KeyA',
             })
@@ -197,21 +241,27 @@ class KeystrokeWithMissingFieldsTest(unittest.TestCase):
     def test_rejects_missing_alt_key_value(self):
         with self.assertRaises(keystroke.MissingFieldErrorError):
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'altRight': False,
+                'ctrlLeft': False,
+                'ctrlRight': False,
                 'key': 'A',
                 'code': 'KeyA',
             })
 
-    def test_rejects_missing_alt_graph_key_value(self):
+    def test_rejects_missing_right_graph_key_value(self):
         with self.assertRaises(keystroke.MissingFieldErrorError):
             keystroke.parse_keystroke({
-                'altKey': False,
-                'metaKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'altLeft': False,
+                'ctrlLeft': False,
+                'ctrlRight': False,
                 'key': 'A',
                 'code': 'KeyA',
             })
@@ -219,10 +269,13 @@ class KeystrokeWithMissingFieldsTest(unittest.TestCase):
     def test_rejects_missing_shift_key_value(self):
         with self.assertRaises(keystroke.MissingFieldErrorError):
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'shiftRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'ctrlLeft': False,
+                'ctrlRight': False,
                 'key': 'A',
                 'code': 'KeyA',
             })
@@ -230,10 +283,13 @@ class KeystrokeWithMissingFieldsTest(unittest.TestCase):
     def test_rejects_missing_ctrl_key_value(self):
         with self.assertRaises(keystroke.MissingFieldErrorError):
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'altGraphKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'ctrlRight': False,
                 'key': 'A',
                 'code': 'KeyA',
             })
@@ -241,21 +297,27 @@ class KeystrokeWithMissingFieldsTest(unittest.TestCase):
     def test_rejects_missing_key_value(self):
         with self.assertRaises(keystroke.MissingFieldErrorError):
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'ctrlLeft': False,
+                'ctrlRight': False,
                 'code': 'KeyA',
             })
 
     def test_rejects_missing_code_value(self):
         with self.assertRaises(keystroke.MissingFieldErrorError):
             keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
+                'metaLeft': False,
+                'metaRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'ctrlLeft': False,
+                'ctrlRight': False,
                 'key': 'A',
             })

--- a/app/request_parsers/keystroke_test.py
+++ b/app/request_parsers/keystroke_test.py
@@ -161,7 +161,7 @@ class KeystrokeWithInvalidValuesTest(unittest.TestCase):
                 'code': 'KeyA',
             })
 
-    def test_rejects_invalid_alt_modifier(self):
+    def test_rejects_invalid_alt_left_modifier(self):
         with self.assertRaises(keystroke.InvalidModifierKeyError):
             keystroke.parse_keystroke({
                 'metaLeft': False,
@@ -176,7 +176,7 @@ class KeystrokeWithInvalidValuesTest(unittest.TestCase):
                 'code': 'KeyA',
             })
 
-    def test_rejects_invalid_right_alt_modifier(self):
+    def test_rejects_invalid_alt_right_modifier(self):
         with self.assertRaises(keystroke.InvalidModifierKeyError):
             keystroke.parse_keystroke({
                 'metaLeft': False,
@@ -238,7 +238,7 @@ class KeystrokeWithMissingFieldsTest(unittest.TestCase):
                 'code': 'KeyA',
             })
 
-    def test_rejects_missing_alt_key_value(self):
+    def test_rejects_missing_alt_left_key_value(self):
         with self.assertRaises(keystroke.MissingFieldErrorError):
             keystroke.parse_keystroke({
                 'metaLeft': False,
@@ -252,7 +252,7 @@ class KeystrokeWithMissingFieldsTest(unittest.TestCase):
                 'code': 'KeyA',
             })
 
-    def test_rejects_missing_right_alt_key_value(self):
+    def test_rejects_missing_alt_right_key_value(self):
         with self.assertRaises(keystroke.MissingFieldErrorError):
             keystroke.parse_keystroke({
                 'metaLeft': False,

--- a/app/request_parsers/keystroke_test.py
+++ b/app/request_parsers/keystroke_test.py
@@ -176,6 +176,21 @@ class KeystrokeWithInvalidValuesTest(unittest.TestCase):
                 'code': 'KeyA',
             })
 
+    def test_rejects_invalid_right_alt_modifier(self):
+        with self.assertRaises(keystroke.InvalidModifierKeyError):
+            keystroke.parse_keystroke({
+                'metaLeft': False,
+                'metaRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'altLeft': False,
+                'altRight': 'banana',
+                'ctrlLeft': False,
+                'ctrlRight': False,
+                'key': 'A',
+                'code': 'KeyA',
+            })
+
     def test_rejects_invalid_shift_modifier(self):
         with self.assertRaises(keystroke.InvalidModifierKeyError):
             keystroke.parse_keystroke({
@@ -201,21 +216,6 @@ class KeystrokeWithInvalidValuesTest(unittest.TestCase):
                 'altLeft': False,
                 'altRight': False,
                 'ctrlLeft': 'banana',
-                'ctrlRight': False,
-                'key': 'A',
-                'code': 'KeyA',
-            })
-
-    def test_rejects_invalid_right_graph_modifier(self):
-        with self.assertRaises(keystroke.InvalidModifierKeyError):
-            keystroke.parse_keystroke({
-                'metaLeft': False,
-                'metaRight': False,
-                'shiftLeft': False,
-                'shiftRight': False,
-                'altLeft': False,
-                'altRight': 'banana',
-                'ctrlLeft': False,
                 'ctrlRight': False,
                 'key': 'A',
                 'code': 'KeyA',
@@ -252,7 +252,7 @@ class KeystrokeWithMissingFieldsTest(unittest.TestCase):
                 'code': 'KeyA',
             })
 
-    def test_rejects_missing_right_graph_key_value(self):
+    def test_rejects_missing_right_alt_key_value(self):
         with self.assertRaises(keystroke.MissingFieldErrorError):
             keystroke.parse_keystroke({
                 'metaLeft': False,

--- a/app/request_parsers/keystroke_test.py
+++ b/app/request_parsers/keystroke_test.py
@@ -99,7 +99,7 @@ class KeystrokeTest(unittest.TestCase):
                                 left_ctrl_modifier=False,
                                 right_ctrl_modifier=True,
                                 key='Control',
-                                code='ControlLeft'),
+                                code='ControlRight'),
             keystroke.parse_keystroke({
                 'metaLeft': False,
                 'metaRight': False,
@@ -110,7 +110,7 @@ class KeystrokeTest(unittest.TestCase):
                 'ctrlLeft': False,
                 'ctrlRight': True,
                 'key': 'Control',
-                'code': 'ControlLeft',
+                'code': 'ControlRight',
             }))
 
     def test_rejects_float_keycode_value(self):

--- a/app/request_parsers/keystroke_test.py
+++ b/app/request_parsers/keystroke_test.py
@@ -120,7 +120,8 @@ class KeystrokeTest(unittest.TestCase):
 
     def test_rejects_invalid_properties(self):
         for invalid_prop in _MODIFIER_PROPS:
-            with self.assertRaises(keystroke.InvalidModifierKeyError):
+            with self.subTest(invalid_prop), self.assertRaises(
+                    keystroke.InvalidModifierKeyError):
                 props = {
                     'metaLeft': False,
                     'metaRight': False,
@@ -153,7 +154,8 @@ class KeystrokeTest(unittest.TestCase):
 
     def test_rejects_missing_value(self):
         for missing_prop in _MODIFIER_PROPS + ['code', 'key']:
-            with self.assertRaises(keystroke.MissingFieldErrorError):
+            with self.subTest(missing_prop), self.assertRaises(
+                    keystroke.MissingFieldErrorError):
                 props = {
                     'metaLeft': False,
                     'metaRight': False,

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -6,6 +6,7 @@ import {
   keystrokeToCanonicalCode,
   requiresShiftKey,
 } from "./keycodes.js";
+import { KeyboardState } from "./keyboardstate.js";
 import { sendKeystroke } from "./keystrokes.js";
 import * as settings from "./settings.js";
 import { OverlayTracker } from "./overlays.js";
@@ -13,8 +14,7 @@ import { OverlayTracker } from "./overlays.js";
 const socket = io();
 let connectedToServer = false;
 
-// A map of keycodes to booleans indicating whether the key is currently pressed.
-let keyState = {};
+const keyboardState = new KeyboardState();
 
 // Keep track of overlays, in order to properly deactivate keypress forwarding.
 const overlayTracker = new OverlayTracker();
@@ -38,18 +38,6 @@ function showError(errorInfo) {
   console.error(`${errorInfo.title}:\n${errorInfo.details}`);
   document.getElementById("error-dialog").setup(errorInfo);
   document.getElementById("error-overlay").show();
-}
-
-function isKeyPressed(code) {
-  return code in keyState && keyState[code];
-}
-
-function isIgnoredKeystroke(code) {
-  // Ignore the keystroke if this is a modifier keycode and the modifier was
-  // already pressed. Otherwise, something like holding down the Shift key
-  // is sent as multiple Shift key presses, which has special meaning on
-  // certain OSes.
-  return isModifierCode(code) && isKeyPressed(code);
 }
 
 function recalculateMouseEventThrottle(
@@ -84,6 +72,7 @@ function browserLanguage() {
 }
 
 const keystrokeHistory = document.getElementById("status-bar").keystrokeHistory;
+const onScreenKeyboard = document.getElementById("on-screen-keyboard");
 
 // Send a keystroke message to the backend, and add a key card to the web UI.
 function processKeystroke(keystroke) {
@@ -125,18 +114,28 @@ function onSocketDisconnect(reason) {
   document.getElementById("app").focus();
 }
 
+/**
+ * @param evt https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
+ */
 function onKeyDown(evt) {
   if (isPasteOverlayShowing() || overlayTracker.hasOverlays()) {
     return;
   }
 
-  const code = keystrokeToCanonicalCode(evt);
+  const canonicalCode = keystrokeToCanonicalCode(evt);
 
-  if (isIgnoredKeystroke(code)) {
+  // Ignore the keystroke if this is a modifier keycode and the modifier was
+  // already pressed. Otherwise, something like holding down the Shift key is
+  // sent as multiple Shift key presses, which has special meaning on certain
+  // OSes.
+  if (
+    isModifierCode(canonicalCode) &&
+    keyboardState.isKeyPressed(canonicalCode)
+  ) {
     return;
   }
 
-  keyState[code] = true;
+  keyboardState.onKeyDown(evt);
 
   if (!connectedToServer) {
     return;
@@ -145,18 +144,33 @@ function onKeyDown(evt) {
     evt.preventDefault();
   }
 
-  const onScreenKeyboard = document.getElementById("on-screen-keyboard");
-
   processKeystroke({
-    metaKey: evt.metaKey || onScreenKeyboard.isMetaKeyPressed,
-    altKey: evt.altKey || onScreenKeyboard.isLeftAltKeyPressed,
-    shiftKey: evt.shiftKey || onScreenKeyboard.isShiftKeyPressed,
-    ctrlKey: evt.ctrlKey || onScreenKeyboard.isCtrlKeyPressed,
-    altGraphKey:
-      isKeyPressed("AltRight") || onScreenKeyboard.isRightAltKeyPressed,
-    sysrqKey: onScreenKeyboard.isSysrqKeyPressed,
+    metaLeft:
+      keyboardState.isKeyPressed("MetaLeft") ||
+      onScreenKeyboard.isModifierKeyPressed("MetaLeft"),
+    metaRight:
+      keyboardState.isKeyPressed("MetaRight") ||
+      onScreenKeyboard.isModifierKeyPressed("MetaRight"),
+    altLeft:
+      keyboardState.isKeyPressed("AltLeft") ||
+      onScreenKeyboard.isModifierKeyPressed("AltLeft"),
+    altRight:
+      keyboardState.isKeyPressed("AltRight") ||
+      onScreenKeyboard.isModifierKeyPressed("AltRight"),
+    shiftLeft:
+      keyboardState.isKeyPressed("ShiftLeft") ||
+      onScreenKeyboard.isModifierKeyPressed("ShiftLeft"),
+    shiftRight:
+      keyboardState.isKeyPressed("ShiftRight") ||
+      onScreenKeyboard.isModifierKeyPressed("ShiftRight"),
+    ctrlLeft:
+      keyboardState.isKeyPressed("ControlLeft") ||
+      onScreenKeyboard.isModifierKeyPressed("ControlLeft"),
+    ctrlRight:
+      keyboardState.isKeyPressed("ControlRight") ||
+      onScreenKeyboard.isModifierKeyPressed("ControlRight"),
     key: evt.key,
-    code: code,
+    code: canonicalCode,
   });
 }
 
@@ -193,16 +207,22 @@ function sendMouseEvent(
   );
 }
 
+/**
+ * @param evt https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
+ */
 function onKeyUp(evt) {
   if (isPasteOverlayShowing()) {
     return;
   }
-  const code = keystrokeToCanonicalCode(evt);
-  keyState[code] = false;
+
+  keyboardState.onKeyUp(evt);
+
   if (!connectedToServer) {
     return;
   }
-  if (isModifierCode(code)) {
+
+  const canonicalCode = keystrokeToCanonicalCode(evt);
+  if (isModifierCode(canonicalCode)) {
     socket.emit("keyRelease");
   }
 }
@@ -224,12 +244,14 @@ function processTextCharacter(textCharacter, language) {
   }
 
   processKeystroke({
-    metaKey: false,
-    altKey: false,
-    shiftKey: requiresShiftKey(textCharacter),
-    ctrlKey: false,
-    altGraphKey: false,
-    sysrqKey: false,
+    metaLeft: false,
+    metaRight: false,
+    altLeft: false,
+    altRight: false,
+    shiftLeft: requiresShiftKey(textCharacter),
+    shiftRight: false,
+    ctrlLeft: false,
+    ctrlRight: false,
     key: friendlyName,
     code: code,
   });

--- a/app/static/js/keyboardstate.js
+++ b/app/static/js/keyboardstate.js
@@ -1,0 +1,74 @@
+"use strict";
+
+import { isModifierCode, keystrokeToCanonicalCode } from "./keycodes.js";
+
+const modifierProp2KeyCodes = {
+  altKey: ["AltLeft", "AltRight"],
+  metaKey: ["MetaLeft", "MetaRight"],
+  ctrlKey: ["CtrlLeft", "CtrlRight"],
+  shiftKey: ["ShiftLeft", "ShiftRight"],
+};
+
+/**
+ * This class is for keeping track internally of the keyboard state.
+ */
+export class KeyboardState {
+  constructor() {
+    this._keys = {};
+  }
+
+  /**
+   * @param canonicalCode (string) The canonical key code.
+   * @returns boolean
+   */
+  isKeyPressed(canonicalCode) {
+    return canonicalCode in this._keys && this._keys[canonicalCode];
+  }
+
+  /**
+   * @param evt https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
+   */
+  onKeyDown(evt) {
+    const canonicalCode = keystrokeToCanonicalCode(evt);
+    this._keys[canonicalCode] = true;
+    if (!isModifierCode(canonicalCode)) {
+      this._fixInternalModifierStates(evt);
+    }
+  }
+
+  /**
+   * @param evt https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
+   */
+  onKeyUp(evt) {
+    const canonicalCode = keystrokeToCanonicalCode(evt);
+    this._keys[canonicalCode] = false;
+  }
+
+  /**
+   * Fixes the internal modifiers’ state according to the information in the key
+   * event. The internal state may have gotten out of sync in case the modifier
+   * keys have been pressed or released while the browser window didn’t have
+   * focus. In doubt, the event object is authoritative.
+   * @param evt https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
+   */
+  _fixInternalModifierStates(evt) {
+    for (const [modifierProp, possibleCodes] of Object.entries(
+      modifierProp2KeyCodes
+    )) {
+      const isModifierPressed = evt[modifierProp];
+      // In case the event reports the modifier to be released, we can just take
+      // that over for the internal state.
+      if (!isModifierPressed) {
+        possibleCodes.forEach((c) => (this._keys[c] = false));
+      }
+
+      // In case the event reports the modifier to be pressed, check whether the
+      // the current internal state is inline with that. If not, adjust the
+      // internal state; for the lack of information about left/right, we just
+      // go for the left one as best guess.
+      else if (isModifierPressed && !possibleCodes.some((c) => this._keys[c])) {
+        this._keys[possibleCodes[0]] = true;
+      }
+    }
+  }
+}

--- a/app/static/js/keyboardstate.js
+++ b/app/static/js/keyboardstate.js
@@ -2,7 +2,7 @@
 
 import { isModifierCode, keystrokeToCanonicalCode } from "./keycodes.js";
 
-const modifierProp2KeyCodes = {
+const modifierPropToKeyCodesMapping = {
   altKey: ["AltLeft", "AltRight"],
   metaKey: ["MetaLeft", "MetaRight"],
   ctrlKey: ["CtrlLeft", "CtrlRight"],
@@ -53,7 +53,7 @@ export class KeyboardState {
    */
   _fixInternalModifierStates(evt) {
     for (const [modifierProp, possibleCodes] of Object.entries(
-      modifierProp2KeyCodes
+      modifierPropToKeyCodesMapping
     )) {
       const isModifierPressed = evt[modifierProp];
       // In case the event reports the modifier to be released, we can just take

--- a/app/static/js/keyboardstate.js
+++ b/app/static/js/keyboardstate.js
@@ -18,7 +18,7 @@ const modifierPropToKeyCodesMapping = {
  */
 export class KeyboardState {
   constructor() {
-    this._keys = {};
+    this._isKeyPressed = {};
   }
 
   /**
@@ -26,7 +26,7 @@ export class KeyboardState {
    * @returns boolean
    */
   isKeyPressed(canonicalCode) {
-    return canonicalCode in this._keys && this._keys[canonicalCode];
+    return canonicalCode in this._isKeyPressed && this._isKeyPressed[canonicalCode];
   }
 
   /**
@@ -34,7 +34,7 @@ export class KeyboardState {
    */
   onKeyDown(evt) {
     const canonicalCode = keystrokeToCanonicalCode(evt);
-    this._keys[canonicalCode] = true;
+    this._isKeyPressed[canonicalCode] = true;
     if (!isModifierCode(canonicalCode)) {
       this._fixInternalModifierStates(evt);
     }
@@ -45,7 +45,7 @@ export class KeyboardState {
    */
   onKeyUp(evt) {
     const canonicalCode = keystrokeToCanonicalCode(evt);
-    this._keys[canonicalCode] = false;
+    this._isKeyPressed[canonicalCode] = false;
   }
 
   /**
@@ -63,15 +63,15 @@ export class KeyboardState {
       // In case the event reports the modifier to be released, we can just take
       // that over for the internal state.
       if (!isModifierPressed) {
-        possibleCodes.forEach((c) => (this._keys[c] = false));
+        possibleCodes.forEach((c) => (this._isKeyPressed[c] = false));
       }
 
       // In case the event reports the modifier to be pressed, check whether the
       // the current internal state is inline with that. If not, adjust the
       // internal state; for the lack of information about left/right, we just
       // go for the left one as best guess.
-      else if (isModifierPressed && !possibleCodes.some((c) => this._keys[c])) {
-        this._keys[possibleCodes[0]] = true;
+      else if (isModifierPressed && !possibleCodes.some((c) => this._isKeyPressed[c])) {
+        this._isKeyPressed[possibleCodes[0]] = true;
       }
     }
   }

--- a/app/static/js/keyboardstate.js
+++ b/app/static/js/keyboardstate.js
@@ -52,7 +52,8 @@ export class KeyboardState {
    * Fixes the internal modifiers’ state according to the information in the key
    * event. The internal state may have gotten out of sync in case the modifier
    * keys have been pressed or released while the browser window didn’t have
-   * focus. In doubt, the event object is authoritative.
+   * focus. The information in the event object takes precedence over this
+   * class's cached state.
    * @param evt https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
    */
   _fixInternalModifierStates(evt) {
@@ -67,7 +68,7 @@ export class KeyboardState {
       }
 
       // In case the event reports the modifier to be pressed, check whether the
-      // the current internal state is inline with that. If not, adjust the
+      // the current internal state is in line with that. If not, adjust the
       // internal state; for the lack of information about left/right, we just
       // go for the left one as best guess.
       else if (isModifierPressed && !possibleCodes.some((c) => this._isKeyPressed[c])) {

--- a/app/static/js/keyboardstate.js
+++ b/app/static/js/keyboardstate.js
@@ -10,7 +10,11 @@ const modifierPropToKeyCodesMapping = {
 };
 
 /**
- * This class is for keeping track internally of the keyboard state.
+ * KeyboardState keeps track of which buttons on the user's keyboard are
+ * pressed. We can't rely on keyboard events (KeyboardEvent) alone because they
+ * don't distinguish between left vs. right modifier keys. By tracking the full
+ * keyboard state, we can send keystrokes to the remote system that more
+ * faithfully match the buttons the user pressed in their browser.
  */
 export class KeyboardState {
   constructor() {

--- a/app/static/js/keyboardstate.js
+++ b/app/static/js/keyboardstate.js
@@ -26,7 +26,9 @@ export class KeyboardState {
    * @returns boolean
    */
   isKeyPressed(canonicalCode) {
-    return canonicalCode in this._isKeyPressed && this._isKeyPressed[canonicalCode];
+    return (
+      canonicalCode in this._isKeyPressed && this._isKeyPressed[canonicalCode]
+    );
   }
 
   /**
@@ -71,7 +73,10 @@ export class KeyboardState {
       // the current internal state is in line with that. If not, adjust the
       // internal state; for the lack of information about left/right, we just
       // go for the left one as best guess.
-      else if (isModifierPressed && !possibleCodes.some((c) => this._isKeyPressed[c])) {
+      else if (
+        isModifierPressed &&
+        !possibleCodes.some((c) => this._isKeyPressed[c])
+      ) {
         this._isKeyPressed[possibleCodes[0]] = true;
       }
     }

--- a/app/static/js/keycodes.js
+++ b/app/static/js/keycodes.js
@@ -71,13 +71,25 @@ const commonKeyCodes = {
   "'": "Quote",
 };
 
-export function keystrokeToCanonicalCode(keystroke) {
+/**
+ * @param evt https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
+ */
+export function keystrokeToCanonicalCode(evt) {
   // Some keyboards send RightAlt/AltGraph as LeftControl then Alt, where the
   // Alt key has a blank code.
-  if (keystroke.key === "Alt" && keystroke.code === "") {
+  if (evt.key === "Alt" && evt.code === "") {
     return "AltRight";
   }
-  return keystroke.code;
+
+  // Firefox calls it `OS...` instead of `Meta...`.
+  if (evt.code === "OSLeft") {
+    return "MetaLeft";
+  }
+  if (evt.code === "OSRight") {
+    return "MetaRight";
+  }
+
+  return evt.code;
 }
 
 // Given a character and a browser language, finds the matching code.

--- a/app/static/js/keycodes.js
+++ b/app/static/js/keycodes.js
@@ -72,24 +72,24 @@ const commonKeyCodes = {
 };
 
 /**
- * @param evt https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
+ * @param keystroke https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
  */
-export function keystrokeToCanonicalCode(evt) {
+export function keystrokeToCanonicalCode(keystroke) {
   // Some keyboards send RightAlt/AltGraph as LeftControl then Alt, where the
   // Alt key has a blank code.
-  if (evt.key === "Alt" && evt.code === "") {
+  if (keystroke.key === "Alt" && keystroke.code === "") {
     return "AltRight";
   }
 
   // Firefox calls it `OS...` instead of `Meta...`.
-  if (evt.code === "OSLeft") {
+  if (keystroke.code === "OSLeft") {
     return "MetaLeft";
   }
-  if (evt.code === "OSRight") {
+  if (keystroke.code === "OSRight") {
     return "MetaRight";
   }
 
-  return evt.code;
+  return keystroke.code;
 }
 
 // Given a character and a browser language, finds the matching code.

--- a/app/templates/custom-elements/on-screen-keyboard.html
+++ b/app/templates/custom-elements/on-screen-keyboard.html
@@ -177,7 +177,7 @@
         <keyboard-key
           code="ShiftLeft"
           modifier="true"
-          class="shift-modifier key-extend-full-half accented"
+          class="modifier key-extend-full-half accented"
           >Shift</keyboard-key
         >
 
@@ -203,7 +203,7 @@
         <keyboard-key
           code="ShiftRight"
           modifier="true"
-          class="shift-modifier key-extend-full-half accented"
+          class="modifier key-extend-full-half accented"
           >Shift</keyboard-key
         >
       </div>
@@ -213,32 +213,26 @@
         <keyboard-key
           code="ControlLeft"
           modifier="true"
-          class="ctrl-modifier key-extend-full accented"
+          class="modifier key-extend-full accented"
           >Control</keyboard-key
         >
         <keyboard-key
           code="MetaLeft"
           modifier="true"
-          class="meta-modifier key-extend-half accented"
+          class="modifier key-extend-half accented"
           >Meta</keyboard-key
         >
-        <keyboard-key
-          code="AltLeft"
-          modifier="true"
-          class="alt-modifier accented"
+        <keyboard-key code="AltLeft" modifier="true" class="modifier accented"
           >Alt</keyboard-key
         >
         <keyboard-key code="32" class="key-space">Space</keyboard-key>
-        <keyboard-key
-          code="AltRight"
-          modifier="true"
-          class="alt-modifier accented"
+        <keyboard-key code="AltRight" modifier="true" class="modifier accented"
           >Alt</keyboard-key
         >
         <keyboard-key
           code="MetaRight"
           modifier="true"
-          class="meta-modifier key-extend-half accented"
+          class="modifier key-extend-half accented"
           >Meta</keyboard-key
         >
         <keyboard-key
@@ -250,7 +244,7 @@
         <keyboard-key
           code="ControlRight"
           modifier="true"
-          class="ctrl-modifier key-extend-full accented"
+          class="modifier key-extend-full accented"
           >Control</keyboard-key
         >
       </div>
@@ -258,9 +252,7 @@
     </div>
     <div id="keyboard-block-right" class="keyboard-block">
       <div class="keyboard-row keyboard-row-bump">
-        <keyboard-key code="PrintScreen" modifier="true" class="sysrq-modifier"
-          >Print</keyboard-key
-        >
+        <keyboard-key code="PrintScreen">Print</keyboard-key>
         <keyboard-key code="ScrollLock">Scroll Lock</keyboard-key>
         <keyboard-key code="Pause">Pause</keyboard-key>
       </div>
@@ -324,13 +316,20 @@
         }
 
         onKeyClick(key, code, isModifier) {
+          // Make uppercase when shift is active – but only if no other modifier
+          // is pressed at the same time.
           if (
-            this.isShiftKeyPressed &&
-            !this.isMetaKeyPressed &&
-            !this.isLeftAltKeyPressed &&
-            !this.isRightAltKeyPressed &&
-            !this.isCtrlKeyPressed &&
-            !this.isSysrqKeyPressed
+            ["ShiftLeft", "ShiftRight"].some((m) =>
+              this.isModifierKeyPressed(m)
+            ) &&
+            [
+              "MetaLeft",
+              "MetaRight",
+              "AltLeft",
+              "AltRight",
+              "ControlLeft",
+              "ControlRight",
+            ].every((m) => !this.isModifierKeyPressed(m))
           ) {
             key = this.getShiftedKeyValue(key);
           }
@@ -346,42 +345,10 @@
           }
         }
 
-        get isMetaKeyPressed() {
-          return this.isModifierKeyPressed("meta");
-        }
-
-        get isLeftAltKeyPressed() {
+        isModifierKeyPressed(keyCode) {
           return (
             this.shadowRoot.querySelectorAll(
-              '.alt-modifier[code="AltLeft"][pressed=true]'
-            ).length > 0
-          );
-        }
-
-        get isRightAltKeyPressed() {
-          return (
-            this.shadowRoot.querySelectorAll(
-              '.alt-modifier[code="AltRight"][pressed=true]'
-            ).length > 0
-          );
-        }
-
-        get isShiftKeyPressed() {
-          return this.isModifierKeyPressed("shift");
-        }
-
-        get isCtrlKeyPressed() {
-          return this.isModifierKeyPressed("ctrl");
-        }
-
-        get isSysrqKeyPressed() {
-          return this.isModifierKeyPressed("sysrq");
-        }
-
-        isModifierKeyPressed(modifier) {
-          return (
-            this.shadowRoot.querySelectorAll(
-              `.${modifier}-modifier[pressed=true]`
+              `.modifier[code=${keyCode}][pressed=true]`
             ).length > 0
           );
         }
@@ -393,10 +360,6 @@
               composed: true,
               key: key,
               code: code,
-              metaKey: this.isMetaKeyPressed,
-              altKey: this.isLeftAltKeyPressed,
-              shiftKey: this.isShiftKeyPressed,
-              ctrlKey: this.isCtrlKeyPressed,
             })
           );
         }
@@ -408,10 +371,6 @@
               composed: true,
               key: key,
               code: code,
-              metaKey: this.isMetaKeyPressed,
-              altKey: this.isLeftAltKeyPressed,
-              shiftKey: this.isShiftKeyPressed,
-              ctrlKey: this.isCtrlKeyPressed,
             })
           );
         }

--- a/app/templates/custom-elements/on-screen-keyboard.html
+++ b/app/templates/custom-elements/on-screen-keyboard.html
@@ -311,7 +311,7 @@
             );
           });
           this.addEventListener("keyrelease", (evt) => {
-            this.emitKeyUpEvent(evt.detail.key, evt.detail.code);
+            this.emitKeyEvent("keyup", evt.detail.key, evt.detail.code);
           });
         }
 
@@ -334,10 +334,10 @@
             key = this.getShiftedKeyValue(key);
           }
 
-          this.emitKeyDownEvent(key, code);
+          this.emitKeyEvent("keydown", key, code);
 
           if (!isModifier) {
-            this.emitKeyUpEvent(key, code);
+            this.emitKeyEvent("keyup", key, code);
 
             // Remove pressed state from all modifier keys if non-modifier key
             // was pressed.
@@ -353,24 +353,25 @@
           );
         }
 
-        emitKeyDownEvent(key, code) {
+        emitKeyEvent(eventType, key, code) {
           this.dispatchEvent(
-            new KeyboardEvent("keydown", {
+            new KeyboardEvent(eventType, {
               bubbles: true,
               composed: true,
               key: key,
               code: code,
-            })
-          );
-        }
-
-        emitKeyUpEvent(key, code) {
-          this.dispatchEvent(
-            new KeyboardEvent("keyup", {
-              bubbles: true,
-              composed: true,
-              key: key,
-              code: code,
+              metaKey:
+                this.isModifierKeyPressed("MetaLeft") ||
+                this.isModifierKeyPressed("MetaRight"),
+              ctrlKey:
+                this.isModifierKeyPressed("CtrlLeft") ||
+                this.isModifierKeyPressed("CtrlRight"),
+              shiftKey:
+                this.isModifierKeyPressed("ShiftLeft") ||
+                this.isModifierKeyPressed("ShiftRight"),
+              altKey:
+                this.isModifierKeyPressed("AltLeft") ||
+                this.isModifierKeyPressed("AltRight"),
             })
           );
         }
@@ -380,7 +381,7 @@
             .querySelectorAll("[modifier=true][pressed=true]")
             .forEach((key) => {
               key.isPressed = false;
-              this.emitKeyUpEvent(key.key, key.code);
+              this.emitKeyEvent("keyup", key.key, key.code);
             });
         }
 


### PR DESCRIPTION
As discussed in https://github.com/tiny-pilot/tinypilot-pro/issues/153 we want move client-specific oddities from the backend to the frontend. That leaves us with one canonical data structure to represent a keystroke, which we can reuse “as is” for the public API.

One note: I’m not sure it’s a good idea to rely on [`KeyboardEvent.metaKey`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey) et al, but I think it’s probably better to always rely on the codes to figure out when it’s a modifier key. Otherwise we will always have the problem that we can’t tell apart left from right (or at least not without workarounds). Therefore, this PR would then also fix https://github.com/tiny-pilot/tinypilot/issues/364.

@mtlynch could you quickly look over this, please? It’s still WIP, but before finishing it off and doing QA/testing, I wanted to make sure we are on the same page about the approach. The tests are all broken (haven’t touched them yet), but apart from that this PR works and seems to behave the same as before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/731)
<!-- Reviewable:end -->
