### PR TITLE
Proposal: return parsed variables directly from JSON message parser

### DIFF
--- a/app/request_parsers/message.py
+++ b/app/request_parsers/message.py
@@ -1,8 +1,25 @@
 from request_parsers import errors
 
 
+# This helper function is only needed during the migration.
+def _process_message(request, required_fields):
+    message = request.get_json()
+
+    if not isinstance(message, dict):
+        raise errors.MalformedRequestError(
+            'Request is invalid, expecting a JSON dictionary')
+
+    result = []
+    for field in required_fields:
+        if field not in message:
+            raise errors.MissingFieldError('Missing required field: %s' % field)
+        result.append(message[field])
+
+    return message, result
+
+
 def parse_message(request, required_fields):
-    """Parse a message with a JSON payload.
+    """Parse a message with a JSON payload. DEPRECATED – use `parse_json_body`.
 
     Args:
       request: A flask.Request object that caller expects to carry a JSON
@@ -12,14 +29,10 @@ def parse_message(request, required_fields):
     Returns:
       The parsed message as a dictionary of its JSON payload.
     """
-    message = request.get_json()
-
-    if not isinstance(message, dict):
-        raise errors.MalformedRequestError(
-            'Request is invalid, expecting a JSON dictionary')
-
-    for field in required_fields:
-        if field not in message:
-            raise errors.MissingFieldError('Missing required field: %s' % field)
-
+    message, _ = _process_message(request, required_fields)
     return message
+
+
+def parse_json_body(request, required_fields):
+    _, required_fields = _process_message(request, required_fields)
+    return tuple(required_fields)

--- a/app/request_parsers/video_fps.py
+++ b/app/request_parsers/video_fps.py
@@ -3,14 +3,15 @@ from request_parsers import message as message_parser
 
 
 def parse(request):
-    message = message_parser.parse_message(request,
-                                           required_fields=['videoFps'])
+    # pylint: disable=unbalanced-tuple-unpacking
+    (video_fps,) = message_parser.parse_json_body(request,
+                                                  required_fields=['videoFps'])
     try:
         # Note: We need to cast the value to a string first otherwise the int
         # function forces floats into integers by simply cutting off the
         # fractional part. This results in the value being incorrectly
         # validated as an integer.
-        video_fps = int(str(message['videoFps']))
+        video_fps = int(str(video_fps))
         if not 1 <= video_fps <= 30:
             raise ValueError
     except ValueError as e:


### PR DESCRIPTION
Parsing things from the JSON request body is always the same two-fold procedure: ([see e.g. here](https://github.com/tiny-pilot/tinypilot/blob/2edfb2d7ec9e5aa70e98a34550efdb3c26190bea/app/request_parsers/hostname.py#L7))

- first, call the `parse_message` function
- then, extract the individual values from the returned dict (thereby effectively repeating the key)

Instead, we could also return a tuple directly, to make the code more concise. I’d find that a bit nicer, now [that we are about to merge parsing and validation into one function](https://github.com/tiny-pilot/tinypilot/pull/846). Downside: the pylint complaint (which should be relatively safe to mute, though, since we have tests).

This PR is just a demonstration to discuss the idea, see `video_fps.py` for an applied example, and `message.py` for how to make it happen with a rolling migration. (`_process_message` is mostly pulled out from the former `parse_message`)

I admit, though, it might be a bit too fancy (read “dynamic”).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/850)
<!-- Reviewable:end -->
