### PR TITLE
Remove scrollbars on overlay elements

### DIFF
--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -5,7 +5,7 @@
     :host {
       display: none;
       position: fixed;
-      overflow: scroll;
+      overflow: auto;
       width: 100%;
       height: 100%;
       top: 0;


### PR DESCRIPTION
The overlay panel was set to overflow: scroll, which caused scrollbars to appear on the right and bottom of the page. These aren't necessary, so this change makes it overflow: auto, causing the scrollbars to disappear unless they're actually scrolling content.

### Before

![image](https://user-images.githubusercontent.com/7783288/130637449-7dcf243d-b710-4405-933c-e14b0fdf8299.png)

### After

![image](https://user-images.githubusercontent.com/7783288/130637273-cea7dd4e-56c0-40ed-9d01-2dfdc19f8130.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/763)
<!-- Reviewable:end -->
