### PR TITLE
Automatically merge from Community -> Pro

### DIFF
--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -21,8 +21,15 @@ jobs:
         with:
           token: ${{ secrets.PR_BOT_PAT }}
           branch: community-changes-${{ github.sha }}
+          delete-branch: true
+          # If the committer to the community repo (github.actor) has no access
+          # to the pro repo, the PR will be unassigned.
           assignees: ${{ github.actor }}
           title: Merge changes from community repository
           body: |
             Merge the last changes from community repository :
+
             https://github.com/tiny-pilot/tinypilot/commit/${{ github.sha }}
+
+            **Do not use "Squash and merge" !**
+            Merge this PR with a merge commit, keeping the commit history.

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -1,0 +1,28 @@
+name: Merge community changes into pro repo
+on:
+  push:
+    branches:
+      - auto-merge-pro
+jobs:
+  updateFork:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: tiny-pilot/tinypilot-pro
+          token: ${{ secrets.PR_BOT_PAT }}
+      - name: Reset the default branch with upstream changes
+        run: |
+          git remote add upstream https://github.com/tiny-pilot/tinypilot.git
+          git fetch upstream master:upstream-master
+          git reset --hard upstream-master
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.PR_BOT_PAT }}
+          branch: community-changes-${{ github.sha }}
+          assignees: ${{ github.actor }}
+          title: Merge changes from community - ${{ github.sha }}
+          body: |
+            Merge changes from community :
+            https://github.com/tiny-pilot/tinypilot/commit/${{ github.sha }}

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           token: ${{ secrets.PR_BOT_PAT }}
           branch: community-changes-${{ github.sha }}
-          assignees: ${{ github.actor }}
+          assignees: air1one
           title: Merge changes from community - ${{ github.sha }}
           body: |
             Merge changes from community :

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -2,7 +2,7 @@ name: Merge community changes into pro repo
 on:
   push:
     branches:
-      - auto-merge-pro
+      - master
 jobs:
   updateFork:
     runs-on: ubuntu-latest
@@ -21,8 +21,8 @@ jobs:
         with:
           token: ${{ secrets.PR_BOT_PAT }}
           branch: community-changes-${{ github.sha }}
-          assignees: air1one
-          title: Merge changes from community - ${{ github.sha }}
+          assignees: ${{ github.actor }}
+          title: Merge changes from community repository
           body: |
-            Merge changes from community :
+            Merge the last changes from community repository :
             https://github.com/tiny-pilot/tinypilot/commit/${{ github.sha }}


### PR DESCRIPTION
On a new commit to master branch in community repo, a merge PR is created in the pro repo, assigned to the author of the triggering commit.

When the committer has no access to the pro repo, the PR is still created but with no assignee.

Resolves #838.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/839)
<!-- Reviewable:end -->
