### PR TITLE
Update run instructions for H264 docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,6 @@ docker run \
   --privileged \
   --network host \
   --volume /dev/shm:/dev/shm \
-  --name janus-ustreamer \
-  jdeanwallace/janus-ustreamer:2022-02-25
+  --name janus \
+  tinypilotkvm/janus:2022-03-07
 ```

--- a/README.md
+++ b/README.md
@@ -105,49 +105,14 @@ curl -fsSL https://get.docker.com | sudo sh && \
 
 ## Run
 
-You need to start Janus and uStreamer manually every time the device reboots.
-
-### Hobbyist
-
-On a Hobbyist device using a MacroSilicon MS2109-based HDMI-to-USB capture
-dongle, run the following command:
+You need to start Janus manually every time the device reboots, by running the
+following command:
 
 ```bash
 docker run \
   --privileged \
   --network host \
+  --volume /dev/shm:/dev/shm \
   --name janus-ustreamer \
-  jdeanwallace/janus-ustreamer:2022-02-19 \
-  --host 127.0.0.1 \
-  --port 8001 \
-  --persistent \
-  --h264-sink tinypilot::ustreamer::h264 \
-  --h264-sink-rm \
-  --h264-sink-mode 777 \
-  --encoder hw \
-  --format jpeg \
-  --resolution 1920x1080
-```
-
-### Voyager
-
-On a Voyager device using a TC358743 capture chip, run the following command:
-
-```bash
-docker run \
-  --privileged \
-  --network host \
-  --name janus-ustreamer \
-  jdeanwallace/janus-ustreamer:2022-02-19 \
-  --host 127.0.0.1 \
-  --port 8001 \
-  --persistent \
-  --h264-sink tinypilot::ustreamer::h264 \
-  --h264-sink-rm \
-  --h264-sink-mode 777 \
-  --encoder omx \
-  --format uyvy \
-  --workers 3 \
-  --drop-same-frames 30 \
-  --dv-timings
+  jdeanwallace/janus-ustreamer:2022-02-25
 ```


### PR DESCRIPTION
This PR is part of https://github.com/tiny-pilot/ansible-role-tinypilot/issues/179.

This PR depends on https://github.com/tiny-pilot/ansible-role-tinypilot/pull/184 being merged.

This PR updates the instructions on how to run the [H264 docker image](https://hub.docker.com/r/jdeanwallace/janus-ustreamer). We no longer need to differentiate between the Hobbyist and Voyager devices because the we no longer run uStreamer in the docker image. We can just let the `quick-install` script set the appropriate uStreamer settings. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/922)
<!-- Reviewable:end -->
