### PR TITLE
Return parsed variables directly from JSON message parser

### DIFF
--- a/app/request_parsers/hostname.py
+++ b/app/request_parsers/hostname.py
@@ -21,9 +21,9 @@ def parse_hostname(request):
     Raises:
         InvalidHostnameError: If the hostname is invalid.
     """
-    message = message_parser.parse_message(request,
-                                           required_fields=['hostname'])
-    hostname = message['hostname']
+    # pylint: disable=unbalanced-tuple-unpacking
+    (hostname,) = message_parser.parse_json_body(request,
+                                                 required_fields=['hostname'])
 
     if not isinstance(hostname, str):
         raise errors.InvalidHostnameError('The hostname is not a string.')

--- a/app/request_parsers/hostname.py
+++ b/app/request_parsers/hostname.py
@@ -1,7 +1,7 @@
 import re
 
 from request_parsers import errors
-from request_parsers import message as message_parser
+from request_parsers import json
 
 _HOSTNAME_PATTERN = re.compile(r'^[-0-9a-z]{1,63}$')
 
@@ -22,8 +22,7 @@ def parse_hostname(request):
         InvalidHostnameError: If the hostname is invalid.
     """
     # pylint: disable=unbalanced-tuple-unpacking
-    (hostname,) = message_parser.parse_json_body(request,
-                                                 required_fields=['hostname'])
+    (hostname,) = json.parse_json_body(request, required_fields=['hostname'])
 
     if not isinstance(hostname, str):
         raise errors.InvalidHostnameError('The hostname is not a string.')

--- a/app/request_parsers/json.py
+++ b/app/request_parsers/json.py
@@ -2,27 +2,27 @@ from request_parsers import errors
 
 
 def parse_json_body(request, required_fields):
-    """Parse a message with a JSON payload.
+    """Parse a request with a JSON payload.
 
     Args:
       request: A flask.Request object that caller expects to carry a JSON
         dictionary payload.
-      required_fields: A list of required fields in the message dictionary.
+      required_fields: A list of required fields in the JSON payload.
 
     Returns:
       The parsed field values as tuple. The arity and order of the tuple
       matches that of the `required_fields` argument.
     """
-    message = request.get_json()
+    json = request.get_json()
 
-    if not isinstance(message, dict):
+    if not isinstance(json, dict):
         raise errors.MalformedRequestError(
             'Request is invalid, expecting a JSON dictionary')
 
     result = []
     for field in required_fields:
-        if field not in message:
+        if field not in json:
             raise errors.MissingFieldError('Missing required field: %s' % field)
-        result.append(message[field])
+        result.append(json[field])
 
     return tuple(result)

--- a/app/request_parsers/json.py
+++ b/app/request_parsers/json.py
@@ -10,7 +10,8 @@ def parse_json_body(request, required_fields):
       required_fields: A list of required fields in the message dictionary.
 
     Returns:
-      The required fields as a tuple.
+      The parsed field values as tuple. The arity and order of the tuple
+      matches that of the `required_fields` argument.
     """
     message = request.get_json()
 

--- a/app/request_parsers/json_test.py
+++ b/app/request_parsers/json_test.py
@@ -14,38 +14,55 @@ def make_mock_request(json_data):
 class JsonParserTest(unittest.TestCase):
 
     def test_parses_required_fields_from_body(self):
+        mock_request = make_mock_request({
+            'a': 'value-for-a',
+            'b': 'value-for-b'
+        })
         self.assertEqual(('value-for-a', 'value-for-b'),
-                         json.parse_json_body(
-                             make_mock_request({
-                                 'a': 'value-for-a',
-                                 'b': 'value-for-b'
-                             }), ['a', 'b']))
+                         json.parse_json_body(mock_request, ['a', 'b']))
 
     def test_parses_one_required_field_from_body(self):
-        self.assertEqual(
-            ('field-value',),
-            json.parse_json_body(make_mock_request({
-                'field': 'field-value',
-            }), ['field']))
+        mock_request = make_mock_request({
+            'field': 'field-value',
+        })
+        self.assertEqual(('field-value',),
+                         json.parse_json_body(mock_request, ['field']))
+
+    def test_parses_with_no_required_field(self):
+        mock_request = make_mock_request({
+            'field': 'field-value',
+        })
+        self.assertEqual((), json.parse_json_body(mock_request, []))
+
+    def test_parses_with_less_required_fields_than_actual_fields_in_body(self):
+        mock_request = make_mock_request({
+            'a': 'value-for-a',
+            'b': 'value-for-b',
+            'c': 'value-for-c',
+        })
+        self.assertEqual(('value-for-a', 'value-for-c'),
+                         json.parse_json_body(mock_request, ['a', 'c']))
 
     def test_parses_different_types(self):
+        mock_request = make_mock_request({
+            'a': 'value-for-a',
+            'b': 52,
+            'c': 27.2,
+            'd': True
+        })
         self.assertEqual(('value-for-a', 52, 27.2, True),
-                         json.parse_json_body(
-                             make_mock_request({
-                                 'a': 'value-for-a',
-                                 'b': 52,
-                                 'c': 27.2,
-                                 'd': True
-                             }), ['a', 'b', 'c', 'd']))
+                         json.parse_json_body(mock_request,
+                                              ['a', 'b', 'c', 'd']))
 
     def raises_error_if_malformed_request(self):
+        mock_request = make_mock_request(None)
         with self.assertRaises(errors.MalformedRequestError):
-            json.parse_json_body(make_mock_request(None), ['field'])
+            json.parse_json_body(mock_request, ['field'])
 
     def raises_error_if_missing_required_field(self):
+        mock_request = make_mock_request({
+            'a': 'value-for-a',
+            'b': 'value-for-b'
+        })
         with self.assertRaises(errors.MissingFieldError):
-            json.parse_json_body(
-                make_mock_request({
-                    'a': 'value-for-a',
-                    'b': 'value-for-b'
-                }), ['a', 'b', 'c'])
+            json.parse_json_body(mock_request, ['a', 'b', 'c'])

--- a/app/request_parsers/json_test.py
+++ b/app/request_parsers/json_test.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest import mock
+
+from request_parsers import errors
+from request_parsers import json
+
+
+def make_mock_request(json_data):
+    mock_request = mock.Mock()
+    mock_request.get_json.return_value = json_data
+    return mock_request
+
+
+class JsonParserTest(unittest.TestCase):
+
+    def test_parses_required_fields_from_body(self):
+        self.assertEqual(('value-for-a', 'value-for-b'),
+                         json.parse_json_body(
+                             make_mock_request({
+                                 'a': 'value-for-a',
+                                 'b': 'value-for-b'
+                             }), ['a', 'b']))
+
+    def test_parses_one_required_field_from_body(self):
+        self.assertEqual(
+            ('field-value',),
+            json.parse_json_body(make_mock_request({
+                'field': 'field-value',
+            }), ['field']))
+
+    def test_parses_different_types(self):
+        self.assertEqual(('value-for-a', 52, 27.2, True),
+                         json.parse_json_body(
+                             make_mock_request({
+                                 'a': 'value-for-a',
+                                 'b': 52,
+                                 'c': 27.2,
+                                 'd': True
+                             }), ['a', 'b', 'c', 'd']))
+
+    def raises_error_if_malformed_request(self):
+        with self.assertRaises(errors.MalformedRequestError):
+            json.parse_json_body(make_mock_request(None), ['field'])
+
+    def raises_error_if_missing_required_field(self):
+        with self.assertRaises(errors.MissingFieldError):
+            json.parse_json_body(
+                make_mock_request({
+                    'a': 'value-for-a',
+                    'b': 'value-for-b'
+                }), ['a', 'b', 'c'])

--- a/app/request_parsers/message.py
+++ b/app/request_parsers/message.py
@@ -1,7 +1,7 @@
 from request_parsers import errors
 
 
-def parse_message(request, required_fields):
+def parse_json_body(request, required_fields):
     """Parse a message with a JSON payload.
 
     Args:
@@ -10,7 +10,7 @@ def parse_message(request, required_fields):
       required_fields: A list of required fields in the message dictionary.
 
     Returns:
-      The parsed message as a dictionary of its JSON payload.
+      The required fields as a tuple.
     """
     message = request.get_json()
 
@@ -18,8 +18,10 @@ def parse_message(request, required_fields):
         raise errors.MalformedRequestError(
             'Request is invalid, expecting a JSON dictionary')
 
+    result = []
     for field in required_fields:
         if field not in message:
             raise errors.MissingFieldError('Missing required field: %s' % field)
+        result.append(message[field])
 
-    return message
+    return tuple(result)

--- a/app/request_parsers/video_settings.py
+++ b/app/request_parsers/video_settings.py
@@ -1,11 +1,10 @@
 from request_parsers import errors
-from request_parsers import message as message_parser
+from request_parsers import json
 
 
 def parse_fps(request):
     # pylint: disable=unbalanced-tuple-unpacking
-    (video_fps,) = message_parser.parse_json_body(request,
-                                                  required_fields=['videoFps'])
+    (video_fps,) = json.parse_json_body(request, required_fields=['videoFps'])
     try:
         # Note: We need to cast the value to a string first otherwise the int
         # function forces floats into integers by simply cutting off the
@@ -22,7 +21,7 @@ def parse_fps(request):
 
 def parse_jpeg_quality(request):
     # pylint: disable=unbalanced-tuple-unpacking
-    (video_jpeg_quality,) = message_parser.parse_json_body(
+    (video_jpeg_quality,) = json.parse_json_body(
         request, required_fields=['videoJpegQuality'])
     try:
         # Note: We need to cast the value to a string first otherwise the int

--- a/app/request_parsers/video_settings.py
+++ b/app/request_parsers/video_settings.py
@@ -3,14 +3,15 @@ from request_parsers import message as message_parser
 
 
 def parse_fps(request):
-    message = message_parser.parse_message(request,
-                                           required_fields=['videoFps'])
+    # pylint: disable=unbalanced-tuple-unpacking
+    (video_fps,) = message_parser.parse_json_body(request,
+                                                  required_fields=['videoFps'])
     try:
         # Note: We need to cast the value to a string first otherwise the int
         # function forces floats into integers by simply cutting off the
         # fractional part. This results in the value being incorrectly
         # validated as an integer.
-        video_fps = int(str(message['videoFps']))
+        video_fps = int(str(video_fps))
         if not 1 <= video_fps <= 30:
             raise ValueError
     except ValueError as e:
@@ -20,14 +21,15 @@ def parse_fps(request):
 
 
 def parse_jpeg_quality(request):
-    message = message_parser.parse_message(request,
-                                           required_fields=['videoJpegQuality'])
+    # pylint: disable=unbalanced-tuple-unpacking
+    (video_jpeg_quality,) = message_parser.parse_json_body(
+        request, required_fields=['videoJpegQuality'])
     try:
         # Note: We need to cast the value to a string first otherwise the int
         # function forces floats into integers by simply cutting off the
         # fractional part. This results in the value being incorrectly
         # validated as an integer.
-        video_jpeg_quality = int(str(message['videoJpegQuality']))
+        video_jpeg_quality = int(str(video_jpeg_quality))
         if not 1 <= video_jpeg_quality <= 100:
             raise ValueError
     except ValueError as e:


### PR DESCRIPTION
Part of #876. (implementation in community repo)

Return parsed variables directly from JSON message parser, as a tuple.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/890)
<!-- Reviewable:end -->
