### PR TITLE
Provide custom log levels for logging sensitive data

### DIFF
--- a/app/log_sensitive.py
+++ b/app/log_sensitive.py
@@ -1,0 +1,17 @@
+import logging
+
+CRITICAL = logging.CRITICAL + 1
+ERROR = logging.ERROR + 1
+WARNING = logging.WARNING + 1
+INFO = logging.INFO + 1
+DEBUG = logging.DEBUG + 1
+
+_SENSITIVE_MARKER = '[SENSITIVE]'
+
+
+def register_levels():
+    logging.addLevelName(CRITICAL, 'CRITICAL ' + _SENSITIVE_MARKER)
+    logging.addLevelName(ERROR, 'ERROR ' + _SENSITIVE_MARKER)
+    logging.addLevelName(WARNING, 'WARNING ' + _SENSITIVE_MARKER)
+    logging.addLevelName(INFO, 'INFO ' + _SENSITIVE_MARKER)
+    logging.addLevelName(DEBUG, 'DEBUG ' + _SENSITIVE_MARKER)

--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from werkzeug import exceptions
 
 import api
 import json_response
+import log_sensitive
 import secret_key
 import socket_api
 import views
@@ -26,6 +27,7 @@ flask.logging.default_handler.setFormatter(
 
 root_logger = logging.getLogger()
 root_logger.addHandler(flask.logging.default_handler)
+log_sensitive.register_levels()
 if debug:
     root_logger.setLevel(logging.DEBUG)
 else:
@@ -35,7 +37,7 @@ else:
     logging.getLogger('engineio').setLevel(logging.ERROR)
 
 logger = logging.getLogger(__name__)
-logger.info('Starting app')
+logger.log(log_sensitive.INFO, 'Starting app')
 
 app = flask.Flask(__name__, static_url_path='')
 app.config.update(

--- a/app/socket_api.py
+++ b/app/socket_api.py
@@ -4,6 +4,7 @@ import flask
 import flask_socketio
 
 import js_to_hid
+import log_sensitive
 import update_logs
 from hid import keyboard as fake_keyboard
 from hid import mouse as fake_mouse
@@ -19,7 +20,7 @@ socketio.on_namespace(update_logs.Namespace('/updateLogs'))
 
 @socketio.on('keystroke')
 def socket_keystroke(message):
-    logger.debug('received keystroke message: %s', message)
+    logger.log(log_sensitive.DEBUG, 'received keystroke message: %s', message)
     try:
         keystroke = keystroke_request.parse_keystroke(message)
     except keystroke_request.Error as e:


### PR DESCRIPTION
Here is another possible approach for the backend [of the sensitive logging](https://github.com/tiny-pilot/tinypilot/issues/807).

It’s based on custom log levels that we register, which has some ups and downs:
- Pro: it’s very simple and straightforward, and it’s not reliant on the import order.
- Con: We are forced to use the `logging.log` method, so it’s a slightly different style than the conventional “convenience” methods.
- Con: we cannot be sure that no 3rd party library will log something at one of these levels, like `11`, which would erroneously appear as `DEBUG [SENSITIVE]` in our logs then. Not super bad of course, and might not even happen at all.
- Con: the semantics of this are not exactly correct, because in my mind the sensitive log messages are not a different actual *level*, but it’s rather the *content* that the flag refers to.

I just wanted to share this as an alternative idea.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/832)
<!-- Reviewable:end -->
