### PR TITLE
Move negation of mouse scroll wheel to the server

### DIFF
--- a/app/hid/mouse.py
+++ b/app/hid/mouse.py
@@ -12,7 +12,7 @@ def send_mouse_event(mouse_path, buttons, relative_x, relative_y,
     buf[2] = (x >> 8) & 0xff
     buf[3] = y & 0xff
     buf[4] = (y >> 8) & 0xff
-    buf[5] = vertical_wheel_delta & 0xff
+    buf[5] = _translate_vertical_wheel_delta(vertical_wheel_delta) & 0xff
     buf[6] = horizontal_wheel_delta & 0xff
     hid_write.write_to_hid_interface(mouse_path, buf)
 
@@ -24,3 +24,10 @@ def _scale_mouse_coordinates(relative_x, relative_y):
     x = int(relative_x * max_hid_value)
     y = int(relative_y * max_hid_value)
     return x, y
+
+
+def _translate_vertical_wheel_delta(vertical_wheel_delta):
+    # In JavaScript, a negative wheel delta number indicates upward scrolling,
+    # but in HID, negative means downward scrolling, so we negate the value to
+    # translate from JavaScript semantics to HID semantics.
+    return vertical_wheel_delta * -1

--- a/app/static/js/mouse.js
+++ b/app/static/js/mouse.js
@@ -229,11 +229,7 @@ function parseMouseEvent(evt) {
     buttons: evt.buttons,
     relativeX: Math.min(1.0, Math.max(0.0, cursorX / width)),
     relativeY: Math.min(1.0, Math.max(0.0, cursorY / height)),
-    // Negate y-delta so that negative number means scroll down.
-    // TODO(mtlynch): We should move the negation to the server because it's
-    // part of converting JS semantics to HID semantics, which is the server's
-    // job.
-    verticalWheelDelta: normalizeWheelDelta(evt.deltaY) * -1,
+    verticalWheelDelta: normalizeWheelDelta(evt.deltaY),
     horizontalWheelDelta: normalizeWheelDelta(evt.deltaX),
   };
 }


### PR DESCRIPTION
JS and HID have opposite semantics for representing vertical scrolling. JavaScript represents downward scrolling with a positive number, whereas HID indicates it with a negative number.

We were previously flipping the sign in JS, but that's a poor place for it because the server is responsible for translating between JS events and HID messages, so this change moves the translation to the server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/823)
<!-- Reviewable:end -->
