### PR TITLE
Revert "Apply a uStreamer workaround for browser bugs in MJPEG handling"

### DIFF
--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -64,10 +64,7 @@
   </style>
   <div class="screen-wrapper">
     <input id="mobile-keyboard-input" autocapitalize="off" type="text" />
-    <img
-      id="remote-screen-img"
-      src="/stream?advance_headers=1&dual_final_frames=1"
-    />
+    <img id="remote-screen-img" src="/stream?advance_headers=1" />
   </div>
   <script
     id="underscore-library"


### PR DESCRIPTION
Reverts tiny-pilot/tinypilot#796

The better fix for this issue is to disable buffering at the nginx level. The nginx changes make these changes unnecessary: https://github.com/tiny-pilot/ansible-role-tinypilot/pull/154

An even better fix is to apply the workaround on a per-browser level, but we can do that later (see #802).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/801)
<!-- Reviewable:end -->
