### PR TITLE
Make keystroke props optional and fall back to default values

### DIFF
--- a/app/request_parsers/keystroke.py
+++ b/app/request_parsers/keystroke.py
@@ -33,7 +33,7 @@ class Keystroke:
     right_alt_modifier: bool
     left_meta_modifier: bool
     right_meta_modifier: bool
-    key: str
+    key: str  # This property is only used for debugging purpose.
     code: str
 
 
@@ -41,33 +41,37 @@ def parse_keystroke(message):
     if not isinstance(message, dict):
         raise MissingFieldErrorError(
             'Keystroke parameter is invalid, expecting a dictionary data type')
-    required_fields = (
-        'key',
-        'code',
-        'ctrlLeft',
-        'ctrlRight',
-        'shiftLeft',
-        'shiftRight',
-        'altLeft',
-        'altRight',
-        'metaLeft',
-        'metaRight',
-    )
-    for field in required_fields:
-        if field not in message:
-            raise MissingFieldErrorError(
-                'Keystroke request is missing required field: %s' % field)
+    if 'code' not in message:
+        raise MissingFieldErrorError(
+            'Keystroke request is missing required field: code')
+    keystroke_props = _merge_message_with_defaults(message)
     return Keystroke(
-        left_ctrl_modifier=_parse_modifier_key(message['ctrlLeft']),
-        right_ctrl_modifier=_parse_modifier_key(message['ctrlRight']),
-        left_shift_modifier=_parse_modifier_key(message['shiftLeft']),
-        right_shift_modifier=_parse_modifier_key(message['shiftRight']),
-        left_alt_modifier=_parse_modifier_key(message['altLeft']),
-        right_alt_modifier=_parse_modifier_key(message['altRight']),
-        left_meta_modifier=_parse_modifier_key(message['metaLeft']),
-        right_meta_modifier=_parse_modifier_key(message['metaRight']),
-        key=message['key'],
-        code=_parse_code(message['code']))
+        left_ctrl_modifier=_parse_modifier_key(keystroke_props['ctrlLeft']),
+        right_ctrl_modifier=_parse_modifier_key(keystroke_props['ctrlRight']),
+        left_shift_modifier=_parse_modifier_key(keystroke_props['shiftLeft']),
+        right_shift_modifier=_parse_modifier_key(keystroke_props['shiftRight']),
+        left_alt_modifier=_parse_modifier_key(keystroke_props['altLeft']),
+        right_alt_modifier=_parse_modifier_key(keystroke_props['altRight']),
+        left_meta_modifier=_parse_modifier_key(keystroke_props['metaLeft']),
+        right_meta_modifier=_parse_modifier_key(keystroke_props['metaRight']),
+        key=keystroke_props['key'],
+        code=_parse_code(keystroke_props['code']))
+
+
+def _merge_message_with_defaults(message):
+    defaults = {
+        'ctrlLeft': False,
+        'ctrlRight': False,
+        'shiftLeft': False,
+        'shiftRight': False,
+        'altLeft': False,
+        'altRight': False,
+        'metaLeft': False,
+        'metaRight': False,
+        'key': '',
+    }
+    defaults.update(message)
+    return defaults
 
 
 def _parse_modifier_key(modifier_key):

--- a/app/request_parsers/keystroke_test.py
+++ b/app/request_parsers/keystroke_test.py
@@ -113,6 +113,58 @@ class KeystrokeTest(unittest.TestCase):
                 'code': 'ControlRight',
             }))
 
+    def test_parses_minimal_valid_keystroke_with_defaults(self):
+        self.assertKeystrokesEqual(
+            keystroke.Keystroke(left_meta_modifier=False,
+                                right_meta_modifier=False,
+                                left_alt_modifier=False,
+                                right_alt_modifier=False,
+                                left_shift_modifier=False,
+                                right_shift_modifier=False,
+                                left_ctrl_modifier=False,
+                                right_ctrl_modifier=False,
+                                key='',
+                                code='KeyA'),
+            keystroke.parse_keystroke({
+                'code': 'KeyA',
+            }))
+
+    def test_parses_and_merges_valid_keystroke_message_with_defaults(self):
+        self.assertKeystrokesEqual(
+            keystroke.Keystroke(left_meta_modifier=True,
+                                right_meta_modifier=False,
+                                left_alt_modifier=True,
+                                right_alt_modifier=False,
+                                left_shift_modifier=False,
+                                right_shift_modifier=True,
+                                left_ctrl_modifier=False,
+                                right_ctrl_modifier=False,
+                                key='A',
+                                code='KeyA'),
+            keystroke.parse_keystroke({
+                'metaLeft': True,
+                'shiftLeft': False,
+                'shiftRight': True,
+                'altLeft': True,
+                'ctrlRight': False,
+                'key': 'A',
+                'code': 'KeyA',
+            }))
+
+    def test_rejects_missing_mandatory_code_value(self):
+        with self.assertRaises(keystroke.MissingFieldErrorError):
+            keystroke.parse_keystroke({
+                'metaLeft': False,
+                'metaRight': False,
+                'shiftLeft': False,
+                'shiftRight': False,
+                'altLeft': False,
+                'altRight': False,
+                'ctrlLeft': False,
+                'ctrlRight': False,
+                'key': 'A',
+            })
+
     def test_rejects_float_keycode_value(self):
         with self.assertRaises(keystroke.InvalidKeyCodeError):
             keystroke.parse_keystroke({
@@ -219,105 +271,4 @@ class KeystrokeWithInvalidValuesTest(unittest.TestCase):
                 'ctrlRight': False,
                 'key': 'A',
                 'code': 'KeyA',
-            })
-
-
-class KeystrokeWithMissingFieldsTest(unittest.TestCase):
-
-    def test_rejects_missing_meta_key_value(self):
-        with self.assertRaises(keystroke.MissingFieldErrorError):
-            keystroke.parse_keystroke({
-                'metaRight': False,
-                'shiftLeft': False,
-                'shiftRight': False,
-                'altLeft': False,
-                'altRight': False,
-                'ctrlLeft': False,
-                'ctrlRight': False,
-                'key': 'A',
-                'code': 'KeyA',
-            })
-
-    def test_rejects_missing_alt_left_key_value(self):
-        with self.assertRaises(keystroke.MissingFieldErrorError):
-            keystroke.parse_keystroke({
-                'metaLeft': False,
-                'metaRight': False,
-                'shiftLeft': False,
-                'shiftRight': False,
-                'altRight': False,
-                'ctrlLeft': False,
-                'ctrlRight': False,
-                'key': 'A',
-                'code': 'KeyA',
-            })
-
-    def test_rejects_missing_alt_right_key_value(self):
-        with self.assertRaises(keystroke.MissingFieldErrorError):
-            keystroke.parse_keystroke({
-                'metaLeft': False,
-                'metaRight': False,
-                'shiftLeft': False,
-                'shiftRight': False,
-                'altLeft': False,
-                'ctrlLeft': False,
-                'ctrlRight': False,
-                'key': 'A',
-                'code': 'KeyA',
-            })
-
-    def test_rejects_missing_shift_key_value(self):
-        with self.assertRaises(keystroke.MissingFieldErrorError):
-            keystroke.parse_keystroke({
-                'metaLeft': False,
-                'metaRight': False,
-                'shiftRight': False,
-                'altLeft': False,
-                'altRight': False,
-                'ctrlLeft': False,
-                'ctrlRight': False,
-                'key': 'A',
-                'code': 'KeyA',
-            })
-
-    def test_rejects_missing_ctrl_key_value(self):
-        with self.assertRaises(keystroke.MissingFieldErrorError):
-            keystroke.parse_keystroke({
-                'metaLeft': False,
-                'metaRight': False,
-                'shiftLeft': False,
-                'shiftRight': False,
-                'altLeft': False,
-                'altRight': False,
-                'ctrlRight': False,
-                'key': 'A',
-                'code': 'KeyA',
-            })
-
-    def test_rejects_missing_key_value(self):
-        with self.assertRaises(keystroke.MissingFieldErrorError):
-            keystroke.parse_keystroke({
-                'metaLeft': False,
-                'metaRight': False,
-                'shiftLeft': False,
-                'shiftRight': False,
-                'altLeft': False,
-                'altRight': False,
-                'ctrlLeft': False,
-                'ctrlRight': False,
-                'code': 'KeyA',
-            })
-
-    def test_rejects_missing_code_value(self):
-        with self.assertRaises(keystroke.MissingFieldErrorError):
-            keystroke.parse_keystroke({
-                'metaLeft': False,
-                'metaRight': False,
-                'shiftLeft': False,
-                'shiftRight': False,
-                'altLeft': False,
-                'altRight': False,
-                'ctrlLeft': False,
-                'ctrlRight': False,
-                'key': 'A',
             })


### PR DESCRIPTION
As discussed in https://github.com/tiny-pilot/tinypilot-pro/pull/188, make keystroke properties optional and fall back to defaults (except for `code`).