### PR TITLE
Use standardized `check-bash` script

### DIFF
--- a/dev-scripts/check-bash
+++ b/dev-scripts/check-bash
@@ -10,9 +10,14 @@ set -u
 
 BASH_SCRIPTS=()
 
-while read -r line; do
-  if head -n 1 "${line}" | grep --quiet "#!/bin/bash"; then
-    BASH_SCRIPTS+=("${line}")
+while read -r filepath; do
+  if head -n 1 "${filepath}" | grep --quiet \
+    --regexp '#!/bin/bash' \
+    --regexp '#!/usr/bin/env bash' \
+    --regexp '#!/usr/sh' \
+    --regexp '#!/usr/bin/env sh' \
+    ; then
+      BASH_SCRIPTS+=("${filepath}")
   fi
 done < <(git ls-files)
 


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/ansible-role-tinypilot-pro/issues/84: use “standardized” `check-bash` script, [as introduced here](https://github.com/tiny-pilot/ansible-role-tinypilot/pull/198).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/974)
<!-- Reviewable:end -->
