### PR TITLE
Add debug logging for raw keystroke messages

### DIFF
--- a/app/socket_api.py
+++ b/app/socket_api.py
@@ -19,6 +19,7 @@ socketio.on_namespace(update_logs.Namespace('/updateLogs'))
 
 @socketio.on('keystroke')
 def socket_keystroke(message):
+    logger.debug('received keystroke message: %s', message)
     try:
         keystroke = keystroke_request.parse_keystroke(message)
     except keystroke_request.Error as e:


### PR DESCRIPTION
I added debug logging when investigating #818, and I feel like it's useful to have permanently. It only logs when the log level is set to DEBUG, so this won't affect typical usage, but it will be helpful if we need to diagnose issues with keystroke forwarding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/819)
<!-- Reviewable:end -->
