### PR TITLE
Prevent closing dialog after shutdown complete

### DIFF
--- a/app/templates/custom-elements/shutdown-dialog.html
+++ b/app/templates/custom-elements/shutdown-dialog.html
@@ -80,6 +80,7 @@
         statesWithoutDialogClose = new Set([
           this.states.RESTARTING,
           this.states.SHUTTING_DOWN,
+          this.states.SHUTDOWN_COMPLETE,
         ]);
 
         constructor() {


### PR DESCRIPTION
Fixes https://github.com/tiny-pilot/tinypilot/issues/882.

I’ve also quickly revisited all the other dialogs again, just to be safe, but they seem all fine.

https://user-images.githubusercontent.com/83721279/149218572-3030e9e2-7ea1-4ef8-ae37-dd6e4be58583.mov

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/887)
<!-- Reviewable:end -->
