### PR TITLE
Remove extraneous try/catch from js_to_hid

### DIFF
--- a/app/js_to_hid.py
+++ b/app/js_to_hid.py
@@ -144,11 +144,7 @@ _MAPPING = {
 
 
 def convert(keystroke):
-    try:
-        return _map_modifier_keys(keystroke), _map_keycode(keystroke)
-    except KeyError as e:
-        raise UnrecognizedKeyCodeError('Unrecognized key code %s (%s)' %
-                                       (keystroke.key, keystroke.code)) from e
+    return _map_modifier_keys(keystroke), _map_keycode(keystroke)
 
 
 def _map_modifier_keys(keystroke):

--- a/app/js_to_hid_test.py
+++ b/app/js_to_hid_test.py
@@ -101,3 +101,31 @@ class ConvertJsToHIDTest(unittest.TestCase):
         self.assertEqual(hid.MODIFIER_LEFT_CTRL | hid.MODIFIER_LEFT_SHIFT,
                          modifier_bitmask)
         self.assertEqual(hid.KEYCODE_LEFT_CTRL, hid_keycode)
+
+    def test_raises_exception_on_unrecognized_code(self):
+        with self.assertRaises(js_to_hid.UnrecognizedKeyCodeError):
+            js_to_hid.convert(
+                keystroke.Keystroke(left_meta_modifier=False,
+                                    right_meta_modifier=False,
+                                    left_alt_modifier=False,
+                                    right_alt_modifier=False,
+                                    left_shift_modifier=False,
+                                    right_shift_modifier=False,
+                                    left_ctrl_modifier=False,
+                                    right_ctrl_modifier=False,
+                                    key='a',
+                                    code='MadeUpInvalidCode'))
+
+    def test_raises_exception_on_blank_code(self):
+        with self.assertRaises(js_to_hid.UnrecognizedKeyCodeError):
+            js_to_hid.convert(
+                keystroke.Keystroke(left_meta_modifier=False,
+                                    right_meta_modifier=False,
+                                    left_alt_modifier=False,
+                                    right_alt_modifier=False,
+                                    left_shift_modifier=False,
+                                    right_shift_modifier=False,
+                                    left_ctrl_modifier=False,
+                                    right_ctrl_modifier=False,
+                                    key='a',
+                                    code=''))


### PR DESCRIPTION
This code block used to be able to throw a KeyError, but as of #511, _map_keycode handles the KeyError internally, so there's no opportunity for it to bubble up to the convert() function, making the try/catch unnecessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/777)
<!-- Reviewable:end -->
