### PR TITLE
Clarify keystroke history on Ctrl-Alt-Del

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -348,6 +348,18 @@ menuBar.addEventListener("paste-requested", () => {
   showPasteOverlay();
 });
 menuBar.addEventListener("ctrl-alt-del-requested", () => {
+  // Even though only the final keystroke matters, send them one at a time to
+  // better match real user behavior, and so that the keystroke history shows
+  // the Control, Alt, Delete sequence clearly.
+  processKeystroke({
+    key: "Control",
+    code: "ControlLeft",
+  });
+  processKeystroke({
+    ctrlLeft: true,
+    key: "Alt",
+    code: "AltLeft",
+  });
   processKeystroke({
     ctrlLeft: true,
     altLeft: true,

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -349,8 +349,8 @@ menuBar.addEventListener("paste-requested", () => {
 });
 menuBar.addEventListener("ctrl-alt-del-requested", () => {
   // Even though only the final keystroke matters, send them one at a time to
-  // better match real user behavior, and so that the keystroke history shows
-  // the Control, Alt, Delete sequence clearly.
+  // better match real user behavior. This ensures that the keystroke history
+  // shows the Control, Alt, Delete sequence clearly.
   processKeystroke({
     key: "Control",
     code: "ControlLeft",

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -352,11 +352,13 @@ menuBar.addEventListener("ctrl-alt-del-requested", () => {
   // better match real user behavior. This ensures that the keystroke history
   // shows the Control, Alt, Delete sequence clearly.
   processKeystroke({
+    ctrlLeft: true,
     key: "Control",
     code: "ControlLeft",
   });
   processKeystroke({
     ctrlLeft: true,
+    altLeft: true,
     key: "Alt",
     code: "AltLeft",
   });


### PR DESCRIPTION
When the user clicks the Ctrl-Alt-Del shortcut from the Actions menu, the key history shows only a Delete keystroke, which might make users wonder whether we sent the keystroke correctly.

This change adds the Control and Alt keystrokes to match a real user's keystrokes and to generate a clear keystroke history.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/790)
<!-- Reviewable:end -->
