### PR TITLE
Upgrade to cryptography==35.0.0 in ansible environment

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -136,11 +136,12 @@ pushd "$INSTALLER_DIR"
 
 python3 -m venv venv
 . venv/bin/activate
-# For some reason, wheel has to be installed before anything else.
-pip install wheel==0.34.2
+# Upgrade to a recent version of pip so that we can use binary wheels where
+# available instead of building the packages locally.
+pip install pip==21.3.1
 echo 'ansible==2.9.10
 cffi==1.14.4
-cryptography==3.3.2
+cryptography==35.0.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
 pkg-resources==0.0.0


### PR DESCRIPTION
TinyPilot bootstraps an Ansible environment in order to install TinyPilot in quick-install. We've been stuck on an old version of the cryptography package for a while because it required a Rust environment to install for a while, but now binary builds are available in wheel, so we don't need Rust to build it anymore, and we may as well be on the latest version.

This also lets us get rid of the workaround where we had to explicitly install the wheel package first. Now we can upgrade to a recent version of pip and it will use binary wheels where available instead of building packages locally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/810)
<!-- Reviewable:end -->
