### PR TITLE
Only allow the suite field to be changed in the debian release info.

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -121,8 +121,7 @@ if [ "$HAS_PRO_INSTALLED" = 1 ]; then
   fi
 fi
 
-readonly DEBIAN_RELEASE="buster"
-sudo apt-get update --target-release "${DEBIAN_RELEASE}"
+sudo apt-get update --allow-releaseinfo-change-suite
 sudo apt-get install -y \
   git \
   libffi-dev \


### PR DESCRIPTION
Fixes #764

I've tested the quick-install script on a fresh install of TinyPilot Pro Hobbyist 2.2.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/776)
<!-- Reviewable:end -->
