### PR TITLE
Add toggle button to style guide

### DIFF
--- a/app/static/css/toggle.css
+++ b/app/static/css/toggle.css
@@ -1,0 +1,50 @@
+.toggle {
+  --height: 1.7em;
+  --spacing: 4px;
+  position: relative;
+  display: inline-block;
+  width: calc(2 * var(--height));
+  height: calc(var(--height) + var(--spacing));
+}
+
+.toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  cursor: pointer;
+  background-color: #ccc;
+  border-radius: calc(var(--height) + var(--spacing));
+  transition: 0.5s;
+}
+
+.toggle-slider:before {
+  position: absolute;
+  content: "";
+  height: calc(var(--height) - var(--spacing));
+  width: calc(var(--height) - var(--spacing));
+  left: var(--spacing);
+  bottom: var(--spacing);
+  background-color: white;
+  border-radius: 50%;
+  transition: 0.5s;
+}
+
+input:checked + .toggle-slider {
+  background-color: var(--brand-blue);
+}
+
+input:focus + .toggle-slider {
+  box-shadow: 0 0 1px var(--brand-blue);
+}
+
+input:checked + .toggle-slider:before {
+  transform: translateX(calc(var(--height) - var(--spacing)));
+}

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -9,6 +9,7 @@
   </head>
   <style>
     @import "css/icons.css";
+    @import "css/toggle.css";
 
     main {
       margin: 1rem auto;
@@ -161,6 +162,16 @@
         <li slot="item">Action 2</li>
         <li slot="item">Action 3</li>
       </dropdown-button>
+      <h3>Toggle button</h3>
+      <p>
+        A button representing a binary state that can be toggled on and off. In
+        contrast to a checkbox, the toggle button is used outside of forms and
+        the click-action is carried out immediately.
+      </p>
+      <label class="toggle">
+        <input type="checkbox" />
+        <span class="toggle-slider"></span>
+      </label>
 
       <h2 class="section">Overlay</h2>
       <p>


### PR DESCRIPTION
Add toggle button to style guide, as needed in https://github.com/tiny-pilot/tinypilot-pro/pull/197.

By the way: I just realised that I always introduce general style-related things in the community repo, even if we only use them in pro. Intuitively, that makes sense to me, because having diverging styling rules might be very confusing. On the other hand, it can also be confusing to see things that don’t appear to be used anywhere… 🤔 Anyway, I’d suggest to continue following that habit for now, because otherwise it’d be even more confusing. A potential topic for discussion, though.