### PR TITLE
Make `<remote-screen>` content injectable

### DIFF
--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -88,7 +88,11 @@
   </style>
   <div class="screen-wrapper">
     <input id="mobile-keyboard-input" autocapitalize="off" type="text" />
-    <slot id="screen"></slot>
+
+    <slot id="screen">
+      <!-- The slot must be filled with a single, non-nested element. Otherwise
+           the CSS sizing settings cannot be correctly applied. -->
+    </slot>
   </div>
 </template>
 

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -2,62 +2,62 @@
   <style>
     @import "css/cursors.css";
 
-    #remote-screen-img {
+    #screen::slotted(*) {
       max-width: 100%;
       max-height: 70vh;
       object-fit: contain;
     }
 
     @media screen and (min-width: 800px) {
-      #remote-screen-img {
+      #screen::slotted(*) {
         max-width: 99%;
       }
     }
 
     @media screen and (min-width: 1000px) {
-      #remote-screen-img {
+      #screen::slotted(*) {
         max-width: 97%;
       }
     }
 
     @media screen and (min-width: 1200px) {
-      #remote-screen-img {
+      #screen::slotted(*) {
         max-width: 96%;
       }
     }
 
     @media screen and (min-width: 1300px) {
-      #remote-screen-img {
+      #screen::slotted(*) {
         max-width: 93%;
       }
     }
 
     @media screen and (min-width: 1400px) {
-      #remote-screen-img {
+      #screen::slotted(*) {
         max-width: 90%;
       }
     }
 
     @media screen and (min-height: 450px) {
-      #remote-screen-img {
+      #screen::slotted(*) {
         max-height: 80vh;
       }
     }
 
     @media screen and (min-height: 600px) {
-      #remote-screen-img {
+      #screen::slotted(*) {
         max-height: 85vh;
       }
     }
 
     @media screen and (min-height: 900px) {
-      #remote-screen-img {
+      #screen::slotted(*) {
         max-height: 90vh;
       }
     }
 
     @media screen and (min-height: 1180px) {
-      #remote-screen-img {
+      #screen::slotted(*) {
         max-height: 100vh;
       }
     }
@@ -67,17 +67,17 @@
       overflow: auto;
     }
 
-    :host([fullscreen="true"]) #remote-screen-img {
+    :host([fullscreen="true"]) #screen::slotted(*) {
       margin: auto;
       max-width: 100vw;
       max-height: 100vh;
     }
 
-    :host([fullscreen="true"]) #remote-screen-img.full-width {
+    :host([fullscreen="true"]) #screen.full-width::slotted(*) {
       width: 100%;
     }
 
-    :host([fullscreen="true"]) #remote-screen-img.full-height {
+    :host([fullscreen="true"]) #screen.full-height::slotted(*) {
       height: 100%;
     }
 
@@ -88,7 +88,7 @@
   </style>
   <div class="screen-wrapper">
     <input id="mobile-keyboard-input" autocapitalize="off" type="text" />
-    <img id="remote-screen-img" src="/stream?advance_headers=1" />
+    <slot id="screen"></slot>
   </div>
 </template>
 
@@ -139,7 +139,7 @@
           );
 
           // Forward all mouse activity that occurs over the image of the remote screen.
-          const screenImg = this.shadowRoot.getElementById("remote-screen-img");
+          const screenImg = this.shadowRoot.getElementById("screen");
           screenImg.addEventListener("mousemove", (evt) => {
             // Ensure that mouse drags don't attempt to drag the image on the screen.
             evt.preventDefault();
@@ -268,7 +268,7 @@
         // depending on which better maximizes space for the remote screen's
         // aspect ratio.
         fillSpace() {
-          const screenImg = this.shadowRoot.getElementById("remote-screen-img");
+          const screenImg = this.shadowRoot.getElementById("screen");
           screenImg.classList.remove("full-width");
           screenImg.classList.remove("full-height");
           const windowRatio = window.innerWidth / window.innerHeight;

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -142,28 +142,31 @@
             template.content.cloneNode(true)
           );
 
+          this.elements = {
+            screen: this.shadowRoot.getElementById("screen"),
+          };
+
           // Forward all mouse activity that occurs over the image of the remote screen.
-          const screenImg = this.shadowRoot.getElementById("screen");
-          screenImg.addEventListener("mousemove", (evt) => {
+          this.elements.screen.addEventListener("mousemove", (evt) => {
             // Ensure that mouse drags don't attempt to drag the image on the screen.
             evt.preventDefault();
 
             this.rateLimitedMouse.onMouseMove(evt);
           });
-          screenImg.addEventListener("mousedown", (evt) => {
+          this.elements.screen.addEventListener("mousedown", (evt) => {
             this.rateLimitedMouse.onMouseDown(evt);
           });
-          screenImg.addEventListener("mouseup", (evt) => {
+          this.elements.screen.addEventListener("mouseup", (evt) => {
             this.rateLimitedMouse.onMouseUp(evt);
           });
-          screenImg.addEventListener("wheel", (evt) => {
+          this.elements.screen.addEventListener("wheel", (evt) => {
             evt.preventDefault();
             this.rateLimitedMouse.onWheel(evt);
           });
 
           // Ignore the context menu so that it doesn't block the screen when the user
           // right-clicks.
-          screenImg.addEventListener("contextmenu", (evt) => {
+          this.elements.screen.addEventListener("contextmenu", (evt) => {
             evt.preventDefault();
           });
 
@@ -272,15 +275,15 @@
         // depending on which better maximizes space for the remote screen's
         // aspect ratio.
         fillSpace() {
-          const screenImg = this.shadowRoot.getElementById("screen");
-          screenImg.classList.remove("full-width");
-          screenImg.classList.remove("full-height");
+          this.elements.screen.classList.remove("full-width");
+          this.elements.screen.classList.remove("full-height");
           const windowRatio = window.innerWidth / window.innerHeight;
-          const screenRatio = screenImg.width / screenImg.height;
+          const screenRatio =
+            this.elements.screen.width / this.elements.screen.height;
           if (screenRatio > windowRatio) {
-            screenImg.classList.add("full-width");
+            this.elements.screen.classList.add("full-width");
           } else {
-            screenImg.classList.add("full-height");
+            this.elements.screen.classList.add("full-height");
           }
         }
       }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -57,7 +57,9 @@
         <remote-screen
           id="remote-screen"
           milliseconds-between-mouse-events="600"
-        ></remote-screen>
+        >
+          <img src="/stream?advance_headers=1" />
+        </remote-screen>
 
         <on-screen-keyboard id="on-screen-keyboard"></on-screen-keyboard>
       </div>


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot/issues/877.

In order for us to swap out the MJPEG `<img>` element with an H264 `<video>` one, we need to parametrize the `<remote-screen>` component.

One relatively clean implementation is to slot in the screen content from the outside into the `<remote-screen>` component. There is a working POC of this in https://github.com/tiny-pilot/tinypilot/pull/940.

This PR is a non-functional refactoring, so the behaviour and appearance should be the same as before. This not just for the (re-)sizing behaviour, but also for how the mouse coordinates compute.

For simplicity, I’ve renamed the internal element’s `id` to just `#screen`, because it should be clear what it is from the context. Something like `#content` or `#canvas` would sound too generic to me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/941)
<!-- Reviewable:end -->
