### PR TITLE
Use isort --top flag to force files to import log.root_logger first

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python
-"""
-isort:skip_file
-"""
-# pylint:disable=wrong-import-position
 
 import logging
 import os
@@ -14,7 +10,6 @@ from werkzeug import exceptions
 # It’s crucial to import the logger before importing anything else, because
 # our custom logger is only available in modules imported _after_ it’s set up.
 import log.root_logger
-
 import api
 import json_response
 import secret_key

--- a/dev-scripts/build-python
+++ b/dev-scripts/build-python
@@ -40,6 +40,7 @@ yapf --diff --recursive ./
 isort \
   --recursive \
   --force-single-line-imports \
+  --top log.root_logger \
   --diff \
   --check-only \
   --skip-glob=third_party/* \

--- a/scripts/update-service
+++ b/scripts/update-service
@@ -1,7 +1,4 @@
 #!/usr/bin/env python3
-"""
-isort:skip_file
-"""
 
 # Standalone executable for running the TinyPilot updater and saving the result
 # to a file. This executable is meant to be run as a systemd one-shot service,
@@ -19,7 +16,6 @@ import subprocess
 # It’s crucial to import the logger before importing anything else, because
 # our custom logger is only available in modules imported _after_ it’s set up.
 import log.root_logger
-
 import update.launcher
 import update.result
 import update.result_store


### PR DESCRIPTION
We need to import log.root_logger before loading any other modules, but that causes isort to complain about the import order. Adding the --top flag tells isort that we intentionally want this import to be first.

This allows us to import log.root_logger first without disabling isort.

pylint will still complain, but we can rebase onto #833 once that's merged in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/834)
<!-- Reviewable:end -->
