### PR TITLE
Refactor: share `make_mock_request` among tests

### DIFF
--- a/app/request_parsers/hostname_test.py
+++ b/app/request_parsers/hostname_test.py
@@ -1,14 +1,8 @@
 import unittest
-from unittest import mock
 
 from request_parsers import errors
 from request_parsers import hostname
-
-
-def make_mock_request(json_data):
-    mock_request = mock.Mock()
-    mock_request.get_json.return_value = json_data
-    return mock_request
+from request_parsers.test_utils.request import make_mock_request
 
 
 class HostnameValidationTest(unittest.TestCase):
@@ -18,45 +12,50 @@ class HostnameValidationTest(unittest.TestCase):
         self.assertEqual(
             hostname_valid,
             hostname.parse_hostname(
-                make_mock_request({'hostname': hostname_valid})))
+                make_mock_request(json_data={'hostname': hostname_valid})))
 
     def test_accepts_hostname_with_exactly_63_characters(self):
         hostname_63_chars = 'a' * 63
         self.assertEqual(
             hostname_63_chars,
             hostname.parse_hostname(
-                make_mock_request({'hostname': hostname_63_chars})))
+                make_mock_request(json_data={'hostname': hostname_63_chars})))
 
     def test_rejects_hostname_that_is_not_a_string(self):
         with self.assertRaises(errors.InvalidHostnameError):
-            hostname.parse_hostname(make_mock_request({'hostname': 1}))
+            hostname.parse_hostname(
+                make_mock_request(json_data={'hostname': 1}))
         with self.assertRaises(errors.InvalidHostnameError):
-            hostname.parse_hostname(make_mock_request({'hostname': None}))
+            hostname.parse_hostname(
+                make_mock_request(json_data={'hostname': None}))
 
     def test_rejects_hostnames_with_invalid_characters(self):
         with self.assertRaises(errors.InvalidHostnameError):
-            hostname.parse_hostname(make_mock_request({'hostname': 'TINYPILOT'
-                                                      }))
+            hostname.parse_hostname(
+                make_mock_request(json_data={'hostname': 'TINYPILOT'}))
         with self.assertRaises(errors.InvalidHostnameError):
             hostname.parse_hostname(
-                make_mock_request({'hostname': 'tinypilot***'}))
+                make_mock_request(json_data={'hostname': 'tinypilot***'}))
         with self.assertRaises(errors.InvalidHostnameError):
             hostname.parse_hostname(
-                make_mock_request({'hostname': 'tiny.pilot'}))
+                make_mock_request(json_data={'hostname': 'tiny.pilot'}))
 
     def test_rejects_localhost_as_hostname(self):
         with self.assertRaises(errors.InvalidHostnameError):
-            hostname.parse_hostname(make_mock_request({'hostname': 'localhost'
-                                                      }))
+            hostname.parse_hostname(
+                make_mock_request(json_data={'hostname': 'localhost'}))
 
     def test_rejects_empty_hostname(self):
         with self.assertRaises(errors.InvalidHostnameError):
-            hostname.parse_hostname(make_mock_request({'hostname': ''}))
+            hostname.parse_hostname(
+                make_mock_request(json_data={'hostname': ''}))
 
     def test_rejects_hostname_that_is_longer_than_63_chars(self):
         with self.assertRaises(errors.InvalidHostnameError):
-            hostname.parse_hostname(make_mock_request({'hostname': 'a' * 64}))
+            hostname.parse_hostname(
+                make_mock_request(json_data={'hostname': 'a' * 64}))
 
     def test_rejects_hostname_that_starts_with_a_dash(self):
         with self.assertRaises(errors.InvalidHostnameError):
-            hostname.parse_hostname(make_mock_request({'hostname': '-invalid'}))
+            hostname.parse_hostname(
+                make_mock_request(json_data={'hostname': '-invalid'}))

--- a/app/request_parsers/test_utils/request.py
+++ b/app/request_parsers/test_utils/request.py
@@ -1,0 +1,9 @@
+from unittest import mock
+
+
+def make_mock_request(json_data=None, query_params=None, headers=None):
+    mock_request = mock.Mock()
+    mock_request.get_json.return_value = json_data
+    mock_request.args = query_params
+    mock_request.headers = headers or {}
+    return mock_request

--- a/app/request_parsers/video_fps_test.py
+++ b/app/request_parsers/video_fps_test.py
@@ -1,30 +1,25 @@
 import unittest
-from unittest import mock
 
 from request_parsers import errors
 from request_parsers import video_fps
-
-
-def make_mock_request(json_data):
-    mock_request = mock.Mock()
-    mock_request.get_json.return_value = json_data
-    return mock_request
+from request_parsers.test_utils.request import make_mock_request
 
 
 class VideoFpsParserTest(unittest.TestCase):
 
     def test_reject_integers_out_of_bounds(self):
         with self.assertRaises(errors.InvalidVideoFpsError):
-            video_fps.parse(make_mock_request({'videoFps': 0}))
+            video_fps.parse(make_mock_request(json_data={'videoFps': 0}))
         with self.assertRaises(errors.InvalidVideoFpsError):
-            video_fps.parse(make_mock_request({'videoFps': 31}))
+            video_fps.parse(make_mock_request(json_data={'videoFps': 31}))
 
     def test_accept_integers_within_bounds(self):
-        self.assertEqual(1, video_fps.parse(make_mock_request({'videoFps': 1})))
-        self.assertEqual(15,
-                         video_fps.parse(make_mock_request({'videoFps': 15})))
-        self.assertEqual(30,
-                         video_fps.parse(make_mock_request({'videoFps': 30})))
+        self.assertEqual(
+            1, video_fps.parse(make_mock_request(json_data={'videoFps': 1})))
+        self.assertEqual(
+            15, video_fps.parse(make_mock_request(json_data={'videoFps': 15})))
+        self.assertEqual(
+            30, video_fps.parse(make_mock_request(json_data={'videoFps': 30})))
 
     def test_reject_non_integers(self):
         for value in [
@@ -32,8 +27,9 @@ class VideoFpsParserTest(unittest.TestCase):
         ]:
             with self.subTest(value):
                 with self.assertRaises(errors.InvalidVideoFpsError):
-                    video_fps.parse(make_mock_request({'videoFps': value}))
+                    video_fps.parse(
+                        make_mock_request(json_data={'videoFps': value}))
 
     def test_reject_incorrect_key(self):
         with self.assertRaises(errors.MissingFieldError):
-            video_fps.parse(make_mock_request({'fps': 1}))
+            video_fps.parse(make_mock_request(json_data={'fps': 1}))

--- a/app/request_parsers/video_jpeg_quality_test.py
+++ b/app/request_parsers/video_jpeg_quality_test.py
@@ -1,38 +1,33 @@
 import unittest
-from unittest import mock
 
 from request_parsers import errors
 from request_parsers import video_jpeg_quality
-
-
-def make_mock_request(json_data):
-    mock_request = mock.Mock()
-    mock_request.get_json.return_value = json_data
-    return mock_request
+from request_parsers.test_utils.request import make_mock_request
 
 
 class VideoJpegQualityParserTest(unittest.TestCase):
 
     def test_reject_integers_out_of_bounds(self):
         with self.assertRaises(errors.InvalidVideoJpegQualityError):
-            video_jpeg_quality.parse(make_mock_request({'videoJpegQuality': 0}))
+            video_jpeg_quality.parse(
+                make_mock_request(json_data={'videoJpegQuality': 0}))
         with self.assertRaises(errors.InvalidVideoJpegQualityError):
             video_jpeg_quality.parse(
-                make_mock_request({'videoJpegQuality': 101}))
+                make_mock_request(json_data={'videoJpegQuality': 101}))
 
     def test_accept_integers_within_bounds(self):
         self.assertEqual(
             1,
-            video_jpeg_quality.parse(make_mock_request({'videoJpegQuality': 1
-                                                       })))
+            video_jpeg_quality.parse(
+                make_mock_request(json_data={'videoJpegQuality': 1})))
         self.assertEqual(
             50,
-            video_jpeg_quality.parse(make_mock_request({'videoJpegQuality': 50
-                                                       })))
+            video_jpeg_quality.parse(
+                make_mock_request(json_data={'videoJpegQuality': 50})))
         self.assertEqual(
             100,
             video_jpeg_quality.parse(
-                make_mock_request({'videoJpegQuality': 100})))
+                make_mock_request(json_data={'videoJpegQuality': 100})))
 
     def test_reject_non_integers(self):
         for value in [
@@ -41,8 +36,10 @@ class VideoJpegQualityParserTest(unittest.TestCase):
             with self.subTest(value):
                 with self.assertRaises(errors.InvalidVideoJpegQualityError):
                     video_jpeg_quality.parse(
-                        make_mock_request({'videoJpegQuality': value}))
+                        make_mock_request(
+                            json_data={'videoJpegQuality': value}))
 
     def test_reject_incorrect_key(self):
         with self.assertRaises(errors.MissingFieldError):
-            video_jpeg_quality.parse(make_mock_request({'jpegQuality': 1}))
+            video_jpeg_quality.parse(
+                make_mock_request(json_data={'jpegQuality': 1}))


### PR DESCRIPTION
Refactor `make_mock_request` to be shared among tests.

I put the common `make_mock_request` definition into `test_utils/request.py`, tell me if you think it would be better with a different structure / naming.

Part of #769.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/852)
<!-- Reviewable:end -->
