### PR TITLE
Extend `atomic_file` to set file permissions

### DIFF
--- a/app/atomic_file.py
+++ b/app/atomic_file.py
@@ -1,0 +1,50 @@
+import contextlib
+import errno
+import logging
+import os
+import shutil
+import tempfile
+
+logger = logging.getLogger(__name__)
+
+# Folder path where the temporary files are created. `None` means that it
+# falls back to the system’s default path for temporary files, e.g. `/tmp`.
+# This variable is only used for the purpose of patching the path in the tests.
+_TEMP_FOLDER = None
+
+
+@contextlib.contextmanager
+def create(file_path):
+    """Creates a new file in an atomic way.
+
+    It creates the file in the temporary folder first until the caller has
+    finished providing all file contents. Only then, it moves the file to the
+    destination. It always will clean up the temporary file properly.
+
+    Args:
+        file_path: The absolute path of the file (str)
+
+    Raises:
+        OSError if disk operations fail.
+
+    Returns:
+        A stream that can be written into.
+    """
+    file_descriptor, temp_file = tempfile.mkstemp(dir=_TEMP_FOLDER)
+    try:
+        with open(temp_file, 'bw') as file:
+            yield file
+        shutil.move(temp_file, file_path)
+    finally:
+        os.close(file_descriptor)
+        _remove_if_exists(temp_file)
+
+
+def _remove_if_exists(file_path):
+    try:
+        os.remove(file_path)
+    except OSError as e:
+        if e.errno == errno.ENOENT:  # No such file or directory
+            pass
+        else:
+            logger.warning('Unexpected error while removing file: %s', str(e))

--- a/app/atomic_file.py
+++ b/app/atomic_file.py
@@ -14,7 +14,7 @@ _TEMP_FOLDER = None
 
 
 @contextlib.contextmanager
-def create(file_path):
+def create(file_path, chmod_mode=None):
     """Creates a new file in an atomic way.
 
     It creates the file in the temporary folder first until the caller has
@@ -22,7 +22,10 @@ def create(file_path):
     destination. It always will clean up the temporary file properly.
 
     Args:
-        file_path: The absolute path of the file (str)
+        file_path: The absolute path of the file (str).
+        chmod_mode: File permissions as bitfield, as used by `os.chmod`. If not
+            specified (None), it falls back to the default permissions of the
+            system/process.
 
     Raises:
         OSError if disk operations fail.
@@ -34,6 +37,8 @@ def create(file_path):
     try:
         with open(temp_file, 'bw') as file:
             yield file
+        if chmod_mode is not None:
+            os.chmod(temp_file, chmod_mode)
         shutil.move(temp_file, file_path)
     finally:
         os.close(file_descriptor)

--- a/app/atomic_file.py
+++ b/app/atomic_file.py
@@ -14,7 +14,7 @@ _TEMP_FOLDER = None
 
 
 @contextlib.contextmanager
-def create(file_path, chmod_mode=None):
+def create(file_path, chmod_mode=0o600):
     """Creates a new file in an atomic way.
 
     It creates the file in the temporary folder first until the caller has
@@ -23,9 +23,8 @@ def create(file_path, chmod_mode=None):
 
     Args:
         file_path: The absolute path of the file (str).
-        chmod_mode: File permissions as bitfield, as used by `os.chmod`. If not
-            specified (None), it falls back to the default permissions of the
-            system/process.
+        chmod_mode: File permissions as bitfield, as used by `os.chmod`. It
+            defaults to 0o600 (-rw------).
 
     Raises:
         OSError if disk operations fail.
@@ -37,8 +36,7 @@ def create(file_path, chmod_mode=None):
     try:
         with open(temp_file, 'bw') as file:
             yield file
-        if chmod_mode is not None:
-            os.chmod(temp_file, chmod_mode)
+        os.chmod(temp_file, chmod_mode)
         shutil.move(temp_file, file_path)
     finally:
         os.close(file_descriptor)

--- a/app/atomic_file_test.py
+++ b/app/atomic_file_test.py
@@ -1,0 +1,82 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import atomic_file
+
+
+class CallerError(Exception):
+    pass
+
+
+class AtomicFileTest(unittest.TestCase):
+
+    def setUp(self):
+        self.destination_dir = tempfile.TemporaryDirectory()
+
+        self.temp_dir = tempfile.TemporaryDirectory()
+        intermediate_files_path_patch = mock.patch.object(
+            atomic_file, '_TEMP_FOLDER', self.temp_dir.name)
+        self.addCleanup(intermediate_files_path_patch.stop)
+        intermediate_files_path_patch.start()
+
+    def tearDown(self):
+        self.destination_dir.cleanup()
+        self.temp_dir.cleanup()
+
+    # Ignore pylint because we want to have naming consistent with other
+    # unittest.TestCase assert methods.
+    # pylint: disable=invalid-name
+    def assertFileContainsData(self, path, data_expected):
+        self.assertTrue(os.path.exists(path))
+        with open(path, 'rb') as file:
+            data_actual = file.read()
+            self.assertEqual(data_expected, data_actual)
+
+    # Ignore pylint because we want to have naming consistent with other
+    # unittest.TestCase assert methods.
+    # pylint: disable=invalid-name
+    def assertFolderIsEmpty(self, path):
+        self.assertTrue(os.path.exists(path))
+        self.assertTrue(os.path.isdir(path))
+        self.assertEqual([], os.listdir(path))
+
+    def test_persists_new_file_in_destination_folder(self):
+        file_path = os.path.join(self.destination_dir.name, 'test.txt')
+        with atomic_file.create(file_path) as file:
+            file.write(bytes('hello world', 'utf-8'))
+
+        saved_path = os.path.join(self.destination_dir.name, 'test.txt')
+        self.assertFileContainsData(saved_path, bytes('hello world', 'utf-8'))
+        self.assertFolderIsEmpty(self.temp_dir.name)
+
+    def test_cleans_up_temp_file_on_os_error(self):
+        file_path = os.path.join(self.destination_dir.name, 'test.txt')
+        m = mock.mock_open()
+        with mock.patch('atomic_file.open', m) as open_patch:
+            open_patch.side_effect = mock.Mock(side_effect=OSError())
+            with self.assertRaises(OSError):
+                with atomic_file.create(file_path) as file:
+                    file.write(bytes('hello world', 'utf-8'))
+
+        # The temporary file should be gone and there also shouldn’t be a
+        # partial file at the destination location.
+        self.assertFolderIsEmpty(self.destination_dir.name)
+        self.assertFolderIsEmpty(self.temp_dir.name)
+
+    def test_cleans_up_temp_file_on_caller_error(self):
+        file_path = os.path.join(self.destination_dir.name, 'test.txt')
+        try:
+            with atomic_file.create(file_path) as file:
+                # Caller begins writing into the file:
+                file.write(bytes('hello world', 'utf-8'))
+                # Then, the caller raises an error:
+                raise CallerError()
+        except CallerError:
+            pass
+
+        # The temporary file should be gone and there also shouldn’t be a
+        # partial file at the destination location.
+        self.assertFolderIsEmpty(self.destination_dir.name)
+        self.assertFolderIsEmpty(self.temp_dir.name)

--- a/app/atomic_file_test.py
+++ b/app/atomic_file_test.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import tempfile
 import unittest
 from unittest import mock
@@ -50,6 +51,40 @@ class AtomicFileTest(unittest.TestCase):
         saved_path = os.path.join(self.destination_dir.name, 'test.txt')
         self.assertFileContainsData(saved_path, bytes('hello world', 'utf-8'))
         self.assertFolderIsEmpty(self.temp_dir.name)
+
+    def test_chmod_sets_desired_permissions(self):
+        file_path_1 = os.path.join(self.destination_dir.name, 'test1.txt')
+        with atomic_file.create(file_path_1, chmod_mode=0o770) as file:
+            file.write(bytes('hello world', 'utf-8'))
+
+        permissions_1 = stat.S_IMODE(os.stat(file_path_1).st_mode)
+        self.assertEqual(0o770, permissions_1)
+
+        # Run the test a second time with different permissions, so that we can
+        # rule out the case where the specified permissions would accidentally
+        # happen to match the system default.
+        file_path_2 = os.path.join(self.destination_dir.name, 'test2.txt')
+        with atomic_file.create(file_path_2, chmod_mode=0o666) as file:
+            file.write(bytes('hello world', 'utf-8'))
+
+        permissions = stat.S_IMODE(os.stat(file_path_2).st_mode)
+        self.assertEqual(0o666, permissions)
+
+    def test_chmod_falls_back_to_system_default(self):
+        file_path = os.path.join(self.destination_dir.name, 'test.txt')
+
+        with atomic_file.create(file_path) as file:
+            file.write(bytes('hello world', 'utf-8'))
+        atomic_file_permissions = stat.S_IMODE(os.stat(file_path).st_mode)
+
+        # Create a temporary dummy file, to find out what chmod value new files
+        # are created with by default. Default file permissions depend on the
+        # umask setting of the system/process.
+        with tempfile.NamedTemporaryFile() as tmp:
+            tmp.write(bytes('', 'utf-8'))
+            default_permissions = stat.S_IMODE(os.stat(tmp.name).st_mode)
+
+        self.assertEqual(default_permissions, atomic_file_permissions)
 
     def test_cleans_up_temp_file_on_os_error(self):
         file_path = os.path.join(self.destination_dir.name, 'test.txt')

--- a/app/atomic_file_test.py
+++ b/app/atomic_file_test.py
@@ -52,39 +52,21 @@ class AtomicFileTest(unittest.TestCase):
         self.assertFileContainsData(saved_path, bytes('hello world', 'utf-8'))
         self.assertFolderIsEmpty(self.temp_dir.name)
 
-    def test_chmod_sets_desired_permissions(self):
-        file_path_1 = os.path.join(self.destination_dir.name, 'test1.txt')
-        with atomic_file.create(file_path_1, chmod_mode=0o770) as file:
-            file.write(bytes('hello world', 'utf-8'))
-
-        permissions_1 = stat.S_IMODE(os.stat(file_path_1).st_mode)
-        self.assertEqual(0o770, permissions_1)
-
-        # Run the test a second time with different permissions, so that we can
-        # rule out the case where the specified permissions would accidentally
-        # happen to match the system default.
-        file_path_2 = os.path.join(self.destination_dir.name, 'test2.txt')
-        with atomic_file.create(file_path_2, chmod_mode=0o666) as file:
-            file.write(bytes('hello world', 'utf-8'))
-
-        permissions = stat.S_IMODE(os.stat(file_path_2).st_mode)
-        self.assertEqual(0o666, permissions)
-
-    def test_chmod_falls_back_to_system_default(self):
+    def test_chmod_uses_0600_as_default_mode(self):
         file_path = os.path.join(self.destination_dir.name, 'test.txt')
-
         with atomic_file.create(file_path) as file:
             file.write(bytes('hello world', 'utf-8'))
-        atomic_file_permissions = stat.S_IMODE(os.stat(file_path).st_mode)
 
-        # Create a temporary dummy file, to find out what chmod value new files
-        # are created with by default. Default file permissions depend on the
-        # umask setting of the system/process.
-        with tempfile.NamedTemporaryFile() as tmp:
-            tmp.write(bytes('', 'utf-8'))
-            default_permissions = stat.S_IMODE(os.stat(tmp.name).st_mode)
+        permissions = stat.S_IMODE(os.stat(file_path).st_mode)
+        self.assertEqual(0o600, permissions)
 
-        self.assertEqual(default_permissions, atomic_file_permissions)
+    def test_chmod_sets_desired_permissions(self):
+        file_path = os.path.join(self.destination_dir.name, 'test.txt')
+        with atomic_file.create(file_path, chmod_mode=0o770) as file:
+            file.write(bytes('hello world', 'utf-8'))
+
+        permissions = stat.S_IMODE(os.stat(file_path).st_mode)
+        self.assertEqual(0o770, permissions)
 
     def test_cleans_up_temp_file_on_os_error(self):
         file_path = os.path.join(self.destination_dir.name, 'test.txt')


### PR DESCRIPTION
This change is needed for the fix for https://github.com/tiny-pilot/tinypilot/issues/917; depends on https://github.com/tiny-pilot/tinypilot/pull/919.

It extends `atomic_file.create` with an additional, optional parameter for specifying the chmod mode on the new file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/920)
<!-- Reviewable:end -->
