### PR TITLE
Demo the generalized H264 Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,49 @@ curl -fsSL https://get.docker.com | sudo sh && \
 
 ## Run
 
-You need to start Janus and uStreamer manually every time the device reboots:
+You need to start Janus and uStreamer manually every time the device reboots.
+
+### Hobbyist
+
+On a Hobbyist device using a MacroSilicon MS2109-based HDMI-to-USB capture
+dongle, run the following command:
 
 ```bash
 docker run \
   --privileged \
   --network host \
   --name janus-ustreamer \
-  mtlynch/ustreamer-janus:2022-02-02
+  jdeanwallace/janus-ustreamer:2022-02-19 \
+  --host 127.0.0.1 \
+  --port 8001 \
+  --persistent \
+  --h264-sink tinypilot::ustreamer::h264 \
+  --h264-sink-rm \
+  --h264-sink-mode 777 \
+  --encoder hw \
+  --format jpeg \
+  --resolution 1920x1080
+```
+
+### Voyager
+
+On a Voyager device using a TC358743 capture chip, run the following command:
+
+```bash
+docker run \
+  --privileged \
+  --network host \
+  --name janus-ustreamer \
+  jdeanwallace/janus-ustreamer:2022-02-19 \
+  --host 127.0.0.1 \
+  --port 8001 \
+  --persistent \
+  --h264-sink tinypilot::ustreamer::h264 \
+  --h264-sink-rm \
+  --h264-sink-mode 777 \
+  --encoder omx \
+  --format uyvy \
+  --workers 3 \
+  --drop-same-frames 30 \
+  --dv-timings
 ```

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ curl -fsSL https://get.docker.com | sudo sh && \
   curl \
   --silent \
   --show-error \
-  https://raw.githubusercontent.com/tiny-pilot/tinypilot/experimental/h264/quick-install | \
+  https://raw.githubusercontent.com/tiny-pilot/tinypilot/demo-general-h264-docker-image/quick-install | \
     bash - && \
   sudo reboot
 ```

--- a/quick-install
+++ b/quick-install
@@ -126,14 +126,14 @@ interpreter_python = /usr/bin/python3
 TINYPILOT_ROLE_NAME="ansible-role-tinypilot"
 if [ -d "$TINYPILOT_ROLE_NAME" ]; then
   pushd "$TINYPILOT_ROLE_NAME"
-  git checkout experimental/h264
-  git pull origin experimental/h264
+  git checkout general-h264-docker-image
+  git pull origin general-h264-docker-image
   popd
 else
   TINYPILOT_ROLE_REPO="https://github.com/tiny-pilot/ansible-role-tinypilot.git"
   git clone "$TINYPILOT_ROLE_REPO" "$TINYPILOT_ROLE_NAME"
   pushd "$TINYPILOT_ROLE_NAME"
-  git checkout experimental/h264
+  git checkout general-h264-docker-image
   popd
 fi
 


### PR DESCRIPTION
This PR is not meant to be merged. You can test out the [generalized H264 Docker image](https://github.com/tiny-pilot/ansible-role-tinypilot/pull/183) on either a Hobbyist or Voyager device by following the instructions in the README:

https://github.com/tiny-pilot/tinypilot/blob/1ca0ca3b3e49d168e55c42f9b316e7442fef61ca/README.md#install

* [x] Tested on Hobbyist device
* [ ] Tested on Voyager device

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/915)
<!-- Reviewable:end -->
