### PR TITLE
Make styling of interactive elements look more “materialistic”

### DIFF
--- a/app/static/css/button.css
+++ b/app/static/css/button.css
@@ -3,11 +3,9 @@
 button,
 .btn {
   display: inline-block;
-  border: none;
-  padding: 1rem 2rem;
+  padding: 0.5rem 1.5rem;
   margin: 1rem;
   text-decoration: none;
-  background: var(--brand-metallic-light);
   color: #ffffff;
   font-size: 1rem;
   font-family: inherit;
@@ -16,6 +14,10 @@ button,
   transition: background 250ms ease-in-out, transform 150ms ease;
   -webkit-appearance: none;
   -moz-appearance: none;
+  border-radius: var(--border-radius);
+  border: 1px solid var(--brand-metallic-medium);
+  background: var(--brand-metallic-light)
+    linear-gradient(0deg, rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0) 60%);
 }
 
 button:hover,
@@ -36,12 +38,14 @@ button:active,
   transform: scale(0.99);
 }
 
+/** DEPRECATED */
 .btn-small {
   padding: 0.5rem 1rem;
 }
 
 .btn-action {
   background-color: var(--brand-blue);
+  border-color: var(--brand-blue-dark);
 }
 
 .btn-action:hover,
@@ -52,6 +56,7 @@ button:active,
 
 .btn-success {
   background-color: var(--brand-green);
+  border-color: var(--brand-green-dark);
 }
 
 .btn-success:hover,
@@ -67,6 +72,7 @@ button:active,
 
 .btn-danger {
   background-color: var(--brand-red);
+  border-color: var(--brand-red-dark);
 }
 
 .btn-danger:hover,

--- a/app/static/css/button.css
+++ b/app/static/css/button.css
@@ -3,7 +3,7 @@
 button,
 .btn {
   display: inline-block;
-  padding: 0.5rem 1.5rem;
+  padding: 0.4rem 1.25rem;
   margin: 1rem;
   text-decoration: none;
   color: #ffffff;
@@ -40,7 +40,7 @@ button:active,
 
 /** DEPRECATED */
 .btn-small {
-  padding: 0.5rem 1rem;
+  padding: 0.4rem 1rem;
 }
 
 .btn-action {

--- a/app/static/css/button.css
+++ b/app/static/css/button.css
@@ -38,11 +38,6 @@ button:active,
   transform: scale(0.99);
 }
 
-/** DEPRECATED */
-.btn-small {
-  padding: 0.4rem 1rem;
-}
-
 .btn-action {
   background-color: var(--brand-blue);
   border-color: var(--brand-blue-dark);

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -18,15 +18,20 @@
   --brand-creme-light: hsl(var(--brand-hue-yellow), 60%, 97%);
 
   --brand-blue: hsl(var(--brand-hue-blue), 55%, 55%);
+  --brand-blue-dark: hsl(var(--brand-hue-blue), 51%, 30%);
   --brand-blue-bright: hsl(var(--brand-hue-blue), 90%, 67%);
 
-  --brand-red: hsl(var(--brand-hue-red), 55%, 40%);
+  --brand-red: hsl(var(--brand-hue-red), 57%, 44%);
+  --brand-red-dark: hsl(var(--brand-hue-red), 72%, 29%);
   --brand-red-light: hsl(var(--brand-hue-red), 54%, 95%);
   --brand-red-bright: hsl(var(--brand-hue-red), 85%, 46%);
 
   --brand-green: hsl(var(--brand-hue-green), 40%, 45%);
+  --brand-green-dark: hsl(var(--brand-hue-green), 46%, 33%);
   --brand-green-light: hsl(var(--brand-hue-green), 42%, 73%);
   --brand-green-bright: hsl(var(--brand-hue-green), 70%, 45%);
+
+  --border-radius: 0.2rem;
 
   --z-index-bar: 1;
   --z-index-overlay: 2;
@@ -97,4 +102,6 @@ input[type="password"] {
   font-family: inherit;
   font-size: inherit;
   border: 1px solid #666;
+  border-radius: var(--border-radius);
+  box-shadow: inset 0 0 0.2rem 0 rgba(0, 0, 0, 0.15);
 }

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -31,7 +31,7 @@
   --brand-green-light: hsl(var(--brand-hue-green), 42%, 73%);
   --brand-green-bright: hsl(var(--brand-hue-green), 70%, 45%);
 
-  --border-radius: 0.2rem;
+  --border-radius: 0.25rem;
 
   --z-index-bar: 1;
   --z-index-overlay: 2;

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -12,7 +12,7 @@
   --brand-metallic-dark: hsl(var(--brand-hue-blue), 33%, 33%);
   --brand-metallic-medium: hsl(var(--brand-hue-metallic), 18%, 45%);
   --brand-metallic-light: hsl(var(--brand-hue-metallic), 16%, 55%);
-  --brand-metallic-bright: hsl(var(--brand-hue-metallic), 18%, 71%);
+  --brand-metallic-bright: hsl(var(--brand-hue-metallic), 18%, 65%);
 
   --brand-sand-light: hsl(var(--brand-hue-yellow), 59%, 92%);
   --brand-creme-light: hsl(var(--brand-hue-yellow), 60%, 97%);

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -98,7 +98,7 @@ img {
 
 input[type="text"],
 input[type="password"] {
-  padding: 0.5rem;
+  padding: 0.4rem;
   font-family: inherit;
   font-size: inherit;
   border: 1px solid #666;

--- a/app/static/css/toggle.css
+++ b/app/static/css/toggle.css
@@ -23,6 +23,7 @@
   background-color: #ccc;
   border-radius: calc(var(--height) + var(--spacing));
   transition: 0.5s;
+  box-shadow: inset 0 0 0.5rem 0 rgba(0, 0, 0, 0.15);
 }
 
 .toggle-slider:before {
@@ -35,14 +36,11 @@
   background-color: white;
   border-radius: 50%;
   transition: 0.5s;
+  box-shadow: 0 0 0.5rem 0 rgba(0, 0, 0, 0.15);
 }
 
 input:checked + .toggle-slider {
   background-color: var(--brand-blue);
-}
-
-input:focus + .toggle-slider {
-  box-shadow: 0 0 1px var(--brand-blue);
 }
 
 input:checked + .toggle-slider:before {

--- a/app/templates/custom-elements/button-dropdown.html
+++ b/app/templates/custom-elements/button-dropdown.html
@@ -20,6 +20,7 @@
       background-color: var(--brand-metallic-light);
       box-shadow: 0 0.2em 0.3rem rgba(0, 0, 0, 0.3);
       text-align: right;
+      border-radius: var(--border-radius);
     }
 
     slot[name="item"]::slotted(li) {

--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -58,10 +58,10 @@
   <div id="logs-success">
     <h3>Debug Logs</h3>
     <div class="action-buttons">
-      <button class="share-btn btn-action btn-small" type="button">
+      <button class="share-btn btn-action" type="button">
         Get Shareable URL
       </button>
-      <button class="copy-btn btn-action btn-small" type="button">
+      <button class="copy-btn btn-action" type="button">
         Copy to Clipboard
       </button>
     </div>

--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -34,6 +34,7 @@
       overflow-y: scroll;
       max-height: 600px;
       white-space: pre-wrap;
+      border-radius: var(--border-radius);
     }
 
     #url-success .url-wrapper {
@@ -43,7 +44,8 @@
     #url-success .url {
       user-select: text;
       background: #bdbdbd;
-      padding: 1rem 2rem;
+      padding: 0.75rem 2rem;
+      border-radius: var(--border-radius);
     }
   </style>
 

--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -44,7 +44,7 @@
     #url-success .url {
       user-select: text;
       background: #bdbdbd;
-      padding: 0.75rem 2rem;
+      padding: 0.6rem 2rem;
       border-radius: var(--border-radius);
     }
   </style>

--- a/app/templates/custom-elements/error-dialog.html
+++ b/app/templates/custom-elements/error-dialog.html
@@ -13,6 +13,7 @@
       font-size: 0.8em;
       white-space: pre-wrap;
       overflow-wrap: break-word;
+      border-radius: var(--border-radius);
     }
 
     .details-label {

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -25,6 +25,7 @@
       margin: 100px auto;
       padding: 2rem;
       text-align: center;
+      border-radius: var(--border-radius);
     }
 
     :host([variant="default"]) #panel,

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -79,9 +79,17 @@
         <br style="clear: both;" />
         <div
           class="colorcard"
+          style="background-color: var(--brand-blue-dark);"
+        ></div>
+        <div
+          class="colorcard"
           style="background-color: var(--brand-blue);"
         ></div>
         <br style="clear: both;" />
+        <div
+          class="colorcard"
+          style="background-color: var(--brand-red-dark);"
+        ></div>
         <div
           class="colorcard"
           style="background-color: var(--brand-red);"
@@ -91,6 +99,10 @@
           style="background-color: var(--brand-red-light);"
         ></div>
         <br style="clear: both;" />
+        <div
+          class="colorcard"
+          style="background-color: var(--brand-green-dark);"
+        ></div>
         <div
           class="colorcard"
           style="background-color: var(--brand-green);"
@@ -172,6 +184,12 @@
         <input type="checkbox" />
         <span class="toggle-slider"></span>
       </label>
+
+      <h2 class="section">Input</h2>
+      <div>
+        Input Text:&nbsp;
+        <input type="text" />
+      </div>
 
       <h2 class="section">Overlay</h2>
       <p>

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -132,14 +132,9 @@
           there are multiple regular actions side by side, the “regular” action
           button should be used.
         </li>
-        <li>
-          To make the button appear less prominent, a smaller variant can be
-          used.
-        </li>
       </ul>
       <h3>Default Button</h3>
       <button>Default</button>
-      <button class="btn-small">Default (Small)</button>
       <p>For harmless operations like “close” or “cancel”.</p>
       <h3>Action Button</h3>
       <button class="btn-action">Action</button>
@@ -158,7 +153,7 @@
         A button that groups multiple related actions.
       </p>
       <dropdown-button>
-        <button slot="button" class="btn-small btn-action">
+        <button slot="button" class="btn-action">
           Dropdown
           <span class="icon-arrow"></span>
         </button>
@@ -167,7 +162,7 @@
         <li slot="item">Action 3</li>
       </dropdown-button>
       <dropdown-button>
-        <button slot="button" class="btn-small">
+        <button slot="button">
           <span class="icon-arrow"></span>
         </button>
         <li slot="item">Action 1</li>
@@ -234,13 +229,13 @@
       <overlay-panel id="overlay-with-feature">
         <h3>Overlay with Feature</h3>
         <div>
-          <button class="btn-small btn-action" onclick="alert('Done.')">
+          <button class="btn-action" onclick="alert('Done.')">
             Action 1
           </button>
-          <button class="btn-small btn-action" onclick="alert('Done.')">
+          <button class="btn-action" onclick="alert('Done.')">
             Action 2
           </button>
-          <button class="btn-small btn-action" onclick="alert('Done.')">
+          <button class="btn-action" onclick="alert('Done.')">
             Action 3
           </button>
         </div>


### PR DESCRIPTION
Addresses https://github.com/tiny-pilot/tinypilot/issues/743; I revised the look of all interactive controls, to give them a more “materialistic” (3-dimensional) appearance and tune their sizing a bit. This PR actually goes a bit beyond the scope of that issue, but for me the proposed changes would be atomic in a **visual** sense. (From a practical point of view, we also don’t have *that* many elements anyway.)

## Changes
- Reduce the default button size; the `.btn-small` variant is practically obsolete now, we can clean it up ~in a subsequent step~ right away.
- All buttons have a slight border to increase their contrast. They also have a subtle background gradient, as if they were “rearing up” a little bit.
- Equivalently to that, the input field and the toggle button have inset shadow, as if they were slightly recessed.
- The rounded corners make the shapes look a bit more friendly, which I think plays well together with our typeface. The radius is reflected in some other elements as well, to make the layout feel consistent.

For my taste, the tuning of the parameters does feel good: the effects are strong enough to make a noticeable difference compared to the old version, but are still so subtle that they shouldn’t wear out over time.

Curious on your impressions, and happy to discuss and experiment further.

<img width="882" alt="Screenshot 2021-07-21 at 16 48 29" src="https://user-images.githubusercontent.com/3618384/126515345-a61a71c0-5fa7-4ce0-b31f-781b6f4a0a38.png">
