### PR TITLE
Provide custom (sensitive) logger in all tests

### DIFF
--- a/dev-scripts/build-python
+++ b/dev-scripts/build-python
@@ -30,7 +30,8 @@ find . \
 coverage run \
   --source "$SOURCE_DIR" \
   --omit "*_test.py" \
-  -m unittest discover --pattern "*_test.py"
+  --module app.log \
+  --module unittest discover --pattern "*_test.py"
 coverage report
 
 # Check that source has correct formatting.


### PR DESCRIPTION
We don’t provide [the custom (sensitive) logger](https://github.com/tiny-pilot/tinypilot/pull/830) for our tests, hence a call to `logger.info_sensitive` during the tests makes the test crash. This problem didn’t surface so far, because none of the modules that use sensitive logging have tests yet.

The easiest way I can think of would be to globally load the module in the test runner, which I think is also the closest imitation of the behaviour when the app is run via `main.py`. (I.e. it’s safe to rely that the logger is just there.)

A downside is that you need to remember doing this when running tests selectively while developing. For example, I run individual test files in the PyCharm IDE directly; for that I can put an `import log` at the top of the file temporarily, which works well enough for me.

I sneaked in `-m` → `--module`, to make it more expressive and in line with the other flags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/859)
<!-- Reviewable:end -->
