### PR TITLE
Accurately detect HID failures.

### DIFF
--- a/app/hid/mouse_test.py
+++ b/app/hid/mouse_test.py
@@ -1,7 +1,7 @@
 import tempfile
 import unittest
 
-from app.hid import mouse
+from hid import mouse
 
 
 class MouseTest(unittest.TestCase):

--- a/app/hid/write.py
+++ b/app/hid/write.py
@@ -12,6 +12,55 @@ class WriteError(Error):
     pass
 
 
+class ProcessWithResult(multiprocessing.Process):
+    """A multiprocessing.Process object that keeps track of the child process'
+    result (i.e., the return value and exception raised).
+
+    Inspired by:
+    https://stackoverflow.com/a/33599967/3769045
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Create the Connection objects used for communication between the
+        # parent and child processes.
+        self.parent_conn, self.child_conn = multiprocessing.Pipe()
+
+    def run(self):
+        """Method to be run in sub-process."""
+        result = {'return_value': None, 'exception': None}
+        try:
+            if self._target:
+                result['return_value'] = self._target(*self._args,
+                                                      **self._kwargs)
+        except Exception as e:
+            result['exception'] = e
+            raise
+        finally:
+            self.child_conn.send(result)
+
+    def result(self):
+        """Get the result from the child process.
+
+        Returns:
+            If the child process has completed, a dictionay with the following
+            keys are returned:
+            return_value: Any object. If no object was returned, this will be
+                None.
+            exception: Exception object. If no exception was raised, then this
+                will be None.
+
+            Example:
+            {
+                'return_value': None,
+                'exception': WriteError('Failed to write to HID interface')
+            }
+
+            If the child process has not yet completed, returns None.
+        """
+        return self.parent_conn.recv() if self.parent_conn.poll() else None
+
+
 def _write_to_hid_interface_immediately(hid_path, buffer):
     try:
         with open(hid_path, 'ab+') as hid_handle:
@@ -31,17 +80,18 @@ def write_to_hid_interface(hid_path, buffer):
     # Writes can hang, for example, when TinyPilot is attempting to write to the
     # mouse interface, but the target system has no GUI. To avoid locking up the
     # main server process, perform the HID interface I/O in a separate process.
-    write_process = multiprocessing.Process(
+    write_process = ProcessWithResult(
         target=_write_to_hid_interface_immediately,
         args=(hid_path, buffer),
         daemon=True)
     write_process.start()
     write_process.join(timeout=0.5)
-    # If the process is still alive, it means the write failed to complete in
-    # time.
     if write_process.is_alive():
         write_process.kill()
         _wait_for_process_exit(write_process)
+    result = write_process.result()
+    # If the result is None, it means the write failed to complete in time.
+    if result is None or result['exception']:
         raise WriteError(
             'Failed to write to HID interface: %s. Is USB cable connected?' %
             hid_path)

--- a/app/hid/write_test.py
+++ b/app/hid/write_test.py
@@ -1,0 +1,47 @@
+import io
+import time
+import unittest
+from unittest import mock
+
+import hid.write
+
+
+class WriteTest(unittest.TestCase):
+
+    def test_process_with_result_child_completed(self):
+
+        def target():
+            pass
+
+        process = hid.write.ProcessWithResult(target=target, daemon=True)
+        process.start()
+        process.join()
+        self.assertEqual({
+            'return_value': None,
+            'exception': None
+        }, process.result())
+
+    def test_process_with_result_child_not_completed(self):
+
+        def target():
+            time.sleep(1)
+
+        process = hid.write.ProcessWithResult(target=target, daemon=True)
+        process.start()
+        process.kill()
+        self.assertIsNone(process.result())
+
+    def test_process_with_result_child_exception(self):
+
+        def target():
+            raise Exception('Child exception')
+
+        # Silence stderr while the child exception is being raised to avoid
+        # polluting the terminal output.
+        with mock.patch('sys.stderr', io.StringIO()):
+            process = hid.write.ProcessWithResult(target=target, daemon=True)
+            process.start()
+            process.join()
+        result = process.result()
+        self.assertEqual({'return_value': None, 'exception': mock.ANY}, result)
+        self.assertEqual('Child exception', str(result['exception']))


### PR DESCRIPTION
Now that we're accurately detecting when TinyPilot fails to write to the HID, the frontend will also show the failures to the user  (as indicated by showing failed keystrokes in red). [Demo video](https://www.loom.com/share/131dc6fdd03049edb5c5907fd066d24f).

Fixes #404