### PR TITLE
Downgrade dnspython to 1.16.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pyyaml==5.4.1
 # Indirect dependencies
 bidict==0.21.2
 click==7.1.2
-dnspython==2.1.0
+dnspython==1.16.0
 greenlet==1.0.0
 itsdangerous==1.1.0
 Jinja2==2.11.3


### PR DESCRIPTION
We were getting a warning during install that eventlet was incompatible with our version of dnspython

>eventlet 0.31.0 has requirement dnspython<2.0.0,>=1.15.0, but you'll have dnspython 2.1.0 which is incompatible.

Downgrading to 1.16.0 fixes the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/774)
<!-- Reviewable:end -->
