### PR TITLE
Remove `use strict` directives from ES6 modules

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import {
   isModifierCode,
   findKeyCode,

--- a/app/static/js/controllers.js
+++ b/app/static/js/controllers.js
@@ -1,3 +1,5 @@
+"use strict";
+
 (function (windows) {
   function getCsrfToken(doc = document) {
     return getCsrfTokenElement(doc).getAttribute("content");

--- a/app/static/js/controllers.js
+++ b/app/static/js/controllers.js
@@ -1,5 +1,3 @@
-"use strict";
-
 (function (windows) {
   function getCsrfToken(doc = document) {
     return getCsrfTokenElement(doc).getAttribute("content");

--- a/app/static/js/keyboardstate.js
+++ b/app/static/js/keyboardstate.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import { isModifierCode, keystrokeToCanonicalCode } from "./keycodes.js";
 
 const modifierPropToKeyCodesMapping = {

--- a/app/static/js/keycodes.js
+++ b/app/static/js/keycodes.js
@@ -1,5 +1,3 @@
-"use strict";
-
 //TODO: Fix these mappings.
 
 // Mappings of characters to codes that are shared among different keyboard

--- a/app/static/js/keystrokes.js
+++ b/app/static/js/keystrokes.js
@@ -1,5 +1,3 @@
-"use strict";
-
 // Send a keystroke message to the backend.
 export function sendKeystroke(socket, keystroke) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot/issues/746, and follow-up of https://github.com/tiny-pilot/tinypilot/pull/757, where I forgot this unfortunately.

[Strict mode is on by default for ES6 modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#strict_mode_for_modules), so the directives are not needed anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/758)
<!-- Reviewable:end -->
