### PR TITLE
Apply a uStreamer workaround for browser bugs in MJPEG handling

### DIFF
--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -64,7 +64,10 @@
   </style>
   <div class="screen-wrapper">
     <input id="mobile-keyboard-input" autocapitalize="off" type="text" />
-    <img id="remote-screen-img" src="/stream?advance_headers=1" />
+    <img
+      id="remote-screen-img"
+      src="/stream?advance_headers=1&dual_final_frames=1"
+    />
   </div>
   <script
     id="underscore-library"


### PR DESCRIPTION
Applies uStreamer's dual_final_frames=1 option to work around a bug in how Chrome and other browsers handle MJPEG when uStreamer's --drop-same-frames option is in use.

uStreamer's documentation suggests that this is a Safari/Webkit-specific workaround, but I've verified that this affects Chrome, Firefox, and Edge as well.

Fix confirmed on:

* Chrome 93 x64 (Windows)
* Edge 94 x64 (Windows)
* Firefox 92 x64 (Windows)

---

## Video demo

To reproduce this, I reduced FPS to 5, so uStreamer was running with the following settings on a TinyPilot Voyager:

```bash
ustreamer \
  --port 8001 \
  --encoder omx \
  --format uyvy \
  --desired-fps 5 \
  --workers 3 \
  --drop-same-frames 30 \
  --persistent \
  --dv-timings
```

I loaded the page in Chrome 93 x64 (Windows) and moved the mouse both before and after the fix.

### Before fix

https://user-images.githubusercontent.com/7783288/135303689-ff5e04fd-8db9-4ebe-b132-6b5d4344e910.mp4

### After fix

https://user-images.githubusercontent.com/7783288/135303725-0561e652-2f38-4072-b5f3-fd7770aed40a.mp4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/796)
<!-- Reviewable:end -->
