### PR TITLE
Set explicit format for log messages

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -19,11 +19,12 @@ port = int(os.environ.get('PORT', 8000))
 debug = 'DEBUG' in os.environ
 use_reloader = os.environ.get('USE_RELOADER', '0') == '1'
 
+flask.logging.default_handler.setFormatter(
+    logging.Formatter(
+        '%(asctime)s.%(msecs)03d %(name)-15s %(levelname)-4s %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'))
+
 root_logger = logging.getLogger()
-handler = logging.StreamHandler()
-formatter = logging.Formatter(
-    '%(asctime)s %(name)-15s %(levelname)-4s %(message)s', '%Y-%m-%d %H:%M:%S')
-handler.setFormatter(formatter)
 root_logger.addHandler(flask.logging.default_handler)
 if debug:
     root_logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
This fixes a bug where TinyPilot's log formatter at some point in our history got disconnected from the root logger, so we were creating a log formatter and discarding it without applying it to the actual logger.

This applies our log format to the root logger and adds in milliseconds-level precision because the default Flask logger includes it, and it might be useful for debugging at some point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/828)
<!-- Reviewable:end -->
