### PR TITLE
Adjust pylint rules to allow URLs longer than the column limit

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -209,7 +209,8 @@ max-nested-blocks=5
 max-line-length=80
 
 # Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+# Allow long URLs if they're in comments or in string literals.
+ignore-long-lines=((# )|')?https?://\S+'?$
 
 # Allow the body of an if to be on the same line as the test if there is no
 # else.


### PR DESCRIPTION
pylint flags on lines that are longer than the column limit because its default rule is to only allow URLs within comments or if they're the only value on the line.

Our style guide allows long URLs on lines for more scenarios:

See https://google.github.io/styleguide/pyguide.html#32-line-length

This change adjusts pylint to better match our style guide.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/841)
<!-- Reviewable:end -->
