### PR TITLE
Virtual Keyboard: Send correct key code when pressing the space bar

### DIFF
--- a/app/templates/custom-elements/on-screen-keyboard.html
+++ b/app/templates/custom-elements/on-screen-keyboard.html
@@ -225,7 +225,7 @@
         <keyboard-key code="AltLeft" modifier="true" class="modifier accented"
           >Alt</keyboard-key
         >
-        <keyboard-key code="32" class="key-space">Space</keyboard-key>
+        <keyboard-key code="Space" class="key-space">Space</keyboard-key>
         <keyboard-key code="AltRight" modifier="true" class="modifier accented"
           >Alt</keyboard-key
         >


### PR DESCRIPTION
Fixes https://github.com/tiny-pilot/tinypilot/issues/729.

(Screenshot to show that we are generating the same tuple of up/down events for physical space and virtual space key.)
<img width="413" alt="Screenshot 2021-06-24 at 21 37 23" src="https://user-images.githubusercontent.com/3618384/123322393-8d442080-d534-11eb-83a7-ea8c42bc8fd9.png">
