### PR TITLE
Scale remote screen size to fit browser height

### DIFF
--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -2,12 +2,6 @@
   <style>
     @import "css/cursors.css";
 
-    @media only screen and (max-width: 992px) {
-      .screen-wrapper {
-        min-width: 992px;
-      }
-    }
-
     #remote-screen-img {
       max-width: 100%;
       max-height: 1080px;
@@ -44,18 +38,6 @@
       }
     }
 
-    @media screen and (min-height: 0px) {
-      #remote-screen-img {
-        max-height: 40vh;
-      }
-    }
-
-    @media screen and (min-height: 250px) {
-      #remote-screen-img {
-        max-height: 60vh;
-      }
-    }
-
     @media screen and (min-height: 350px) {
       #remote-screen-img {
         max-height: 70vh;
@@ -82,7 +64,7 @@
 
     @media screen and (min-height: 1180px) {
       #remote-screen-img {
-        max-height: 1080px;
+        max-height: 100vh;
       }
     }
 

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -4,7 +4,7 @@
 
     #remote-screen-img {
       max-width: 100%;
-      max-height: 1080px;
+      max-height: 70vh;
       object-fit: contain;
     }
 
@@ -35,12 +35,6 @@
     @media screen and (min-width: 1400px) {
       #remote-screen-img {
         max-width: 90%;
-      }
-    }
-
-    @media screen and (min-height: 350px) {
-      #remote-screen-img {
-        max-height: 70vh;
       }
     }
 

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -44,6 +44,48 @@
       }
     }
 
+    @media screen and (min-height: 0px) {
+      #remote-screen-img {
+        max-height: 40vh;
+      }
+    }
+
+    @media screen and (min-height: 250px) {
+      #remote-screen-img {
+        max-height: 60vh;
+      }
+    }
+
+    @media screen and (min-height: 350px) {
+      #remote-screen-img {
+        max-height: 70vh;
+      }
+    }
+
+    @media screen and (min-height: 450px) {
+      #remote-screen-img {
+        max-height: 80vh;
+      }
+    }
+
+    @media screen and (min-height: 600px) {
+      #remote-screen-img {
+        max-height: 85vh;
+      }
+    }
+
+    @media screen and (min-height: 900px) {
+      #remote-screen-img {
+        max-height: 90vh;
+      }
+    }
+
+    @media screen and (min-height: 1180px) {
+      #remote-screen-img {
+        max-height: 1080px;
+      }
+    }
+
     :host([fullscreen="true"]) .screen-wrapper {
       display: grid;
       overflow: auto;
@@ -147,10 +189,6 @@
 
           window.addEventListener("resize", this.onWindowResize);
 
-          this.shadowRoot.getElementById("remote-screen-img").onload = () => {
-            this.verticalSpace();
-          };
-
           // Detect whether this is a touchscreen device.
           let isTouchScreen = false;
           this.shadowRoot.addEventListener("touchend", () => {
@@ -247,8 +285,6 @@
         onWindowResize() {
           if (this.fullscreen) {
             this.fillSpace();
-          } else {
-            this.verticalSpace();
           }
         }
 
@@ -259,21 +295,12 @@
           const screenImg = this.shadowRoot.getElementById("remote-screen-img");
           screenImg.classList.remove("full-width");
           screenImg.classList.remove("full-height");
-          screenImg.removeAttribute("height");
           const windowRatio = window.innerWidth / window.innerHeight;
           const screenRatio = screenImg.width / screenImg.height;
           if (screenRatio > windowRatio) {
             screenImg.classList.add("full-width");
           } else {
             screenImg.classList.add("full-height");
-          }
-        }
-
-        verticalSpace() {
-          const screenImg = this.shadowRoot.getElementById("remote-screen-img");
-          screenImg.removeAttribute("height");
-          if (screenImg.height >= window.innerHeight - 100) {
-            screenImg.height = window.innerHeight - 100;
           }
         }
       }

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -2,6 +2,12 @@
   <style>
     @import "css/cursors.css";
 
+    @media only screen and (max-width: 992px) {
+      .screen-wrapper {
+        min-width: 992px;
+      }
+    }
+
     #remote-screen-img {
       max-width: 100%;
       max-height: 1080px;
@@ -141,6 +147,10 @@
 
           window.addEventListener("resize", this.onWindowResize);
 
+          this.shadowRoot.getElementById("remote-screen-img").onload = () => {
+            this.verticalSpace();
+          };
+
           // Detect whether this is a touchscreen device.
           let isTouchScreen = false;
           this.shadowRoot.addEventListener("touchend", () => {
@@ -237,6 +247,8 @@
         onWindowResize() {
           if (this.fullscreen) {
             this.fillSpace();
+          } else {
+            this.verticalSpace();
           }
         }
 
@@ -247,12 +259,21 @@
           const screenImg = this.shadowRoot.getElementById("remote-screen-img");
           screenImg.classList.remove("full-width");
           screenImg.classList.remove("full-height");
+          screenImg.removeAttribute("height");
           const windowRatio = window.innerWidth / window.innerHeight;
           const screenRatio = screenImg.width / screenImg.height;
           if (screenRatio > windowRatio) {
             screenImg.classList.add("full-width");
           } else {
             screenImg.classList.add("full-height");
+          }
+        }
+
+        verticalSpace() {
+          const screenImg = this.shadowRoot.getElementById("remote-screen-img");
+          screenImg.removeAttribute("height");
+          if (screenImg.height >= window.innerHeight - 100) {
+            screenImg.height = window.innerHeight - 100;
           }
         }
       }


### PR DESCRIPTION
Marked as Draft to come up with a good solution that works for everyone.

I had to implement JS to make this work , not sure if it can be done with CSS alone.

I believe I had originally suggested having multiple view options depending on user preference but we ended up only using default screen and full screen.

The min-width 992px is something I added to correct small screen when keyboard is visible.  I can remove this if not needed but it's there so I don't forget.

Resolves #797

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/878)
<!-- Reviewable:end -->
