### PR TITLE
Introduce “Pro” badge for menu items

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -37,6 +37,11 @@
   --brand-green-light: hsl(var(--brand-hue-green), 34%, 70%);
   --brand-green-bright: hsl(var(--brand-hue-green), 70%, 45%);
 
+  /* This is the green color that is used in the logo. It should only be
+     scarcely used outside the logo, for example for brand- or marketing-related
+     things. */
+  --brand-logo-accent-color: #3df91e;
+
   --border-radius: 0.25rem;
 
   --z-index-bar: 1;

--- a/app/templates/custom-elements/menu-bar.html
+++ b/app/templates/custom-elements/menu-bar.html
@@ -152,6 +152,21 @@
     .spacer {
       flex: 1;
     }
+
+    .pro-badge:after {
+      position: absolute;
+      display: block;
+      z-index: var(--z-index-bar);
+      content: "PRO";
+      font-size: 0.8em; /* Equivalent of the x-height of the parent font size */
+      top: 0.75em;
+      right: 0.9em;
+      padding: 0 0.4em;
+      color: var(--brand-logo-accent-color);
+      border: 1px solid var(--brand-logo-accent-color);
+      border-radius: 0.8em;
+      pointer-events: none; /* “Click-through” to underlying menu item */
+    }
   </style>
 
   <div class="logo"><img src="/img/logo.svg" alt="TinyPilot logo" /></div>
@@ -159,7 +174,7 @@
     <li class="group">
       <a>System</a>
       <ul class="items">
-        <li class="item">
+        <li class="item pro-badge">
           <a id="mass-storage-btn">Virtual Media</a>
         </li>
         <li class="item">


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot/issues/785#issuecomment-1025139976.

One note about the new color: the “plutonium green” that we use in the logo is different from the green that we have in the [app design’s color palette](https://github.com/tiny-pilot/tinypilot/blob/183eaf2e1a48af96fe48a26245b640b7c54e8fd3/app/static/css/style.css#L35). I think we should only use the logo’s green scarcely, to keep it distinct and unique (“shiny”). For something like this badge it seems to be a good fit, though, because the badge is somewhat marketing- or brand-related.

Since the logo green is a specific color that’s defined externally, I think it’s okay to hard-code the RGB value instead of using our usual way of defining the colors.

<img width="564" alt="Screenshot 2022-01-30 at 14 04 50" src="https://user-images.githubusercontent.com/83721279/151701248-e6a50c03-6cb0-4472-bf33-615c887a5d98.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/899)
<!-- Reviewable:end -->
