### PR TITLE
Hide X close button when the app state requires it

### DIFF
--- a/app/static/js/events.js
+++ b/app/static/js/events.js
@@ -29,3 +29,27 @@ export class DialogFailedEvent extends CustomEvent {
     });
   }
 }
+
+export class StateDisablingCloseEvent extends CustomEvent {
+  /**
+   * Event warning that we enter a state that disables the close behavior.
+   */
+  constructor() {
+    super("state-disabling-close", {
+      bubbles: true,
+      composed: true,
+    });
+  }
+}
+
+export class StateAllowingCloseEvent extends CustomEvent {
+  /**
+   * Event warning that we enter a state that allows the close behavior.
+   */
+  constructor() {
+    super("state-allowing-close", {
+      bubbles: true,
+      composed: true,
+    });
+  }
+}

--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -80,9 +80,26 @@
 </template>
 
 <script type="module">
-  import { DialogClosedEvent, DialogFailedEvent } from "/js/events.js";
+  import {
+    DialogClosedEvent,
+    DialogFailedEvent,
+    StateDisablingCloseEvent,
+    StateAllowingCloseEvent,
+  } from "/js/events.js";
   import { copyElementTextToClipboard } from "/js/clipboard.js";
   import { getDebugLogs, textToShareableUrl } from "/js/controllers.js";
+
+  const states = {
+    LOGS_LOADING: "logs-loading",
+    LOGS_SUCCESS: "logs-success",
+    URL_LOADING: "url-loading",
+    URL_SUCCESS: "url-success",
+  };
+  // the states in statesDisablingClose requires to disable the eventual close buttons
+  const statesDisablingClose = {
+    [states.LOGS_LOADING]: true,
+    [states.URL_LOADING]: true,
+  };
 
   (function () {
     const template = document.querySelector("#debug-dialog-template");
@@ -136,16 +153,21 @@
 
         set state(newValue) {
           this.setAttribute("state", newValue);
+          if (statesDisablingClose[newValue]) {
+            this.dispatchEvent(new StateDisablingCloseEvent());
+          } else {
+            this.dispatchEvent(new StateAllowingCloseEvent());
+          }
         }
 
         getLogs() {
-          this.state = "logs-loading";
+          this.state = states.LOGS_LOADING;
           getDebugLogs()
             .then((text) => {
               this.shadowRoot.querySelector(
                 "#logs-success .logs"
               ).textContent = text;
-              this.state = "logs-success";
+              this.state = states.LOGS_SUCCESS;
             })
             .catch((error) => {
               this.dispatchEvent(
@@ -158,7 +180,7 @@
         }
 
         _getUrl() {
-          this.state = "url-loading";
+          this.state = states.URL_LOADING;
           const text = this.shadowRoot.querySelector("#logs-success .logs")
             .textContent;
           textToShareableUrl(text)
@@ -168,7 +190,7 @@
               );
               urlElement.textContent = url;
               urlElement.href = url;
-              this.state = "url-success";
+              this.state = states.URL_SUCCESS;
             })
             .catch((error) => {
               this.dispatchEvent(

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -40,6 +40,9 @@
       border: 1px solid black;
       opacity: 0.55;
     }
+    :host([hide-close-button="true"]) #close-button {
+      display: none;
+    }
 
     #close-button svg {
       display: block;
@@ -91,6 +94,12 @@
             // This event is further handled in `app.js`.
             this.show(false)
           );
+          this.shadowRoot.addEventListener("state-disabling-close", () => {
+            this.setAttribute("hide-close-button", "true");
+          });
+          this.shadowRoot.addEventListener("state-allowing-close", () => {
+            this.setAttribute("hide-close-button", "false");
+          });
           this.shadowRoot
             .getElementById("close-button")
             .addEventListener("click", () => this.show(false));


### PR DESCRIPTION
Work in progress, but you can already give me feedback on how I'm implementing it :

I'm using events from the child components inside overlay-panel to send the information that we're in a state where we are disabling/allowing the close behavior.
The overlay panel picks these events to hide/show the X close button accordingly.

(The other option was to make the child component go and directly hide the X close button, but it seemed bad because it should not be aware of what's outside its scope -- in that case the parent's X close button element)

Resolves #789.