### PR TITLE
Default inline-message to text-align left

### DIFF
--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -31,7 +31,6 @@
 
     #input-error {
       margin-top: 1rem;
-      text-align: left;
     }
   </style>
 

--- a/app/templates/custom-elements/inline-message.html
+++ b/app/templates/custom-elements/inline-message.html
@@ -6,6 +6,7 @@
       border-radius: var(--border-radius);
       border-width: 1px;
       border-style: solid;
+      text-align: left;
     }
 
     :host([show=""]) {


### PR DESCRIPTION
The style guide says of inline-message:

>The text should be left-aligned, even in an otherwise centered context.

So we should do this in the template rather than relying on the client to set the style in every instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/854)
<!-- Reviewable:end -->
