### PR TITLE
Only fail quick-install on 64-bit versions of Raspberry Pi OS

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -37,7 +37,7 @@ set -u
 
 # Prevent installation on the 64-bit version of Raspberry Pi OS.
 # https://github.com/tiny-pilot/tinypilot/issues/929
-if [[ "$(uname -m)" == 'aarch64' ]]; then
+if [[ "$(uname -m)" == 'aarch64' && "$(lsb_release --id --short)" == 'Raspbian' ]]; then
   echo '64-bit Raspberry Pi OS is not yet supported.' >&2
   echo 'Please use the 32-bit version of Raspberry Pi OS.' >&2
   exit 1


### PR DESCRIPTION
We added this check for 64-bit (https://github.com/tiny-pilot/tinypilot/pull/930) because a user reported that the USB gadget service didn't work, leading to a confusing user experience (https://github.com/tiny-pilot/tinypilot/issues/929).

Another user reports that TinyPilot works on Ubuntu 20.04.4 LTS 64-bit, so it's possible the 64-bit issue is specific to Raspberry Pi OS (aka Raspbian). https://forum.tinypilotkvm.com/-285/unable-to-update-64bit-pi-to-240

Adding a stricter check for Raspberry Pi OS 64-bit should allow non-Raspbian users to continue using TinyPilot on compatible systems.