### PR TITLE
Change default cursor from `crosshair` to `default`

### DIFF
--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -5,7 +5,7 @@ try {
 
 const defaults = {
   isKeyHistoryEnabled: true,
-  cursor: "crosshair",
+  cursor: "default",
   isKeyboardVisible: true,
 };
 


### PR DESCRIPTION
Fixes https://github.com/tiny-pilot/tinypilot/issues/727.

<img width="458" alt="Screenshot 2021-07-07 at 17 14 18" src="https://user-images.githubusercontent.com/3618384/124785025-c8881b80-df46-11eb-875e-ef976834645a.png">

For persisted settings, we can’t determine whether the user had explicitly set the cursor or whether it was just the former default, because we always persist the [full settings including defaults](https://github.com/tiny-pilot/tinypilot/blob/792e2b783eaea3741bdb46fcacc620218192a49b/app/static/js/settings.js#L12). I’d think that’s not a big deal, though.