### PR TITLE
Load keyboard and mouse paths from Flask config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ coverage.xml
 # Django stuff:
 *.log
 
+# Flask
+app_settings.cfg
+
 # Sphinx documentation
 docs/_build/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,8 +93,6 @@ TinyPilot accepts various options through environment variables:
 |----------------------|--------------|-------------|
 | `HOST`               | `127.0.0.1`  | Network interface to listen for incoming connections. |
 | `PORT`               | `8000`       | HTTP port to listen for incoming connections. |
-| `KEYBOARD_PATH`      | `/dev/hidg0` | Path to keyboard HID interface. |
-| `MOUSE_PATH`         | `/dev/hidg1` | Path to mouse HID interface. |
 | `DEBUG`              | undefined    | Set to `1` to enable debug logging. |
 
 ## Code style conventions

--- a/app/main.py
+++ b/app/main.py
@@ -41,6 +41,7 @@ app.config.update(
     TEMPLATES_AUTO_RELOAD=True,
     WTF_CSRF_TIME_LIMIT=None,
 )
+app.config.from_envvar('APP_SETTINGS_FILE')
 
 # Configure CSRF protection.
 csrf = flask_wtf.csrf.CSRFProtect(app)

--- a/app/socket_api.py
+++ b/app/socket_api.py
@@ -17,30 +17,6 @@ socketio = flask_socketio.SocketIO()
 socketio.on_namespace(update_logs.Namespace('/updateLogs'))
 
 
-def _get_keyboard_path():
-    """Get the file path at which to write keyboard HID input.
-
-    Returns:
-        A string of the keyboard file path.
-
-    Raises:
-        RuntimeError: If called outside of the Flask application context.
-    """
-    return flask.current_app.config.get('KEYBOARD_PATH')
-
-
-def _get_mouse_path():
-    """Get the file path at which to write mouse HID input.
-
-    Returns:
-        A string of the mouse file path.
-
-    Raises:
-        RuntimeError: If called outside of the Flask application context.
-    """
-    return flask.current_app.config.get('MOUSE_PATH')
-
-
 @socketio.on('keystroke')
 def socket_keystroke(message):
     try:
@@ -59,9 +35,9 @@ def socket_keystroke(message):
         logger.info('Ignoring %s key (keycode=%s)', keystroke.key,
                     keystroke.code)
         return {'success': False}
+    keyboard_path = flask.current_app.config.get('KEYBOARD_PATH')
     try:
-        fake_keyboard.send_keystroke(_get_keyboard_path(), control_keys,
-                                     hid_keycode)
+        fake_keyboard.send_keystroke(keyboard_path, control_keys, hid_keycode)
     except hid_write.WriteError as e:
         logger.error('Failed to write key: %s (keycode=%s). %s', keystroke.key,
                      keystroke.code, e)
@@ -76,8 +52,9 @@ def socket_mouse_event(message):
     except mouse_event_request.Error as e:
         logger.error('Failed to parse mouse event request: %s', e)
         return {'success': False}
+    mouse_path = flask.current_app.config.get('MOUSE_PATH')
     try:
-        fake_mouse.send_mouse_event(_get_mouse_path(), mouse_move_event.buttons,
+        fake_mouse.send_mouse_event(mouse_path, mouse_move_event.buttons,
                                     mouse_move_event.relative_x,
                                     mouse_move_event.relative_y,
                                     mouse_move_event.vertical_wheel_delta,
@@ -90,8 +67,9 @@ def socket_mouse_event(message):
 
 @socketio.on('keyRelease')
 def socket_key_release():
+    keyboard_path = flask.current_app.config.get('KEYBOARD_PATH')
     try:
-        fake_keyboard.release_keys(_get_keyboard_path())
+        fake_keyboard.release_keys(keyboard_path)
     except hid_write.WriteError as e:
         logger.error('Failed to release keys: %s', e)
 

--- a/dev-scripts/mock-scripts/collect-debug-logs
+++ b/dev-scripts/mock-scripts/collect-debug-logs
@@ -29,8 +29,7 @@ WorkingDirectory=/opt/tinypilot
 ExecStart=/opt/tinypilot/venv/bin/python app/main.py
 Environment=HOST=127.0.0.1
 Environment=PORT=8000
-Environment=KEYBOARD_PATH=/dev/hidg0
-Environment=MOUSE_PATH=/dev/hidg1
+Environment=APP_SETTINGS_FILE=/opt/tinypilot/app_settings.cfg
 Restart=always
 
 [Install]

--- a/dev-scripts/serve-dev
+++ b/dev-scripts/serve-dev
@@ -12,8 +12,7 @@ set -u
 # Serve TinyPilot in dev mode.
 HOST=0.0.0.0 \
   PORT=8000 \
-  KEYBOARD_PATH=/dev/null \
-  MOUSE_PATH=/dev/null \
   DEBUG=1 \
   USE_RELOADER=1 \
+  APP_SETTINGS_FILE=../dev_app_settings.cfg \
   ./app/main.py

--- a/dev_app_settings.cfg
+++ b/dev_app_settings.cfg
@@ -1,0 +1,5 @@
+# This configuration file is an actual Python file. Only variables in uppercase
+# are recognized as config keys.
+
+KEYBOARD_PATH = '/dev/null'
+MOUSE_PATH = '/dev/null'


### PR DESCRIPTION
Dependent on https://github.com/tiny-pilot/ansible-role-tinypilot/pull/148

# Caveat
The only place we use `KEYBOARD_PATH` and `MOUSE_PATH` is in the socket API. Now that these variables are stored in the Flask app config, we need to have a handle on the current Flask app in order to reference these variables. To avoid circular imports, the [Flask docs](https://flask.palletsprojects.com/en/2.0.x/appcontext/#purpose-of-the-context) suggest using `flask.current_app` which is only available when a request comes in. This means that we can't have a global `keyboard_path`/`mouse_path` variable like before. Instead, I opted for [helper functions](https://github.com/tiny-pilot/tinypilot/blob/0999f46dc9fbaf84163fa10c35d8d03e63106a3d/app/socket_api.py#L20-L41) to be called within the context of a request.

Fixes #738

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/754)
<!-- Reviewable:end -->
