### PR TITLE
Backport `atomic_file` package from Pro

### DIFF
--- a/app/atomic_file.py
+++ b/app/atomic_file.py
@@ -1,0 +1,50 @@
+import contextlib
+import errno
+import logging
+import os
+import shutil
+import tempfile
+
+logger = logging.getLogger(__name__)
+
+# Folder path where the temporary files are created. `None` means that it
+# falls back to the system’s default path for temporary files, e.g. `/tmp`.
+# This variable is only used for the purpose of patching the path in the tests.
+_TEMP_FOLDER = None
+
+
+@contextlib.contextmanager
+def create(file_path):
+    """Creates a new file in an atomic way.
+
+    It creates the file in the temporary folder first until the caller has
+    finished providing all file contents. Only then, it moves the file to the
+    destination. It always will clean up the temporary file properly.
+
+    Args:
+        file_path: The absolute path of the file (str)
+
+    Raises:
+        OSError if disk operations fail.
+
+    Returns:
+        A stream that can be written into.
+    """
+    file_descriptor, temp_file = tempfile.mkstemp(dir=_TEMP_FOLDER)
+    try:
+        with open(temp_file, 'bw') as file:
+            yield file
+        shutil.move(temp_file, file_path)
+    finally:
+        os.close(file_descriptor)
+        _remove_if_exists(temp_file)
+
+
+def _remove_if_exists(file_path):
+    try:
+        os.remove(file_path)
+    except OSError as e:
+        if e.errno == errno.ENOENT:  # No such file or directory
+            pass
+        else:
+            logger.warning('Unexpected error while removing file: %s', str(e))

--- a/app/atomic_file_test.py
+++ b/app/atomic_file_test.py
@@ -1,0 +1,82 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import atomic_file
+
+
+class CallerError(Exception):
+    pass
+
+
+class AtomicFileTest(unittest.TestCase):
+
+    def setUp(self):
+        self.destination_dir = tempfile.TemporaryDirectory()
+
+        self.temp_dir = tempfile.TemporaryDirectory()
+        intermediate_files_path_patch = mock.patch.object(
+            atomic_file, '_TEMP_FOLDER', self.temp_dir.name)
+        self.addCleanup(intermediate_files_path_patch.stop)
+        intermediate_files_path_patch.start()
+
+    def tearDown(self):
+        self.destination_dir.cleanup()
+        self.temp_dir.cleanup()
+
+    # Ignore pylint because we want to have naming consistent with other
+    # unittest.TestCase assert methods.
+    # pylint: disable=invalid-name
+    def assertFileContainsData(self, path, data_expected):
+        self.assertTrue(os.path.exists(path))
+        with open(path, 'rb') as file:
+            data_actual = file.read()
+            self.assertEqual(data_expected, data_actual)
+
+    # Ignore pylint because we want to have naming consistent with other
+    # unittest.TestCase assert methods.
+    # pylint: disable=invalid-name
+    def assertFolderIsEmpty(self, path):
+        self.assertTrue(os.path.exists(path))
+        self.assertTrue(os.path.isdir(path))
+        self.assertEqual([], os.listdir(path))
+
+    def test_persists_new_file_in_destination_folder(self):
+        file_path = os.path.join(self.destination_dir.name, 'test.txt')
+        with atomic_file.create(file_path) as file:
+            file.write(bytes('hello world', 'utf-8'))
+
+        saved_path = os.path.join(self.destination_dir.name, 'test.txt')
+        self.assertFileContainsData(saved_path, bytes('hello world', 'utf-8'))
+        self.assertFolderIsEmpty(self.temp_dir.name)
+
+    def test_cleans_up_temp_file_on_os_error(self):
+        file_path = os.path.join(self.destination_dir.name, 'test.txt')
+        m = mock.mock_open()
+        with mock.patch('atomic_file.open', m) as open_patch:
+            open_patch.side_effect = mock.Mock(side_effect=OSError())
+            with self.assertRaises(OSError):
+                with atomic_file.create(file_path) as file:
+                    file.write(bytes('hello world', 'utf-8'))
+
+        # The temporary file should be gone and there also shouldn’t be a
+        # partial file at the destination location.
+        self.assertFolderIsEmpty(self.destination_dir.name)
+        self.assertFolderIsEmpty(self.temp_dir.name)
+
+    def test_cleans_up_temp_file_on_caller_error(self):
+        file_path = os.path.join(self.destination_dir.name, 'test.txt')
+        try:
+            with atomic_file.create(file_path) as file:
+                # Caller begins writing into the file:
+                file.write(bytes('hello world', 'utf-8'))
+                # Then, the caller raises an error:
+                raise CallerError()
+        except CallerError:
+            pass
+
+        # The temporary file should be gone and there also shouldn’t be a
+        # partial file at the destination location.
+        self.assertFolderIsEmpty(self.destination_dir.name)
+        self.assertFolderIsEmpty(self.temp_dir.name)


### PR DESCRIPTION
This change is needed for the fix for https://github.com/tiny-pilot/tinypilot/issues/917.

It’s the `atomic_file` package plus the tests taken over verbatim from the Pro repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/919)
<!-- Reviewable:end -->
