### PR TITLE
Explicitly target buster as release version during apt-get update

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -121,7 +121,8 @@ if [ "$HAS_PRO_INSTALLED" = 1 ]; then
   fi
 fi
 
-sudo apt-get update
+readonly DEBIAN_RELEASE="buster"
+sudo apt-get update --target-release "${DEBIAN_RELEASE}"
 sudo apt-get install -y \
   git \
   libffi-dev \


### PR DESCRIPTION
Fixes #764

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/768)
<!-- Reviewable:end -->
