### PR TITLE
Add automatic request retry on CSRF failures.

### DIFF
--- a/app/static/js/csrf.js
+++ b/app/static/js/csrf.js
@@ -1,3 +1,6 @@
+// This variable indicates if the CSRF token has been locked and in the process
+// of being refreshed. The value is either a Promise when locked or null
+// otherwise.
 let csrfRefreshLock = null;
 
 export function getCsrfToken(doc = document) {
@@ -35,7 +38,7 @@ async function refreshCsrfToken() {
  * API as the global fetch function.
  */
 export async function fetchWithCsrfRetry(resource, init) {
-  let response = await fetch(resource, init);
+  const response = await fetch(resource, init);
   // Only retry a request when the original request has a CSRF token header.
   // This is to avoid programmers from getting lazy and never including a CSRF
   // token header in their requests.

--- a/app/static/js/csrf.js
+++ b/app/static/js/csrf.js
@@ -1,0 +1,72 @@
+let csrfRefreshLock = null;
+
+export function getCsrfToken(doc = document) {
+  return getCsrfTokenElement(doc).getAttribute("content");
+}
+
+function getCsrfTokenElement(doc) {
+  return doc.querySelector("meta[name='csrf-token']");
+}
+
+function setCsrfToken(tokenValue) {
+  return getCsrfTokenElement(document).setAttribute("content", tokenValue);
+}
+
+async function refreshCsrfToken() {
+  return fetch("/")
+    .then(function (response) {
+      return response.text();
+    })
+    .then(function (html) {
+      const doc = new DOMParser().parseFromString(html, "text/html");
+      const csrfToken = getCsrfToken(doc);
+      setCsrfToken(csrfToken);
+      return Promise.resolve();
+    })
+    .catch(function (error) {
+      return Promise.reject("Failed to refresh CSRF token: " + error);
+    });
+}
+
+/**
+ * Adds retry functionality to the Fetch API.
+ * If the HTTP request fails due to a stale CSRF token, then refresh the CSRF
+ * token and retry the original request once more. This function has the same
+ * API as the global fetch function.
+ */
+export async function fetchWithCsrfRetry(resource, init) {
+  let response = await fetch(resource, init);
+  // Only retry a request when the original request has a CSRF token header.
+  // This is to avoid programmers from getting lazy and never including a CSRF
+  // token header in their requests.
+  let csrfTokenHeader = init?.headers?.["X-CSRFToken"] || null;
+  if (!csrfTokenHeader) {
+    console.error(
+      "Cannot trigger a CSRF token refresh when the CSRF token header is missing from the request."
+    );
+    return response;
+  }
+  if (response.status !== 403) {
+    return response;
+  }
+  if (!csrfRefreshLock) {
+    // Initialize the lock.
+    csrfRefreshLock = new Promise(async (resolve, reject) => {
+      try {
+        await refreshCsrfToken();
+        resolve();
+      } catch (e) {
+        reject(e);
+      } finally {
+        // Release the lock.
+        csrfRefreshLock = null;
+      }
+    });
+  }
+  // Wait for the CSRF token to be refreshed.
+  await csrfRefreshLock;
+  // Update the CSRF token header.
+  init.headers["X-CSRFToken"] = getCsrfToken();
+  // Retry the original request.
+  return fetch(resource, init);
+}

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -116,7 +116,6 @@
     getLatestRelease,
     getUpdateStatus,
     getVersion,
-    refreshCsrfToken,
     shutdown,
     update,
   } from "/js/controllers.js";
@@ -290,8 +289,6 @@
 
           try {
             await this._waitForUpdateToFinish();
-            // Updating causes the backend to restart, changing the CSRF token.
-            await refreshCsrfToken();
             await this._performRestart();
             // Wait at least 10 seconds to ensure reboot has started before
             // checking whether the system is back up.


### PR DESCRIPTION
This PR wraps all unsafe HTTP requests (made from the frontend) with a function that retries the request once more if it fails due to a stale CSRF token.

## Desired behaviour
1. Frontend gets loaded in the browser
2. Backend restarts for whatever reason. This changes the CSRF token.
3. Frontend makes a unsafe HTTP request (i.e. PUT, POST, DELETE) to the backend.
4. The request fails with a 403 Forbidden HTTP error because the frontend has an outdated CSRF token.
5. The frontend refreshes its CSRF token
6. The original request (in step 3) is retried once.

## Caveat
Seeing as the retry behaviour is applied to the individual controller functions, a race-condition is created when calling these controllers in "parallel" and passing them to `Promise.all`. Currently this race-condition can only happen in the [`video-dialog` component](https://github.com/tiny-pilot/tinypilot/blob/8eb0f485b025d02040361a7d27182c0b41b78930/app/templates/custom-elements/video-settings-dialog.html#L288) and if the backend restarted before clicking "Apply". [Here's a video to demonstrate](https://www.loom.com/share/a87ef929b0094128bb7be2b8a0abe909).

Fixes #495 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/762)
<!-- Reviewable:end -->
