### PR TITLE
Tinypilot Janus integration (3/?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,34 +85,13 @@ For more details about WebRTC and the required network setup please refer to [th
 
 ## Install
 
-### Docker
-
-```bash
-curl -fsSL https://get.docker.com | sudo sh && \
-  sudo usermod -aG docker $(whoami)
-```
-
 ### TinyPilot
 
 ```bash
-  curl \
+curl \
   --silent \
   --show-error \
   https://raw.githubusercontent.com/tiny-pilot/tinypilot/experimental/h264/quick-install | \
     bash - && \
   sudo reboot
-```
-
-## Run
-
-You need to start Janus manually every time the device reboots, by running the
-following command:
-
-```bash
-docker run \
-  --privileged \
-  --network host \
-  --volume /dev/shm:/dev/shm \
-  --name janus \
-  tinypilotkvm/janus:2022-03-07
 ```


### PR DESCRIPTION
This PR is part of https://github.com/tiny-pilot/ansible-role-tinypilot/issues/168.

This PR updates the README instructions by removing the need to install & run docker.

This PR relies on https://github.com/tiny-pilot/ansible-role-tinypilot/pull/190 being merged.

Resolves https://github.com/tiny-pilot/ansible-role-tinypilot/issues/168

---

You can test the entire "TinyPilot Janus integration" via the following throwaway PR: https://github.com/tiny-pilot/tinypilot/pull/937

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/936)
<!-- Reviewable:end -->
