### PR TITLE
Backport `inline-message` from pro

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -6,6 +6,7 @@
   --brand-hue-metallic: 230;
   --brand-hue-blue: 230;
   --brand-hue-yellow: 35;
+  --brand-hue-orange: 28;
   --brand-hue-red: 5;
   --brand-hue-green: 135;
 
@@ -16,6 +17,9 @@
 
   --brand-sand-light: hsl(var(--brand-hue-yellow), 59%, 92%);
   --brand-creme-light: hsl(var(--brand-hue-yellow), 60%, 97%);
+
+  --brand-orange-light: hsl(var(--brand-hue-orange), 100%, 80%);
+  --brand-orange-dark: hsl(var(--brand-hue-orange), 50%, 50%);
 
   --brand-blue: hsl(var(--brand-hue-blue), 55%, 55%);
   --brand-blue-dark: hsl(var(--brand-hue-blue), 51%, 30%);

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -5,8 +5,7 @@
 
     #initializing,
     #prompt,
-    #changing,
-    #input-error {
+    #changing {
       display: none;
     }
 
@@ -22,10 +21,6 @@
       display: block;
     }
 
-    :host([has-input-error="true"]) #input-error {
-      display: block;
-    }
-
     #hostname-input {
       margin-left: 0.5rem;
     }
@@ -35,8 +30,8 @@
     }
 
     #input-error {
-      color: var(--brand-red);
-      font-weight: bold;
+      margin-top: 1rem;
+      text-align: left;
     }
   </style>
 
@@ -56,7 +51,11 @@
     <div class="input-container">
       <label for="hostname-input">Hostname:</label>
       <input type="text" id="hostname-input" size="30" class="monospace" />
-      <p id="input-error"><!-- Filled programmatically --></p>
+      <inline-message variant="error" id="input-error">
+        <strong>Invalid hostname:</strong> it can only contain the letters a-z,
+        digits and dashes (it cannot start with a dash, though). It must contain
+        1-63 characters and cannot be "localhost".
+      </inline-message>
     </div>
     <button id="change-and-restart" class="btn-success" type="button">
       Change and Restart
@@ -184,23 +183,8 @@
           this.setAttribute("initial-hostname", initialHostname);
         }
 
-        get inputError() {
-          return this.getAttribute("has-input-error");
-        }
-
-        set inputError(message) {
-          const inputError = this.elements.inputError;
-          if (message) {
-            this.setAttribute("has-input-error", "true");
-            inputError.innerText = message;
-            return;
-          }
-          this.removeAttribute("has-input-error");
-          inputError.innerText = "";
-        }
-
         initialize() {
-          this.inputError = null;
+          this.elements.inputError.hide();
           this.state = this.states.INITIALIZING;
           determineHostname()
             .then((hostname) => {
@@ -248,11 +232,7 @@
               if (error.code === "INVALID_HOSTNAME") {
                 // Display validation errors inline in order to make it more
                 // convenient for the user to correct them.
-                this.inputError =
-                  "Invalid hostname: it can only contain the " +
-                  "letters a-z, digits and dashes (it cannot start with a " +
-                  "dash, though). It must contain 1-63 characters and cannot " +
-                  'be "localhost".';
+                this.elements.inputError.show();
                 this.state = this.states.PROMPT;
                 return;
               }

--- a/app/templates/custom-elements/inline-message.html
+++ b/app/templates/custom-elements/inline-message.html
@@ -1,0 +1,51 @@
+<template id="inline-message-template">
+  <style>
+    :host {
+      display: none;
+      padding: 0.5rem 1.5rem;
+      border-radius: var(--border-radius);
+      border-width: 1px;
+      border-style: solid;
+    }
+
+    :host([show=""]) {
+      display: block;
+    }
+
+    :host([variant="warning"]) {
+      background-color: var(--brand-orange-light);
+      border-color: var(--brand-orange-dark);
+    }
+
+    :host([variant="error"]) {
+      background-color: var(--brand-red-light);
+      border-color: var(--brand-red-dark);
+    }
+  </style>
+  <slot></slot>
+</template>
+
+<script type="module">
+  (function () {
+    const template = document.querySelector("#inline-message-template");
+
+    customElements.define(
+      "inline-message",
+      class extends HTMLElement {
+        connectedCallback() {
+          this.attachShadow({ mode: "open" }).appendChild(
+            template.content.cloneNode(true)
+          );
+        }
+
+        show() {
+          this.setAttribute("show", "");
+        }
+
+        hide() {
+          this.removeAttribute("show");
+        }
+      }
+    );
+  })();
+</script>

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -122,6 +122,14 @@
         <br style="clear: both;" />
         <div
           class="colorcard"
+          style="background-color: var(--brand-orange-dark);"
+        ></div>
+        <div
+          class="colorcard"
+          style="background-color: var(--brand-orange-light);"
+        ></div>
+        <div
+          class="colorcard"
           style="background-color: var(--brand-sand-light);"
         ></div>
       </div>
@@ -215,6 +223,35 @@
         />
         <button>Send</button>
       </div>
+
+      <h2 class="section">Inline message</h2>
+      <p>
+        When we want to display a feedback message (error or warning), we can
+        use the inline-message component:
+      </p>
+      <inline-message variant="error" show>
+        <strong>Error:</strong> We use inline errors for “minor” issues that the
+        user can fix right away. For example, validation errors of input fields.
+      </inline-message>
+      <br />
+      <inline-message variant="warning" show>
+        <strong>Warning:</strong> We use warnings to raise attention about
+        potential problems. In contrast to errors, these don’t necessarily
+        require fixing for the user to proceed.
+      </inline-message>
+      <p>Some notes about usage:</p>
+      <ul>
+        <li>
+          The text should be left-aligned, even in an otherwise centered
+          context.
+        </li>
+        <li>
+          If sensible, the text should be prefaced with a short error headword
+          (set in bold) that concisely summarizes what the message is about. For
+          example: <strong>Invalid Input</strong>, or (for generic messages)
+          just <strong>Error</strong> or <strong>Warning</strong>.
+        </li>
+      </ul>
 
       <h2 class="section">Overlay</h2>
       <h3>Design</h3>


### PR DESCRIPTION
Applied `inline-message` changes from pro, effectively backporting `inline-message` and `change-hostname-dialog` components.

Resolves #806.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/820)
<!-- Reviewable:end -->
