### PR TITLE
Use title case in headlines

### DIFF
--- a/app/templates/custom-elements/feature-pro-dialog.html
+++ b/app/templates/custom-elements/feature-pro-dialog.html
@@ -5,7 +5,7 @@
   </style>
 
   <div id="feature-pro">
-    <h3>This feature is available in TinyPilot Pro.</h3>
+    <h3>This Feature is Available in TinyPilot Pro.</h3>
     <button id="upgrade-to-pro" class="btn-success" type="button">
       Upgrade to Pro
     </button>

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -60,7 +60,7 @@
   </style>
 
   <div id="checking">
-    <h3>Checking for updates</h3>
+    <h3>Checking for Updates</h3>
     <progress-spinner></progress-spinner>
   </div>
 

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -44,7 +44,7 @@
         <img src="/img/logo.svg" alt="Tiny Pilot" />
       </div>
 
-      <h1 style="text-align: center;">Style guide</h1>
+      <h1 style="text-align: center;">Style Guide</h1>
       <p>
         This style guide is an ongoing collection of all things visual that make
         up the brand, such as colours, fonts, patterns or UI components.
@@ -167,7 +167,7 @@
       <button class="btn-danger">Danger</button>
       <button class="btn-danger" disabled>(disabled)</button>
       <p>For destructive call-to-actions like “delete” or “shutdown”.</p>
-      <h3>Dropdown button</h3>
+      <h3>Dropdown Button</h3>
       <p>
         A button that groups multiple related actions.
       </p>
@@ -188,7 +188,7 @@
         <li slot="item">Action 2</li>
         <li slot="item">Action 3</li>
       </dropdown-button>
-      <h3>Toggle button</h3>
+      <h3>Toggle Button</h3>
       <p>
         A button representing a binary state that can be toggled on and off. In
         contrast to a checkbox, the toggle button is used outside of forms and
@@ -224,7 +224,7 @@
         <button>Send</button>
       </div>
 
-      <h2 class="section">Inline message</h2>
+      <h2 class="section">Inline Message</h2>
       <p>
         When we want to display a feedback message (error or warning), we can
         use the inline-message component:
@@ -367,7 +367,7 @@
             document.getElementById("error-overlay").show();
           });
       </script>
-      <h3>Loading states</h3>
+      <h3>Loading States</h3>
       <p>
         When the overlay is in a loading state, we generally do not want the
         user to close it. Therefore, we don’t show any close button, and we also
@@ -381,7 +381,7 @@
         for details).
       </p>
 
-      <h2 class="section">Progress indicator</h2>
+      <h2 class="section">Progress Indicator</h2>
       <p>
         The spinner is used to indicate that an operation is in progress. The
         styling can be adjusted through CSS variables.

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -253,6 +253,12 @@
         </li>
       </ul>
 
+      <h2 class="section">Headlines</h2>
+      <p>
+        Use <a href="https://en.wikipedia.org/wiki/Title_case">“Title Case”</a>
+        in all headlines.
+      </p>
+
       <h2 class="section">Overlay</h2>
       <h3>Design</h3>
       <p>

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -255,7 +255,10 @@
 
       <h2 class="section">Headlines</h2>
       <p>
-        Use <a href="https://en.wikipedia.org/wiki/Title_case">“Title Case”</a>
+        Use
+        <a href="https://en.wikipedia.org/wiki/Title_case" target="_blank">
+          “Title Case”
+        </a>
         in all headlines.
       </p>
 


### PR DESCRIPTION
While testing https://github.com/tiny-pilot/tinypilot-pro/pull/343, I noticed that we forgot to use title case here. I’ve also document that rule in the style guide, for future reference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/866)
<!-- Reviewable:end -->
