### PR TITLE
Remove 'Copy to Clipboard' button on logs page

### DIFF
--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -75,9 +75,6 @@
       <button class="share-btn btn-action" type="button">
         Get Shareable URL
       </button>
-      <button class="copy-btn btn-action" type="button">
-        Copy to Clipboard
-      </button>
       <div style="flex: 1;"><!-- Spacer --></div>
       <div class="toggle-container">
         Hide Sensitive Data
@@ -180,14 +177,6 @@
           this.shadowRoot
             .querySelector("#logs-success .share-btn")
             .addEventListener("click", this._getUrl);
-          this.shadowRoot
-            .querySelector("#logs-success .copy-btn")
-            .addEventListener("click", (event) => {
-              this.onPushCopyButton(
-                /*buttonElement=*/ event.target,
-                /*sourceElement=*/ this.elements.logsText
-              );
-            });
           this.shadowRoot
             .querySelector("#url-success .copy-btn")
             .addEventListener("click", (event) => {


### PR DESCRIPTION
The Copy to Clipboard button is primarily so that users can get technical support, and there are no technical support channels where pasting the full logs directly into the communication is the right thing. If they paste it into email or our support forum, the formatting gets mangled and it's very hard to read.

It's better if users just do 'Get Shareable URL' and share the URL with us.

This simplifies the page to remove the unneeded 'Copy to Clipboard' button for copying full logs to the clipboard.

If the user *really* wants to copy everything to their clipboard, they still can by just highlighting the text and using the browser's normal text copy functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/960)
<!-- Reviewable:end -->
