### PR TITLE
Fix screen aspect ratio calculation when in fullscreen mode

### DIFF
--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -71,13 +71,7 @@
       margin: auto;
       max-width: 100vw;
       max-height: 100vh;
-    }
-
-    :host([fullscreen="true"]) #screen.full-width::slotted(*) {
       width: 100%;
-    }
-
-    :host([fullscreen="true"]) #screen.full-height::slotted(*) {
       height: 100%;
     }
 
@@ -107,7 +101,6 @@
       class extends HTMLElement {
         constructor() {
           super();
-          this.onWindowResize = this.onWindowResize.bind(this);
 
           // Prevent drag on screen for Firefox.
           this.addEventListener("dragstart", function (evt) {
@@ -170,8 +163,6 @@
             evt.preventDefault();
           });
 
-          window.addEventListener("resize", this.onWindowResize);
-
           // Detect whether this is a touchscreen device.
           let isTouchScreen = false;
           this.shadowRoot.addEventListener("touchend", () => {
@@ -208,7 +199,6 @@
         }
 
         disconnectedCallback() {
-          window.removeEventListener("resize", this.onWindowResize);
           super.disconnectedCallback && super.disconnectedCallback();
         }
 
@@ -262,28 +252,6 @@
             }
           } else if (name === "milliseconds-between-mouse-events") {
             this.rateLimitedMouse.setTimeoutWindow(parseInt(newValue));
-          }
-        }
-
-        onWindowResize() {
-          if (this.fullscreen) {
-            this.fillSpace();
-          }
-        }
-
-        // Adjust style so that the screen is either full-width or full-height,
-        // depending on which better maximizes space for the remote screen's
-        // aspect ratio.
-        fillSpace() {
-          this.elements.screen.classList.remove("full-width");
-          this.elements.screen.classList.remove("full-height");
-          const windowRatio = window.innerWidth / window.innerHeight;
-          const screenRatio =
-            this.elements.screen.width / this.elements.screen.height;
-          if (screenRatio > windowRatio) {
-            this.elements.screen.classList.add("full-width");
-          } else {
-            this.elements.screen.classList.add("full-height");
           }
         }
       }

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -71,7 +71,13 @@
       margin: auto;
       max-width: 100vw;
       max-height: 100vh;
+    }
+
+    :host([fullscreen="true"]) #screen.full-width::slotted(*) {
       width: 100%;
+    }
+
+    :host([fullscreen="true"]) #screen.full-height::slotted(*) {
       height: 100%;
     }
 
@@ -101,6 +107,7 @@
       class extends HTMLElement {
         constructor() {
           super();
+          this.onWindowResize = this.onWindowResize.bind(this);
 
           // Prevent drag on screen for Firefox.
           this.addEventListener("dragstart", function (evt) {
@@ -163,6 +170,8 @@
             evt.preventDefault();
           });
 
+          window.addEventListener("resize", this.onWindowResize);
+
           // Detect whether this is a touchscreen device.
           let isTouchScreen = false;
           this.shadowRoot.addEventListener("touchend", () => {
@@ -199,6 +208,7 @@
         }
 
         disconnectedCallback() {
+          window.removeEventListener("resize", this.onWindowResize);
           super.disconnectedCallback && super.disconnectedCallback();
         }
 
@@ -252,6 +262,28 @@
             }
           } else if (name === "milliseconds-between-mouse-events") {
             this.rateLimitedMouse.setTimeoutWindow(parseInt(newValue));
+          }
+        }
+
+        onWindowResize() {
+          if (this.fullscreen) {
+            this.fillSpace();
+          }
+        }
+
+        // Adjust style so that the screen is either full-width or full-height,
+        // depending on which better maximizes space for the remote screen's
+        // aspect ratio.
+        fillSpace() {
+          this.elements.screen.classList.remove("full-width");
+          this.elements.screen.classList.remove("full-height");
+          const windowRatio = window.innerWidth / window.innerHeight;
+          const screenRatio =
+            this.elements.screen.width / this.elements.screen.height;
+          if (screenRatio > windowRatio) {
+            this.elements.screen.classList.add("full-width");
+          } else {
+            this.elements.screen.classList.add("full-height");
           }
         }
       }

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -73,13 +73,11 @@
       max-height: 100vh;
     }
 
-    :host([fullscreen="true"][fullscreen-maximize="width"])
-      #screen::slotted(*) {
+    :host([fullscreen="true"]) #screen.full-width::slotted(*) {
       width: 100%;
     }
 
-    :host([fullscreen="true"][fullscreen-maximize="height"])
-      #screen::slotted(*) {
+    :host([fullscreen="true"]) #screen.full-height::slotted(*) {
       height: 100%;
     }
 
@@ -110,7 +108,6 @@
         constructor() {
           super();
           this.onWindowResize = this.onWindowResize.bind(this);
-          this.fillSpace = this.fillSpace.bind(this);
 
           // Prevent drag on screen for Firefox.
           this.addEventListener("dragstart", function (evt) {
@@ -245,19 +242,6 @@
             .setAttribute("cursor", newValue);
         }
 
-        set fullscreenMaximize(newValue) {
-          if (newValue === null) {
-            this.removeAttribute("fullscreen-maximize");
-            return;
-          }
-          if (!["width", "height"].includes(newValue)) {
-            throw new Error(
-              "Invalid value. Can only maximize either 'width' or 'height' in fullscreen."
-            );
-          }
-          this.setAttribute("fullscreen-maximize", newValue);
-        }
-
         static get observedAttributes() {
           return ["fullscreen", "milliseconds-between-mouse-events"];
         }
@@ -284,24 +268,22 @@
         onWindowResize() {
           if (this.fullscreen) {
             this.fillSpace();
-          } else {
-            this.fullscreenMaximize = null;
           }
         }
 
-        // Adjust the screen size so that it is either full-width or
-        // full-height in fullscreen mode, depending on which better maximizes
-        // space for the remote screen's aspect ratio. This is needed in order
-        // to matchup the coordinates of the mouse events on the browser and
-        // remote screen.
+        // Adjust style so that the screen is either full-width or full-height,
+        // depending on which better maximizes space for the remote screen's
+        // aspect ratio.
         fillSpace() {
-          const slottedScreen = this.elements.screen.assignedElements()[0];
+          this.elements.screen.classList.remove("full-width");
+          this.elements.screen.classList.remove("full-height");
           const windowRatio = window.innerWidth / window.innerHeight;
-          const screenRatio = slottedScreen.width / slottedScreen.height;
+          const screenRatio =
+            this.elements.screen.width / this.elements.screen.height;
           if (screenRatio > windowRatio) {
-            this.fullscreenMaximize = "width";
+            this.elements.screen.classList.add("full-width");
           } else {
-            this.fullscreenMaximize = "height";
+            this.elements.screen.classList.add("full-height");
           }
         }
       }

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -73,14 +73,6 @@
       max-height: 100vh;
     }
 
-    :host([fullscreen="true"]) #screen.full-width::slotted(*) {
-      width: 100%;
-    }
-
-    :host([fullscreen="true"]) #screen.full-height::slotted(*) {
-      height: 100%;
-    }
-
     #mobile-keyboard-input {
       position: fixed;
       top: -1000px;
@@ -107,7 +99,6 @@
       class extends HTMLElement {
         constructor() {
           super();
-          this.onWindowResize = this.onWindowResize.bind(this);
 
           // Prevent drag on screen for Firefox.
           this.addEventListener("dragstart", function (evt) {
@@ -170,8 +161,6 @@
             evt.preventDefault();
           });
 
-          window.addEventListener("resize", this.onWindowResize);
-
           // Detect whether this is a touchscreen device.
           let isTouchScreen = false;
           this.shadowRoot.addEventListener("touchend", () => {
@@ -208,7 +197,6 @@
         }
 
         disconnectedCallback() {
-          window.removeEventListener("resize", this.onWindowResize);
           super.disconnectedCallback && super.disconnectedCallback();
         }
 
@@ -262,28 +250,6 @@
             }
           } else if (name === "milliseconds-between-mouse-events") {
             this.rateLimitedMouse.setTimeoutWindow(parseInt(newValue));
-          }
-        }
-
-        onWindowResize() {
-          if (this.fullscreen) {
-            this.fillSpace();
-          }
-        }
-
-        // Adjust style so that the screen is either full-width or full-height,
-        // depending on which better maximizes space for the remote screen's
-        // aspect ratio.
-        fillSpace() {
-          this.elements.screen.classList.remove("full-width");
-          this.elements.screen.classList.remove("full-height");
-          const windowRatio = window.innerWidth / window.innerHeight;
-          const screenRatio =
-            this.elements.screen.width / this.elements.screen.height;
-          if (screenRatio > windowRatio) {
-            this.elements.screen.classList.add("full-width");
-          } else {
-            this.elements.screen.classList.add("full-height");
           }
         }
       }

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -73,11 +73,13 @@
       max-height: 100vh;
     }
 
-    :host([fullscreen="true"]) #screen.full-width::slotted(*) {
+    :host([fullscreen="true"][fullscreen-maximize="width"])
+      #screen::slotted(*) {
       width: 100%;
     }
 
-    :host([fullscreen="true"]) #screen.full-height::slotted(*) {
+    :host([fullscreen="true"][fullscreen-maximize="height"])
+      #screen::slotted(*) {
       height: 100%;
     }
 
@@ -108,6 +110,7 @@
         constructor() {
           super();
           this.onWindowResize = this.onWindowResize.bind(this);
+          this.fillSpace = this.fillSpace.bind(this);
 
           // Prevent drag on screen for Firefox.
           this.addEventListener("dragstart", function (evt) {
@@ -242,6 +245,19 @@
             .setAttribute("cursor", newValue);
         }
 
+        set fullscreenMaximize(newValue) {
+          if (newValue === null) {
+            this.removeAttribute("fullscreen-maximize");
+            return;
+          }
+          if (!["width", "height"].includes(newValue)) {
+            throw new Error(
+              "Invalid value. Can only maximize either 'width' or 'height' in fullscreen."
+            );
+          }
+          this.setAttribute("fullscreen-maximize", newValue);
+        }
+
         static get observedAttributes() {
           return ["fullscreen", "milliseconds-between-mouse-events"];
         }
@@ -268,22 +284,24 @@
         onWindowResize() {
           if (this.fullscreen) {
             this.fillSpace();
+          } else {
+            this.fullscreenMaximize = null;
           }
         }
 
-        // Adjust style so that the screen is either full-width or full-height,
-        // depending on which better maximizes space for the remote screen's
-        // aspect ratio.
+        // Adjust the screen size so that it is either full-width or
+        // full-height in fullscreen mode, depending on which better maximizes
+        // space for the remote screen's aspect ratio. This is needed in order
+        // to matchup the coordinates of the mouse events on the browser and
+        // remote screen.
         fillSpace() {
-          this.elements.screen.classList.remove("full-width");
-          this.elements.screen.classList.remove("full-height");
+          const slottedScreen = this.elements.screen.assignedElements()[0];
           const windowRatio = window.innerWidth / window.innerHeight;
-          const screenRatio =
-            this.elements.screen.width / this.elements.screen.height;
+          const screenRatio = slottedScreen.width / slottedScreen.height;
           if (screenRatio > windowRatio) {
-            this.elements.screen.classList.add("full-width");
+            this.fullscreenMaximize = "width";
           } else {
-            this.elements.screen.classList.add("full-height");
+            this.fullscreenMaximize = "height";
           }
         }
       }


### PR DESCRIPTION
While working on https://github.com/tiny-pilot/tinypilot/pull/950, I discovered some dead code that seems to never execute.

[Demo video](https://www.loom.com/share/058ee773d4ed40278c09185b9fc79e16).

**Before change:**
When going fullscreen, the size of the `remote-screen` always preferences the full height by [adding a `full-height` class to the screen element](https://github.com/tiny-pilot/tinypilot/blob/32422d642479dd7e143bcbb49f28a22919798b10/app/templates/custom-elements/remote-screen.html#L286). The `full-width` class never gets added because [the screen element has no width/height attributes](https://github.com/tiny-pilot/tinypilot/blob/32422d642479dd7e143bcbb49f28a22919798b10/app/templates/custom-elements/remote-screen.html#L281-L282), resulting in `screenRatio = NaN`. The `full-width`/`full-height` classes just make the `width: 100%` / `height: 100%`, respectively.

**After change:**
 Setting both the width & height to 100% on fullscreen has the same desired result.

---

This reason why I want to remove this code is because I'm refactoring the `video`/`img` element back into the `remote-screen` component ([based on this comment](https://github.com/tiny-pilot/tinypilot/pull/950#pullrequestreview-935264560)) and I don't want to port over code we're not currently using.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/957)
<!-- Reviewable:end -->
