### PR TITLE
Fix test run configuration

### DIFF
--- a/dev-scripts/build-python
+++ b/dev-scripts/build-python
@@ -27,11 +27,13 @@ find . \
   -delete
 
 # Run unit tests and calculate code coverage.
+# Load module `app.log` to initialize our custom logger.
 coverage run \
   --source "$SOURCE_DIR" \
   --omit "*_test.py" \
-  --module app.log \
-  --module unittest discover --pattern "*_test.py"
+  --module \
+    unittest discover --pattern "*_test.py" \
+    app.log
 coverage report
 
 # Check that source has correct formatting.


### PR DESCRIPTION
Fixes https://github.com/tiny-pilot/tinypilot/issues/861, which was caused by https://github.com/tiny-pilot/tinypilot/pull/859.

`--module`/`-m` can’t be specified multiple times, but instead you just give it a list of modules to load.

[The tests are all executed again](https://app.circleci.com/pipelines/github/tiny-pilot/tinypilot/1839/workflows/1d3b7e9b-0f72-4201-b3b8-b1010068e7a4/jobs/6575), I have also verified this locally by changing a random assertion to see it fail.

The test coverage is slightly increased now, from 55% to 56%, because the imported `log.py` file is now always counted, even if it’s not executed by any of the underlying test code.

Thanks again @rw4nn for spotting this!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/862)
<!-- Reviewable:end -->
