### PR TITLE
Add disabled state for all button variants

### DIFF
--- a/app/static/css/button.css
+++ b/app/static/css/button.css
@@ -38,6 +38,11 @@ button:active,
   transform: scale(0.99);
 }
 
+button:disabled,
+.btn:disabled {
+  cursor: not-allowed;
+}
+
 .btn-action {
   background-color: var(--brand-blue);
   border-color: var(--brand-blue-dark);
@@ -47,6 +52,10 @@ button:active,
 .btn-action:active,
 .btn-action:focus {
   background-color: var(--brand-blue-bright);
+}
+
+.btn-action:disabled {
+  background-color: var(--brand-blue-light);
 }
 
 .btn-success {
@@ -62,7 +71,6 @@ button:active,
 
 .btn-success:disabled {
   background-color: var(--brand-green-light);
-  cursor: not-allowed;
 }
 
 .btn-danger {
@@ -74,4 +82,8 @@ button:active,
 .btn-danger:active,
 .btn-danger:focus {
   background-color: var(--brand-red-bright);
+}
+
+.btn-danger:disabled {
+  background-color: var(--brand-red-light);
 }

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -20,15 +20,17 @@
   --brand-blue: hsl(var(--brand-hue-blue), 55%, 55%);
   --brand-blue-dark: hsl(var(--brand-hue-blue), 51%, 30%);
   --brand-blue-bright: hsl(var(--brand-hue-blue), 90%, 67%);
+  --brand-blue-light: hsl(var(--brand-hue-blue), 74%, 79%);
 
   --brand-red: hsl(var(--brand-hue-red), 57%, 44%);
   --brand-red-dark: hsl(var(--brand-hue-red), 72%, 29%);
-  --brand-red-light: hsl(var(--brand-hue-red), 54%, 95%);
+  --brand-red-light: hsl(var(--brand-hue-red), 64%, 77%);
   --brand-red-bright: hsl(var(--brand-hue-red), 85%, 46%);
+  --brand-red-background: hsl(var(--brand-hue-red), 54%, 95%);
 
   --brand-green: hsl(var(--brand-hue-green), 40%, 45%);
   --brand-green-dark: hsl(var(--brand-hue-green), 46%, 33%);
-  --brand-green-light: hsl(var(--brand-hue-green), 42%, 73%);
+  --brand-green-light: hsl(var(--brand-hue-green), 34%, 70%);
   --brand-green-bright: hsl(var(--brand-hue-green), 70%, 45%);
 
   --border-radius: 0.25rem;

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -37,7 +37,7 @@
 
     :host([variant="danger"]) #panel {
       border-top: 0.4rem solid var(--brand-red-bright);
-      background-color: var(--brand-red-light);
+      background-color: var(--brand-red-background);
     }
   </style>
 

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -85,6 +85,10 @@
           class="colorcard"
           style="background-color: var(--brand-blue);"
         ></div>
+        <div
+          class="colorcard"
+          style="background-color: var(--brand-blue-light);"
+        ></div>
         <br style="clear: both;" />
         <div
           class="colorcard"
@@ -97,6 +101,10 @@
         <div
           class="colorcard"
           style="background-color: var(--brand-red-light);"
+        ></div>
+        <div
+          class="colorcard"
+          style="background-color: var(--brand-red-background);"
         ></div>
         <br style="clear: both;" />
         <div
@@ -138,15 +146,18 @@
       <p>For harmless operations like “close” or “cancel”.</p>
       <h3>Action Button</h3>
       <button class="btn-action">Action</button>
+      <button class="btn-action" disabled>(disabled)</button>
       <p>
         For operations that do or apply something. (Don’t use for the primary
         call-to-action.)
       </p>
       <h3>Success Button (Primary Action)</h3>
       <button class="btn-success">Success</button>
+      <button class="btn-success" disabled>(disabled)</button>
       <p>For the main (and non-destructive) call-to-action.</p>
       <h3>Danger Button (Primary Action)</h3>
       <button class="btn-danger">Danger</button>
+      <button class="btn-danger" disabled>(disabled)</button>
       <p>For destructive call-to-actions like “delete” or “shutdown”.</p>
       <h3>Dropdown button</h3>
       <p>


### PR DESCRIPTION
We only have styling for the disabled state of the success button, but not for the others. For the WOL overlay I need a disabled action button, and while I was on it I also did the error one.

- I had to change the `--brand-red-light` to `--brand-red-background`, since we are running out of labels… It’s only usage is as background colour of the error overlay.
- I also adjusted the colour values a bit for slightly better contrast.

<img width="352" alt="Screenshot 2021-08-25 at 17 28 22" src="https://user-images.githubusercontent.com/3618384/130819737-76578213-1703-4474-b154-77956eb41299.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/773)
<!-- Reviewable:end -->
