### PR TITLE
Fix monospace variant of input field

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -106,6 +106,14 @@ input[type="password"] {
   box-shadow: inset 0 0 0.2rem 0 rgba(0, 0, 0, 0.15);
 }
 
+input[type="text"].monospace {
+  font-family: "Overpass Mono", monospace;
+  /* Since the monospace font has different characteristics than the regular
+     font, we need to set the height here explicitly. In the end, the input
+     field needs to have the same height when placed next to a button. */
+  height: 1.58rem;
+}
+
 .logs-output {
   /* Note: don't forget to also add the monospace class when using this class */
   padding: 0.25rem 0.5rem;

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -181,9 +181,28 @@
       </label>
 
       <h2 class="section">Input</h2>
+      <h3>For Regular Text</h3>
       <div>
-        Input Text:&nbsp;
-        <input type="text" />
+        <input
+          type="text"
+          style="width: 15rem;"
+          value="My name is Pilot. Tiny Pilot."
+        />
+        <button>Send</button>
+      </div>
+
+      <h3>For Monospace Text</h3>
+      <p>
+        Used for entering “technical” values, e.g. IP addresses.
+      </p>
+      <div>
+        <input
+          type="text"
+          class="monospace"
+          style="width: 15rem;"
+          value="192.168.0.1"
+        />
+        <button>Send</button>
       </div>
 
       <h2 class="section">Overlay</h2>


### PR DESCRIPTION
Small UI issue: I noticed that the monospace class didn’t have any effect on the input field, due to CSS selector specificity. The monospace font is better suited for technical jargon/values, because it’s designed to make individual characters distinguishable. E.g. if you compare:

- |IlliO0o'"' (regular font)
- `|IlliO0o'"` (same copy, but monospace font)


I need this for https://github.com/tiny-pilot/tinypilot-pro/issues/216. But it also fixes the hostname dialog, which should be (have been) monospace too.

It’s quite hard to get the sizing exactly equal on all browsers / OSses. I’ve tested on Mac (Firefox / Chrome / Safari), and Ubuntu (Firefox), and it appeared to be roughly the same everywhere. In the end, the goal is that input field and button always have the same visual height.

## Styleguide
<img width="683" alt="Screenshot 2021-08-18 at 18 37 14" src="https://user-images.githubusercontent.com/3618384/129937598-a9d7b306-9e0f-445b-8446-1de89e03eeba.png">

## Hostname dialog fix
(before)
<img width="250" alt="Screenshot 2021-08-18 at 18 41 01" src="https://user-images.githubusercontent.com/3618384/129937952-2e4b4605-d1df-43b2-bfe1-2893842f3c3b.png">

(after)
<img width="284" alt="Screenshot 2021-08-18 at 18 40 50" src="https://user-images.githubusercontent.com/3618384/129937947-6a63abe1-2ef1-4ef4-81bb-7db1711e2299.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/760)
<!-- Reviewable:end -->
