### PR TITLE
Import all global JS upfront

### DIFF
--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -76,7 +76,6 @@
   </div>
 </template>
 
-<script src="/js/util/poll.js"></script>
 <script>
   (function () {
     const doc = (document._currentScript || document.currentScript)

--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -85,7 +85,6 @@
   </div>
 </template>
 
-<script src="/js/util/clipboard.js"></script>
 <script>
   (function () {
     const doc = (document._currentScript || document.currentScript)

--- a/app/templates/custom-elements/shutdown-dialog.html
+++ b/app/templates/custom-elements/shutdown-dialog.html
@@ -57,7 +57,6 @@
   </div>
 </template>
 
-<script src="/js/controllers.js"></script>
 <script>
   (function () {
     const doc = (document._currentScript || document.currentScript)

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -82,7 +82,6 @@
   </div>
 </template>
 
-<script src="/js/util/poll.js"></script>
 <script>
   (function () {
     const doc = (document._currentScript || document.currentScript)

--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -75,7 +75,6 @@
   </div>
 </template>
 
-<script src="/js/controllers.js"></script>
 <script>
   (function () {
     const doc = (document._currentScript || document.currentScript)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,8 +12,8 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content="{{ csrf_token() }}" />
-    <script src="/js/util/clipboard.js"></script>
     <script src="/js/controllers.js"></script>
+    <script src="/js/util/clipboard.js"></script>
     <script src="/js/util/poll.js"></script>
   </head>
   <body>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,6 +12,9 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content="{{ csrf_token() }}" />
+    <script src="/js/util/clipboard.js"></script>
+    <script src="/js/controllers.js"></script>
+    <script src="/js/util/poll.js"></script>
   </head>
   <body>
     <!-- prettier-ignore -->


### PR DESCRIPTION
Fixes part 2 of https://github.com/tiny-pilot/ansible-role-tinypilot/issues/144.

`<script src="">` fetches are dumped into the global scope, and in contrast to CSS the shadow’s JS scope is **not** isolated. We can therefore just pre-fetch all global JS and thereby ensure that it’ll only be requested once.

Note to self: fix in Pro as well after this is merged.