### PR TITLE
Update instructions on how to run Janus & uStreamer on a Hobbyist or Voyager device

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,49 @@ curl -fsSL https://get.docker.com | sudo sh && \
 
 ## Run
 
-You need to start Janus and uStreamer manually every time the device reboots:
+You need to start Janus and uStreamer manually every time the device reboots.
+
+### Hobbyist
+
+On a Hobbyist device using a MacroSilicon MS2109-based HDMI-to-USB capture
+dongle, run the following command:
 
 ```bash
 docker run \
   --privileged \
   --network host \
   --name janus-ustreamer \
-  mtlynch/ustreamer-janus:2022-02-02
+  jdeanwallace/janus-ustreamer:2022-02-19 \
+  --host 127.0.0.1 \
+  --port 8001 \
+  --persistent \
+  --h264-sink tinypilot::ustreamer::h264 \
+  --h264-sink-rm \
+  --h264-sink-mode 777 \
+  --encoder hw \
+  --format jpeg \
+  --resolution 1920x1080
+```
+
+### Voyager
+
+On a Voyager device using a TC358743 capture chip, run the following command:
+
+```bash
+docker run \
+  --privileged \
+  --network host \
+  --name janus-ustreamer \
+  jdeanwallace/janus-ustreamer:2022-02-19 \
+  --host 127.0.0.1 \
+  --port 8001 \
+  --persistent \
+  --h264-sink tinypilot::ustreamer::h264 \
+  --h264-sink-rm \
+  --h264-sink-mode 777 \
+  --encoder omx \
+  --format uyvy \
+  --workers 3 \
+  --drop-same-frames 30 \
+  --dv-timings
 ```


### PR DESCRIPTION
This PR explains how to run the [H264 docker image](https://hub.docker.com/r/jdeanwallace/janus-ustreamer) on either a Hobbyist or Voyager device.

This PR depends on https://github.com/tiny-pilot/ansible-role-tinypilot/pull/183 being merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/914)
<!-- Reviewable:end -->
