### PR TITLE
Rename "Ctrl" to "Control" in JS key codes

### DIFF
--- a/app/static/js/keyboardstate.js
+++ b/app/static/js/keyboardstate.js
@@ -3,7 +3,7 @@ import { isModifierCode, keystrokeToCanonicalCode } from "./keycodes.js";
 const modifierPropToKeyCodesMapping = {
   altKey: ["AltLeft", "AltRight"],
   metaKey: ["MetaLeft", "MetaRight"],
-  ctrlKey: ["CtrlLeft", "CtrlRight"],
+  ctrlKey: ["ControlLeft", "ControlRight"],
   shiftKey: ["ShiftLeft", "ShiftRight"],
 };
 

--- a/app/static/js/keyboardstate.test.js
+++ b/app/static/js/keyboardstate.test.js
@@ -1,0 +1,44 @@
+import { describe, it } from "mocha";
+import assert from "assert";
+import { KeyboardState } from "./keyboardstate.js";
+
+describe("KeyboardState", () => {
+  it("should override cached state with event state", () => {
+    const keyboardState = new KeyboardState();
+    const events = [
+      {
+        code: "ControlLeft",
+        key: "Control",
+        altKey: false,
+        ctrlKey: true,
+        metaKey: false,
+        shiftKey: false,
+        location: 1,
+      },
+      {
+        code: "",
+        key: "Alt",
+        altKey: true,
+        ctrlKey: true,
+        metaKey: false,
+        shiftKey: false,
+        location: 0,
+      },
+      {
+        code: "KeyE",
+        key: "€",
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+        location: 0,
+      },
+    ];
+    for (const event of events) {
+      keyboardState.onKeyDown(event);
+    }
+    assert.strictEqual(true, keyboardState.isKeyPressed("KeyE"));
+    assert.strictEqual(false, keyboardState.isKeyPressed("ControlLeft"));
+    assert.strictEqual(false, keyboardState.isKeyPressed("AltRight"));
+  });
+});

--- a/app/templates/custom-elements/on-screen-keyboard.html
+++ b/app/templates/custom-elements/on-screen-keyboard.html
@@ -362,8 +362,8 @@
                 this.isModifierKeyPressed("MetaLeft") ||
                 this.isModifierKeyPressed("MetaRight"),
               ctrlKey:
-                this.isModifierKeyPressed("CtrlLeft") ||
-                this.isModifierKeyPressed("CtrlRight"),
+                this.isModifierKeyPressed("ControlLeft") ||
+                this.isModifierKeyPressed("ControlRight"),
               shiftKey:
                 this.isModifierKeyPressed("ShiftLeft") ||
                 this.isModifierKeyPressed("ShiftRight"),


### PR DESCRIPTION
This PR is based on @mtlynch [suggestion to write a test for the `keyboardstate` module](https://github.com/tiny-pilot/tinypilot/issues/818#issuecomment-1029131802).

There was a typo in `keyboardstate` module causing the cached state for the left/right control keys to never be overwritten by the actual event state. This is a bug according to this [docstring](https://github.com/tiny-pilot/tinypilot/blob/c67bd1af8d7650af0d94b7a43619adcf904cf8dc/app/static/js/keyboardstate.js#L52-L56):
> The internal state may have gotten out of sync in case the modifier
   keys have been pressed or released while the browser window didn’t have
   focus. The information in the event object takes precedence over this
   class's cached state.

There was the same typo in the `on-screen-keyboard` element causing the emitted KeyboardEvent's `ctrlKey` to always be `false`. However this didn't cause any real issues because the [`keyboardstate` module uses the KeyboardEvent's `code` property](https://github.com/tiny-pilot/tinypilot/blob/c67bd1af8d7650af0d94b7a43619adcf904cf8dc/app/static/js/keycodes.js#L90) to [determine the key being pressed](https://github.com/tiny-pilot/tinypilot/blob/c67bd1af8d7650af0d94b7a43619adcf904cf8dc/app/static/js/keyboardstate.js#L36-L37).

Fixes #818 