### PR TITLE
Demo "Remove ustreamer service from h264 docker image"

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,49 @@ curl -fsSL https://get.docker.com | sudo sh && \
 
 ## Run
 
-You need to start Janus and uStreamer manually every time the device reboots:
+You need to start Janus and uStreamer manually every time the device reboots.
+
+### Hobbyist
+
+On a Hobbyist device using a MacroSilicon MS2109-based HDMI-to-USB capture
+dongle, run the following command:
 
 ```bash
 docker run \
   --privileged \
   --network host \
   --name janus-ustreamer \
-  mtlynch/ustreamer-janus:2022-02-02
+  jdeanwallace/janus-ustreamer:2022-02-19 \
+  --host 127.0.0.1 \
+  --port 8001 \
+  --persistent \
+  --h264-sink tinypilot::ustreamer::h264 \
+  --h264-sink-rm \
+  --h264-sink-mode 777 \
+  --encoder hw \
+  --format jpeg \
+  --resolution 1920x1080
+```
+
+### Voyager
+
+On a Voyager device using a TC358743 capture chip, run the following command:
+
+```bash
+docker run \
+  --privileged \
+  --network host \
+  --name janus-ustreamer \
+  jdeanwallace/janus-ustreamer:2022-02-19 \
+  --host 127.0.0.1 \
+  --port 8001 \
+  --persistent \
+  --h264-sink tinypilot::ustreamer::h264 \
+  --h264-sink-rm \
+  --h264-sink-mode 777 \
+  --encoder omx \
+  --format uyvy \
+  --workers 3 \
+  --drop-same-frames 30 \
+  --dv-timings
 ```

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ curl -fsSL https://get.docker.com | sudo sh && \
   curl \
   --silent \
   --show-error \
-  https://raw.githubusercontent.com/tiny-pilot/tinypilot/experimental/h264/quick-install | \
+  https://raw.githubusercontent.com/tiny-pilot/tinypilot/demo-remove-ustreamer-service-h264-docker-image/quick-install | \
     bash - && \
   sudo reboot
 ```

--- a/README.md
+++ b/README.md
@@ -105,49 +105,14 @@ curl -fsSL https://get.docker.com | sudo sh && \
 
 ## Run
 
-You need to start Janus and uStreamer manually every time the device reboots.
-
-### Hobbyist
-
-On a Hobbyist device using a MacroSilicon MS2109-based HDMI-to-USB capture
-dongle, run the following command:
+You need to start Janus manually every time the device reboots, by running the
+following command:
 
 ```bash
 docker run \
   --privileged \
   --network host \
+  --volume /dev/shm:/dev/shm \
   --name janus-ustreamer \
-  jdeanwallace/janus-ustreamer:2022-02-19 \
-  --host 127.0.0.1 \
-  --port 8001 \
-  --persistent \
-  --h264-sink tinypilot::ustreamer::h264 \
-  --h264-sink-rm \
-  --h264-sink-mode 777 \
-  --encoder hw \
-  --format jpeg \
-  --resolution 1920x1080
-```
-
-### Voyager
-
-On a Voyager device using a TC358743 capture chip, run the following command:
-
-```bash
-docker run \
-  --privileged \
-  --network host \
-  --name janus-ustreamer \
-  jdeanwallace/janus-ustreamer:2022-02-19 \
-  --host 127.0.0.1 \
-  --port 8001 \
-  --persistent \
-  --h264-sink tinypilot::ustreamer::h264 \
-  --h264-sink-rm \
-  --h264-sink-mode 777 \
-  --encoder omx \
-  --format uyvy \
-  --workers 3 \
-  --drop-same-frames 30 \
-  --dv-timings
+  jdeanwallace/janus-ustreamer:2022-02-25
 ```

--- a/quick-install
+++ b/quick-install
@@ -126,14 +126,14 @@ interpreter_python = /usr/bin/python3
 TINYPILOT_ROLE_NAME="ansible-role-tinypilot"
 if [ -d "$TINYPILOT_ROLE_NAME" ]; then
   pushd "$TINYPILOT_ROLE_NAME"
-  git checkout experimental/h264
-  git pull origin experimental/h264
+  git checkout demo-remove-ustreamer-service-h264-docker-image
+  git pull origin demo-remove-ustreamer-service-h264-docker-image
   popd
 else
   TINYPILOT_ROLE_REPO="https://github.com/tiny-pilot/ansible-role-tinypilot.git"
   git clone "$TINYPILOT_ROLE_REPO" "$TINYPILOT_ROLE_NAME"
   pushd "$TINYPILOT_ROLE_NAME"
-  git checkout experimental/h264
+  git checkout demo-remove-ustreamer-service-h264-docker-image
   popd
 fi
 


### PR DESCRIPTION
This PR is not meant to be merged. You can use this branch to test the ["Remove ustreamer service from h264 docker image" PR](https://github.com/tiny-pilot/ansible-role-tinypilot/pull/184).

On a fresh Raspberry PI device, run the commands outlined here:
https://github.com/tiny-pilot/tinypilot/blob/demo-remove-ustreamer-service-h264-docker-image/README.md#install

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/923)
<!-- Reviewable:end -->
