### PR TITLE
Port over the threads module from TinyPilot Pro.

### DIFF
--- a/app/threads.py
+++ b/app/threads.py
@@ -1,0 +1,17 @@
+import eventlet
+
+
+def reschedule(seconds=0):
+    """Reschedules the current thread to allow other waiting threads to proceed.
+
+    When carrying out longer-running operations e.g. in a while loop, the Python
+    process is blocked by default. That means that all other threads are frozen.
+    This problem can be avoided by frequently calling this method in the loop at
+    a (most likely) negligible performance penalty.
+
+    Args:
+        seconds: An integer or a float of the number of seconds to yield for.
+    """
+    # Flask uses eventlet internally. Calling `time.sleep` wouldn’t help here,
+    # since we don’t (and don’t want to) monkey-patch Python’s time API.
+    eventlet.sleep(seconds)

--- a/app/update_logs.py
+++ b/app/update_logs.py
@@ -2,8 +2,9 @@ import logging
 import os.path
 import subprocess
 
-import eventlet
 import flask_socketio
+
+import threads
 
 _READ_SCRIPT_PATH = '/opt/tinypilot-privileged/read-update-log'
 logger = logging.getLogger(__name__)
@@ -80,7 +81,7 @@ class Namespace(flask_socketio.Namespace):
                 # Send the update logs to all connected clients.
                 flask_socketio.emit('logs', new_logs, broadcast=True)
                 self.prev_logs = logs
-            eventlet.sleep(0.5)
+            threads.reschedule(seconds=0.5)
 
     def on_stop(self):
         self.is_streaming = False


### PR DESCRIPTION
In order to hide the implementation details of using eventlet (and for consistency) we're porting over the [threads.py](https://github.com/tiny-pilot/tinypilot-pro/blob/master/app/threads.py) module from TinyPilot Pro.

This PR comes off the back of a [review comment here](https://github.com/tiny-pilot/tinypilot/pull/742#pullrequestreview-710988924).