### PR TITLE
Log out client id for socket connection events

### DIFF
--- a/app/socket_api.py
+++ b/app/socket_api.py
@@ -77,9 +77,9 @@ def on_key_release():
 
 @socketio.on('connect')
 def on_connect():
-    logger.info('Client connected')
+    logger.info('Client %s connected', flask.request.sid)
 
 
 @socketio.on('disconnect')
 def on_disconnect():
-    logger.info('Client disconnected')
+    logger.info('Client %s disconnected', flask.request.sid)


### PR DESCRIPTION
For debugging purpose, I think it’s useful for the socket connection handlers to also log the socket ID, so that the corresponding “connect” and “disconnect” events can be matched more easily.

The socket ID is internal, and I wouldn’t classify it as personal information which we would have to flag as sensitive.

<img width="966" alt="Screenshot 2022-02-21 at 17 37 44" src="https://user-images.githubusercontent.com/83721279/154996441-866f95da-a447-4497-9c7d-7b9e53431fb9.png">

Note that we have also https://github.com/tiny-pilot/tinypilot-pro/issues/387, which this is somewhat related to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/916)
<!-- Reviewable:end -->
