### PR TITLE
Add a static secret key.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ coverage.xml
 
 # Flask
 app_settings.cfg
+.secret_key
 
 # Sphinx documentation
 docs/_build/

--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from werkzeug import exceptions
 
 import api
 import json_response
+import secret_key
 import socket_api
 import views
 from find_files import find as find_files
@@ -37,7 +38,7 @@ logger.info('Starting app')
 
 app = flask.Flask(__name__, static_url_path='')
 app.config.update(
-    SECRET_KEY=os.urandom(32),
+    SECRET_KEY=secret_key.get(),
     TEMPLATES_AUTO_RELOAD=True,
     WTF_CSRF_TIME_LIMIT=None,
 )

--- a/app/secret_key.py
+++ b/app/secret_key.py
@@ -1,0 +1,65 @@
+import os
+
+SECRET_KEY_FILE = '.secret_key'
+
+
+class Error(Exception):
+    pass
+
+
+class InvalidSecretKeyError(Error):
+    pass
+
+
+def read():
+    """
+    Read the currently saved secret key from the filesystem.
+
+    Args:
+        None
+
+    Returns:
+        The byte string content of the secret key file.
+
+    Raises:
+        IOError: If the secret key file doesn't exist yet.
+    """
+    with open(SECRET_KEY_FILE, 'rb') as f:  # pylint: disable=invalid-name
+        return f.read()
+
+
+def create():
+    """
+    Generate and save a secret key to the filesystem.
+
+    Args:
+        None
+
+    Returns:
+        A string of 32 random bytes suitable for cryptographic use.
+    """
+    with open(SECRET_KEY_FILE, 'wb') as f:  # pylint: disable=invalid-name
+        secret_key = os.urandom(32)
+        f.write(secret_key)
+        return secret_key
+
+
+def get():
+    """
+    Get or create a secret key.
+
+    If a secret key doesn't exist, a new one will be created and returned.
+
+    Args:
+        None
+
+    Returns:
+        The byte string content of the secret key file.
+    """
+    try:
+        secret_key = read()
+        if not secret_key:
+            raise InvalidSecretKeyError
+        return secret_key
+    except (IOError, InvalidSecretKeyError):
+        return create()

--- a/app/secret_key_tests.py
+++ b/app/secret_key_tests.py
@@ -1,0 +1,107 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import secret_key
+
+
+class SecretKeyTest(unittest.TestCase):
+
+    def assertSecretKeyValue(self, value):  # pylint: disable=invalid-name
+        self.assertIs(bytes, type(value))
+        self.assertEqual(32, len(value))
+
+    def assertSecretKeyFile(self, value):  # pylint: disable=invalid-name
+        self.assertTrue(os.path.exists(secret_key.SECRET_KEY_FILE))
+        with open(secret_key.SECRET_KEY_FILE, 'rb') as f:  # pylint: disable=invalid-name
+            self.assertEqual(value, f.read())
+
+    def test_read_when_file_exists(self):
+        with tempfile.NamedTemporaryFile() as temp_file:
+            mock_secret_key_file = temp_file.name
+            temp_file.write(b'insecure')
+            temp_file.flush()
+
+            with mock.patch.object(secret_key, 'SECRET_KEY_FILE',
+                                   mock_secret_key_file):
+                # Returns exactly what's in the file.
+                self.assertEqual(b'insecure', secret_key.read())
+
+    def test_read_when_file_does_not_exist(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            mock_secret_key_file = os.path.join(temp_dir,
+                                                secret_key.SECRET_KEY_FILE)
+            self.assertFalse(os.path.exists(mock_secret_key_file))
+
+            with mock.patch.object(secret_key, 'SECRET_KEY_FILE',
+                                   mock_secret_key_file):
+                # Fails with an IOError.
+                with self.assertRaises(IOError):
+                    secret_key.read()
+
+    def test_create_when_file_exists(self):
+        with tempfile.NamedTemporaryFile() as temp_file:
+            mock_secret_key_file = temp_file.name
+            temp_file.write(b'insecure')
+            temp_file.flush()
+
+            with mock.patch.object(secret_key, 'SECRET_KEY_FILE',
+                                   mock_secret_key_file):
+                # The file is overwritten with a new secret key.
+                secret_key_value = secret_key.create()
+                self.assertNotEqual(b'insecure', secret_key_value)
+                self.assertSecretKeyValue(secret_key_value)
+                self.assertSecretKeyFile(secret_key_value)
+
+    def test_create_when_file_does_not_exist(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            mock_secret_key_file = os.path.join(temp_dir,
+                                                secret_key.SECRET_KEY_FILE)
+            self.assertFalse(os.path.exists(mock_secret_key_file))
+
+            with mock.patch.object(secret_key, 'SECRET_KEY_FILE',
+                                   mock_secret_key_file):
+                # The file is created and a new secret key is written.
+                secret_key_value = secret_key.create()
+                self.assertSecretKeyValue(secret_key_value)
+                self.assertSecretKeyFile(secret_key_value)
+
+    def test_get_when_file_exists(self):
+        with tempfile.NamedTemporaryFile() as temp_file:
+            mock_secret_key_file = temp_file.name
+            temp_file.write(b'insecure')
+            temp_file.flush()
+
+            with mock.patch.object(secret_key, 'SECRET_KEY_FILE',
+                                   mock_secret_key_file):
+                # Returns exactly what's in the file.
+                secret_key_value = secret_key.get()
+                self.assertEqual(b'insecure', secret_key_value)
+                self.assertSecretKeyFile(secret_key_value)
+
+    def test_get_when_an_invalid_secret_key_exists(self):
+        with tempfile.NamedTemporaryFile() as temp_file:
+            mock_secret_key_file = temp_file.name
+            temp_file.write(b'')
+            temp_file.flush()
+
+            with mock.patch.object(secret_key, 'SECRET_KEY_FILE',
+                                   mock_secret_key_file):
+                # The file is overwritten with a new secret key.
+                secret_key_value = secret_key.get()
+                self.assertSecretKeyValue(secret_key_value)
+                self.assertSecretKeyFile(secret_key_value)
+
+    def test_get_when_file_does_not_exist(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            mock_secret_key_file = os.path.join(temp_dir,
+                                                secret_key.SECRET_KEY_FILE)
+            self.assertFalse(os.path.exists(mock_secret_key_file))
+
+            with mock.patch.object(secret_key, 'SECRET_KEY_FILE',
+                                   mock_secret_key_file):
+                # The file is created and a new secret key is written.
+                secret_key_value = secret_key.get()
+                self.assertSecretKeyValue(secret_key_value)
+                self.assertSecretKeyFile(secret_key_value)


### PR DESCRIPTION
Based on our discussion [here](https://github.com/tiny-pilot/tinypilot-pro/pull/253#issuecomment-923979071), we have decided to use a static `SECRET_KEY` which will prevent our CSRF tokens from ever expiring when the server restarts.

# Outstanding changes
1. Wait for https://github.com/tiny-pilot/tinypilot/pull/793 to be merged
1. Remove the code for [`refreshCsrfToken`](https://github.com/tiny-pilot/tinypilot/blob/a19f7ee3acfbe017b59611345aa5e2648cfdd9e6/app/static/js/controllers.js#L66-L80) completely.
2. Add demo video.