### PR TITLE
Properly recognize pasting shortcut on MacOS

### DIFF
--- a/app/static/js/paste.js
+++ b/app/static/js/paste.js
@@ -21,12 +21,18 @@ function hidePasteOverlay() {
 
 function onPasteOverlayKeyDown(evt) {
   evt.stopPropagation();
-  // Return false on Ctrl or V because otherwise we capture the
+  // Return false on Ctrl/Meta or V because otherwise we capture the
   // event before the paste event can occur.
   if (
-    evt.code === "ControlLeft" ||
-    evt.code === "ControlRight" ||
-    evt.code === "KeyV"
+    [
+      "ControlLeft",
+      "ControlRight",
+      "MetaLeft", // Chrome on MacOS
+      "MetaRight", // Chrome on MacOS
+      "OSLeft", // Firefox on MacOS
+      "OSRight", // Firefox on MacOS
+      "KeyV",
+    ].includes(evt.code)
   ) {
     return false;
   }


### PR DESCRIPTION
Fixes https://github.com/tiny-pilot/tinypilot/issues/730. The problem is MacOS-specific, because 1) on MacOS the Meta (⌘) key is used instead of Ctrl, and 2) Firefox and Chrome differ in their keycode for said Meta key.

I simplified the code a bit, for long monotonous checks like here I find list expressions easier to understand than boolean statements.

I’ve tested on both Chrome and Firefox, so in case you don’t have a Mac at hand for QAing I think it should be fine.

I also checked the rest of the codebase for this issue, but couldn’t find any other place where we might have forgotten about MacOS.

<img width="171" alt="Screenshot 2021-08-16 at 15 26 23" src="https://user-images.githubusercontent.com/3618384/129571384-7c70bedc-4d0b-4932-bf9f-1b154e51eb29.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/756)
<!-- Reviewable:end -->
