### PR TITLE
Fix WebRTC cold start behaviour

### DIFF
--- a/app/static/js/webrtc-video.js
+++ b/app/static/js/webrtc-video.js
@@ -85,6 +85,12 @@ function attachToJanusPlugin() {
      * @param {object|null} jsep JSEP = JavaScript Session Establishment Protocol
      */
     onmessage: function (msg, jsep) {
+      // `503` indicates that the plugin is not ready to stream yet. Retry
+      // the watch request, until the H.264 stream is available.
+      if (msg.error_code === 503) {
+        janusPluginHandle.send({ message: { request: "watch" } });
+        return;
+      }
       if (!jsep) {
         return;
       }


### PR DESCRIPTION
As @jotaen4tinypilot [discovered](https://github.com/tiny-pilot/tinypilot/issues/948#issuecomment-1087923465), the uStreamer Janus plugin takes a few seconds to initiate the H.264 stream internally. This results in the [watch command](https://github.com/tiny-pilot/tinypilot/blob/06882c61440258a9ce2067e7d6bc261d507f298d/app/static/js/webrtc-video.js#L71) returning a 503 error. This PR retries the watch command when a 503 error is received.

The fix is ported over from our "Guide to H.264 streaming" [sample code](https://github.com/tiny-pilot/ustreamer/blob/a8dfa96db0c1ed5ae216a58f4f07a955cd23a212/docs/h264.md#sample-code).

Resolves https://github.com/tiny-pilot/tinypilot/issues/948

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/962)
<!-- Reviewable:end -->
