### PR TITLE
Give clearer names to the Python websocket connection handlers

### DIFF
--- a/app/socket_api.py
+++ b/app/socket_api.py
@@ -76,10 +76,10 @@ def socket_key_release():
 
 
 @socketio.on('connect')
-def test_connect():
+def on_connect():
     logger.info('Client connected')
 
 
 @socketio.on('disconnect')
-def test_disconnect():
+def on_disconnect():
     logger.info('Client disconnected')

--- a/app/socket_api.py
+++ b/app/socket_api.py
@@ -18,7 +18,7 @@ socketio.on_namespace(update_logs.Namespace('/updateLogs'))
 
 
 @socketio.on('keystroke')
-def socket_keystroke(message):
+def on_keystroke(message):
     logger.debug_sensitive('received keystroke message: %s', message)
     try:
         keystroke = keystroke_request.parse_keystroke(message)
@@ -47,7 +47,7 @@ def socket_keystroke(message):
 
 
 @socketio.on('mouse-event')
-def socket_mouse_event(message):
+def on_mouse_event(message):
     try:
         mouse_move_event = mouse_event_request.parse_mouse_event(message)
     except mouse_event_request.Error as e:
@@ -67,7 +67,7 @@ def socket_mouse_event(message):
 
 
 @socketio.on('keyRelease')
-def socket_key_release():
+def on_key_release():
     keyboard_path = flask.current_app.config.get('KEYBOARD_PATH')
     try:
         fake_keyboard.release_keys(keyboard_path)


### PR DESCRIPTION
These names date back to the original addition of websockets to the app (b45c7ccf3437aafc10b19d6e5874911e5ccc00f1). I used the names test_connect and test_disconnect based on the Flask-SocketIO documentation, thinking that the test_ prefix was a convention. I now realize it was just for demonstration purposes, and the test_ prefix is meaningless.

https://flask-socketio.readthedocs.io/en/latest/getting_started.html#connection-events

This changes the names to on_connect and on_disconnect so the functions are not confused for test functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/879)
<!-- Reviewable:end -->
