### PR TITLE
Add a test for missing __init__.py files #653

### DIFF
--- a/dev-scripts/build-python
+++ b/dev-scripts/build-python
@@ -17,6 +17,8 @@ UPDATE_SCRIPT="scripts/update-service"
 # Location of virtualenv.
 VIRTUALENV_DIR=venv
 
+./dev-scripts/check-for-init-py-files
+
 # Delete pyc files from previous builds.
 find . \
   -name "*.pyc" \

--- a/dev-scripts/check-for-init-py-files
+++ b/dev-scripts/check-for-init-py-files
@@ -1,23 +1,26 @@
 #!/bin/bash
 
-# test if __init__.py file exists in directory containing .py files
+# Test if __init__.py file exists in directory containing .py files.
 
 # Exit build script on first failure.
 set -e
-# Echo commands to stdout.
-set -x
 # Exit on unset variable.
 set -u
 
 success=0
 
 while read -r directory; do
-  if [ ! -f "$directory/__init__.py" ]; then
+  if [[ ! -f "${directory}/__init__.py" ]]; then
     printf "Directory missing __init__.py file: %s\n" "${directory}" >&2
     success=255
   fi
 done < <(
-  find . -type f -name '*.py' -not -path "./venv/*" -not -path "./.git/*" -exec dirname {} \; \
+  find . \
+    -type f \
+    -name '*.py' \
+    -not -path "./venv/*" \
+    -not -path "./.git/*" \
+    -exec dirname {} \; \
     | sort --unique
 )
 


### PR DESCRIPTION
As @mtlynch pointed out that pylint ignore directory which
does not contain __init__.py files which would be bad as
we do static analysis checking it would be good to test
directory which contains *.py file to has __init__.py file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/805)
<!-- Reviewable:end -->
