### PR TITLE
Remove spellcheck and other formatters on hostname input

### DIFF
--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -49,7 +49,16 @@
     </p>
     <div class="input-container">
       <label for="hostname-input">Hostname:</label>
-      <input type="text" id="hostname-input" size="30" class="monospace" />
+      <input
+        type="text"
+        id="hostname-input"
+        size="30"
+        class="monospace"
+        autocomplete="off"
+        autocorrect="off"
+        autocapitalize="off"
+        spellcheck="false"
+      />
       <inline-message variant="error" id="input-error">
         <strong>Invalid hostname:</strong> it can only contain the letters a-z,
         digits and dashes (it cannot start with a dash, though). It must contain

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -200,6 +200,20 @@
       </label>
 
       <h2 class="section">Input</h2>
+      <ul>
+        <li>
+          For text input fields that expect non-English words, use any/all of
+          the following attributes to
+          <a href="https://github.com/tiny-pilot/tinypilot/pull/972"
+            >prevent browsers from spellchecking</a
+          >
+          or auto-correcting the text:
+          <pre>autocomplete="off"</pre>
+          <pre>autocorrect="off"</pre>
+          <pre>autocapitalize="off"</pre>
+          <pre>spellcheck="false"</pre>
+        </li>
+      </ul>
       <h3>For Regular Text</h3>
       <div>
         <input


### PR DESCRIPTION
I just noticed that Chrome puts a red squiggle under 'tinypilot' because it flags it as an unrecognized word. We can add HTML attributes to prevent this behavior, and while we're at it, we may as well prevent autocomplete and friends on mobile devices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/972)
<!-- Reviewable:end -->
