### PR TITLE
Recreate corrupt Flask secret key, instead of failing

### DIFF
--- a/app/secret_key_test.py
+++ b/app/secret_key_test.py
@@ -9,8 +9,7 @@ import secret_key
 
 class SecretKeyTest(unittest.TestCase):
 
-    # pylint: disable=invalid-name
-    def assertIsValidKeyValue(self, secret_key_value):
+    def assertIsValidKeyValue(self, secret_key_value):  # pylint: disable=invalid-name
         self.assertIs(bytes, type(secret_key_value))
         self.assertEqual(32, len(secret_key_value))
 

--- a/app/secret_key_test.py
+++ b/app/secret_key_test.py
@@ -22,7 +22,7 @@ class SecretKeyTest(unittest.TestCase):
             with mock.patch.object(secret_key, '_SECRET_KEY_FILE',
                                    mock_secret_key_file.name):
                 secret_key_value = secret_key.get_or_create()
-                self.assertIsValidKeyValue(secret_key_value)
+                self.assertEqual(b'0' * 32, secret_key_value)
 
     def test_get_or_create_will_recreate_if_file_has_invalid_perms(self):
         initial_key = b'0' * 32

--- a/app/secret_key_test.py
+++ b/app/secret_key_test.py
@@ -9,6 +9,11 @@ import secret_key
 
 class SecretKeyTest(unittest.TestCase):
 
+    # pylint: disable=invalid-name
+    def assertIsValidKeyValue(self, secret_key_value):
+        self.assertIs(bytes, type(secret_key_value))
+        self.assertEqual(32, len(secret_key_value))
+
     def test_get_or_create_will_get_when_valid_file_exists(self):
         with tempfile.NamedTemporaryFile() as mock_secret_key_file:
             mock_secret_key_file.write(b'0' * 32)
@@ -17,28 +22,37 @@ class SecretKeyTest(unittest.TestCase):
             with mock.patch.object(secret_key, '_SECRET_KEY_FILE',
                                    mock_secret_key_file.name):
                 secret_key_value = secret_key.get_or_create()
-                self.assertEqual(b'0' * 32, secret_key_value)
+                self.assertIsValidKeyValue(secret_key_value)
 
-    def test_get_or_create_will_raise_error_when_file_has_invalid_perms(self):
+    def test_get_or_create_will_recreate_if_file_has_invalid_perms(self):
+        initial_key = b'0' * 32
+
         with tempfile.NamedTemporaryFile() as mock_secret_key_file:
-            mock_secret_key_file.write(b'0' * 32)
+            mock_secret_key_file.write(initial_key)
             mock_secret_key_file.flush()
             os.chmod(mock_secret_key_file.name, 0o700)
 
             with mock.patch.object(secret_key, '_SECRET_KEY_FILE',
                                    mock_secret_key_file.name):
-                with self.assertRaises(secret_key.InvalidSecretKeyError):
-                    secret_key.get_or_create()
+                secret_key_value = secret_key.get_or_create()
+                self.assertIsValidKeyValue(secret_key_value)
+                self.assertNotEqual(initial_key, secret_key_value)
+                file_perms = stat.S_IMODE(
+                    os.stat(mock_secret_key_file.name).st_mode)
+                self.assertEqual(0o600, file_perms)
 
-    def test_get_or_create_will_raise_error_when_file_has_invalid_content(self):
+    def test_get_or_create_will_recreate_file_if_content_is_corrupt(self):
+        initial_key = b'dummy key data with incorrect size'
+
         with tempfile.NamedTemporaryFile() as mock_secret_key_file:
-            mock_secret_key_file.write(b'dummy key data with incorrect size')
+            mock_secret_key_file.write(initial_key)
             mock_secret_key_file.flush()
 
             with mock.patch.object(secret_key, '_SECRET_KEY_FILE',
                                    mock_secret_key_file.name):
-                with self.assertRaises(secret_key.InvalidSecretKeyError):
-                    secret_key.get_or_create()
+                secret_key_value = secret_key.get_or_create()
+                self.assertIsValidKeyValue(secret_key_value)
+                self.assertNotEqual(initial_key, secret_key_value)
 
     def test_get_or_create_will_create_when_file_does_not_exist(self):
         with tempfile.TemporaryDirectory() as mock_secret_key_dir:
@@ -52,5 +66,9 @@ class SecretKeyTest(unittest.TestCase):
                 self.assertTrue(os.path.exists(mock_secret_key_file))
                 file_perms = stat.S_IMODE(os.stat(mock_secret_key_file).st_mode)
                 self.assertEqual(0o600, file_perms)
-                self.assertIs(bytes, type(secret_key_value))
-                self.assertEqual(32, len(secret_key_value))
+                self.assertIsValidKeyValue(secret_key_value)
+
+                # Verify that the file was actually persisted by retrieving it
+                # again and then checking that the value is still the same.
+                reread_secret_key_value = secret_key.get_or_create()
+                self.assertEqual(secret_key_value, reread_secret_key_value)


### PR DESCRIPTION
Hey @jdeanwallace, sorry for overloading you with PRs this week…

This is a follow-up of https://github.com/tiny-pilot/tinypilot/pull/921. Per discussion in https://github.com/tiny-pilot/tinypilot/issues/917, we wanted to recreate corrupt secret key files on the fly, rather than letting the server fail altogether.

Some notes:
- This mechanism obviously wouldn’t work for cases such as where we don’t have any permissions on the file at all (however that could happen). But for the regular “user has accidentally altered the file contents” case, it should suffice. Also, if the content is valid but only the permissions are wrong, we could handle it more fine-granularly. I don’t think that’s worthwhile, though.
- I debated whether to change the name of `get_or_create`, because of the new recreation behaviour. But in the end, I think the name still holds true. `get_or_recreate` would sound misleading to me, and `get_or_create_or_recreate` is maybe a bit much. Unless you have a good idea, the current name would do for me.
- I pulled up a custom assert function in the test, so that we can re-use the logic. I also extended the last test case, just to make the test even more robust.
- About the `initial_key` variable in the tests: we usually don’t use variables in tests, but we rather deliberately repeat values for stylistic reasons. This case is a bit different, though, since we are performing an inequality check here. Consider:
  ```python
  mock_secret_key_file.write(b'dummy key data with incorrect size')
  # ...
  secret_key_value = secret_key.get_or_create()
  self.assertNotEqual(b'dummy key data with incorect size', secret_key_value)
  ```
  The second string literal has a typo, which is super hard to spot. That test would still pass, though, even if the implementation was broken. By means of a shared variable, we are safe against that mistake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/924)
<!-- Reviewable:end -->
