### PR TITLE
Use html attributes to maximize the screen size in fullscreen mode

### DIFF
--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -73,13 +73,11 @@
       max-height: 100vh;
     }
 
-    :host([fullscreen="true"][fullscreen-maximize="width"])
-      #screen::slotted(*) {
+    :host([fullscreen="true"][fullscreen-is-full-width]) #screen::slotted(*) {
       width: 100%;
     }
 
-    :host([fullscreen="true"][fullscreen-maximize="height"])
-      #screen::slotted(*) {
+    :host([fullscreen="true"][fullscreen-is-full-height]) #screen::slotted(*) {
       height: 100%;
     }
 
@@ -123,6 +121,8 @@
           this.addEventListener("fullscreenchange", () => {
             if (!document.fullscreenElement) {
               this.fullscreen = false;
+              this.fullscreenIsFullWidth = false;
+              this.fullscreenIsFullHeight = false;
             }
           });
           this.rateLimitedMouse = new RateLimitedMouse(
@@ -245,17 +245,20 @@
             .setAttribute("cursor", newValue);
         }
 
-        /**
-         * Maximize either the width or height of the screen element in
-         * fullscreen mode.
-         * @param {('width'|'height')} dimension (optional)
-         */
-        set fullscreenMaximize(dimension) {
-          if (dimension === null) {
-            this.removeAttribute("fullscreen-maximize");
-            return;
+        set fullscreenIsFullWidth(enabled) {
+          if (enabled) {
+            this.setAttribute("fullscreen-is-full-width", "");
+          } else {
+            this.removeAttribute("fullscreen-is-full-width");
           }
-          this.setAttribute("fullscreen-maximize", dimension);
+        }
+
+        set fullscreenIsFullHeight(enabled) {
+          if (enabled) {
+            this.setAttribute("fullscreen-is-full-height", "");
+          } else {
+            this.removeAttribute("fullscreen-is-full-height");
+          }
         }
 
         static get observedAttributes() {
@@ -284,8 +287,6 @@
         onWindowResize() {
           if (this.fullscreen) {
             this.fillSpace();
-          } else {
-            this.fullscreenMaximize = null;
           }
         }
 
@@ -302,9 +303,11 @@
           const windowRatio = window.innerWidth / window.innerHeight;
           const screenRatio = slottedScreen.width / slottedScreen.height;
           if (screenRatio > windowRatio) {
-            this.fullscreenMaximize = "width";
+            this.fullscreenIsFullHeight = false;
+            this.fullscreenIsFullWidth = true;
           } else {
-            this.fullscreenMaximize = "height";
+            this.fullscreenIsFullWidth = false;
+            this.fullscreenIsFullHeight = true;
           }
         }
       }

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -245,10 +245,6 @@
             .setAttribute("cursor", newValue);
         }
 
-        get fullscreenMaximize() {
-          return this.getAttribute("fullscreen-maximize");
-        }
-
         /**
          * Maximize either the width or height of the screen element in
          * fullscreen mode.

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -248,7 +248,7 @@
         /**
          * Maximize either the width or height of the screen element in
          * fullscreen mode.
-         * @param {('width'|'height')} dimension
+         * @param {('width'|'height')} dimension (optional)
          */
         set fullscreenMaximize(dimension) {
           if (dimension === null) {

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -289,12 +289,14 @@
           }
         }
 
-        // Adjust the screen size so that it is either full-width or
-        // full-height in fullscreen mode, depending on which better maximizes
-        // space for the remote screen's aspect ratio. This is needed, because
-        // otherwise the calculation of the mouse coordinates in fullscreen mode
-        // does not yield correct results, and hence the mouse cursor position
-        // appears to be slightly off.
+        /**
+         * Adjust the screen size so that it is either full-width or
+         * full-height in fullscreen mode, depending on which better maximizes
+         * space for the remote screen's aspect ratio. This is needed, because
+         * otherwise the calculation of the mouse coordinates in fullscreen mode
+         * does not yield correct results, and hence the mouse cursor position
+         * appears to be slightly off.
+         */
         fillSpace() {
           const slottedScreen = this.elements.screen.assignedElements()[0];
           const windowRatio = window.innerWidth / window.innerHeight;

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -73,11 +73,13 @@
       max-height: 100vh;
     }
 
-    :host([fullscreen="true"]) #screen.full-width::slotted(*) {
+    :host([fullscreen="true"][fullscreen-maximize="width"])
+      #screen::slotted(*) {
       width: 100%;
     }
 
-    :host([fullscreen="true"]) #screen.full-height::slotted(*) {
+    :host([fullscreen="true"][fullscreen-maximize="height"])
+      #screen::slotted(*) {
       height: 100%;
     }
 
@@ -108,6 +110,7 @@
         constructor() {
           super();
           this.onWindowResize = this.onWindowResize.bind(this);
+          this.fillSpace = this.fillSpace.bind(this);
 
           // Prevent drag on screen for Firefox.
           this.addEventListener("dragstart", function (evt) {
@@ -242,6 +245,23 @@
             .setAttribute("cursor", newValue);
         }
 
+        get fullscreenMaximize() {
+          return this.getAttribute("fullscreen-maximize");
+        }
+
+        /**
+         * Maximize either the width or height of the screen element in
+         * fullscreen mode.
+         * @param {('width'|'height')} dimension
+         */
+        set fullscreenMaximize(dimension) {
+          if (dimension === null) {
+            this.removeAttribute("fullscreen-maximize");
+            return;
+          }
+          this.setAttribute("fullscreen-maximize", dimension);
+        }
+
         static get observedAttributes() {
           return ["fullscreen", "milliseconds-between-mouse-events"];
         }
@@ -268,22 +288,25 @@
         onWindowResize() {
           if (this.fullscreen) {
             this.fillSpace();
+          } else {
+            this.fullscreenMaximize = null;
           }
         }
 
-        // Adjust style so that the screen is either full-width or full-height,
-        // depending on which better maximizes space for the remote screen's
-        // aspect ratio.
+        // Adjust the screen size so that it is either full-width or
+        // full-height in fullscreen mode, depending on which better maximizes
+        // space for the remote screen's aspect ratio. This is needed, because
+        // otherwise the calculation of the mouse coordinates in fullscreen mode
+        // does not yield correct results, and hence the mouse cursor position
+        // appears to be slightly off.
         fillSpace() {
-          this.elements.screen.classList.remove("full-width");
-          this.elements.screen.classList.remove("full-height");
+          const slottedScreen = this.elements.screen.assignedElements()[0];
           const windowRatio = window.innerWidth / window.innerHeight;
-          const screenRatio =
-            this.elements.screen.width / this.elements.screen.height;
+          const screenRatio = slottedScreen.width / slottedScreen.height;
           if (screenRatio > windowRatio) {
-            this.elements.screen.classList.add("full-width");
+            this.fullscreenMaximize = "width";
           } else {
-            this.elements.screen.classList.add("full-height");
+            this.fullscreenMaximize = "height";
           }
         }
       }


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot/issues/946

This PR adds a `fullscreenMaximize` attribute to the `remote-screen` element to either maximize the width or height of the screen element instead of using JS to add/remove CSS classes.

This change is needed in order to refactor the video & img elements back into the `remote-screen` component (based on this comment https://github.com/tiny-pilot/tinypilot/pull/950#pullrequestreview-935264560) because adding/removing CSS classes from multiple screen elements would be tedious.

This PR does **not** address the known "[misaligned mouse coordinates](https://github.com/tiny-pilot/tinypilot/issues/964)" bug. That bug is still present in this PR.

---

@jotaen4tinypilot This PR is similar to [one of the commits you've already reviewed](https://github.com/tiny-pilot/tinypilot/pull/957#pullrequestreview-939799501). I've addressed those comments in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/965)
<!-- Reviewable:end -->
