### PR TITLE
Put template for About dialog credits in a separate file

### DIFF
--- a/app/templates/custom-elements/about-dialog.html
+++ b/app/templates/custom-elements/about-dialog.html
@@ -122,9 +122,11 @@
 
               const credit = document.createElement("credit-entry");
               creditsDiv.appendChild(credit);
-              credit.title = project.name;
-              credit.licenseUrl = project.licenseUrl;
-              credit.homepageUrl = project.homepageUrl;
+              credit.populate(
+                project.name,
+                project.licenseUrl,
+                project.homepageUrl
+              );
             }
           });
         }

--- a/app/templates/custom-elements/about-dialog.html
+++ b/app/templates/custom-elements/about-dialog.html
@@ -66,33 +66,6 @@
   </div>
 </template>
 
-<!-- Template for entries in the .credits element -->
-<template id="credit-box-template">
-  <style>
-    .project {
-      margin-bottom: 0.2rem;
-    }
-
-    .title {
-      font-weight: bold;
-    }
-
-    .license-wrapper {
-      margin-left: 0.2em;
-      font-size: 0.85em;
-    }
-  </style>
-
-  <li class="project">
-    <a class="homepage" target="_blank" rel="noopener noreferrer">
-      <span class="title"></span>
-    </a>
-    <span class="license-wrapper">
-      (<a class="license" target="_blank" rel="noopener noreferrer">License</a>)
-    </span>
-  </li>
-</template>
-
 <script type="module">
   import { DialogClosedEvent, DialogFailedEvent } from "/js/events.js";
   import { getLicensingMetadata, getVersion } from "/js/controllers.js";
@@ -147,11 +120,11 @@
                 continue;
               }
 
-              const credit = creditBoxTemplate.content.cloneNode(true);
-              credit.querySelector(".title").innerText = project.name;
-              credit.querySelector(".license").href = project.licenseUrl;
-              credit.querySelector(".homepage").href = project.homepageUrl;
+              const credit = document.createElement("credit-entry");
               creditsDiv.appendChild(credit);
+              credit.title = project.name;
+              credit.licenseUrl = project.licenseUrl;
+              credit.homepageUrl = project.homepageUrl;
             }
           });
         }

--- a/app/templates/custom-elements/credit-entry.html
+++ b/app/templates/custom-elements/credit-entry.html
@@ -1,6 +1,8 @@
 <!-- Displays credit for a third-party dependency -->
 <template id="credit-entry-template">
   <style>
+    @import "css/style.css";
+
     .project {
       margin-bottom: 0.2rem;
     }

--- a/app/templates/custom-elements/credit-entry.html
+++ b/app/templates/custom-elements/credit-entry.html
@@ -40,16 +40,10 @@
           );
         }
 
-        set title(newValue) {
-          this.shadowRoot.querySelector(".title").innerText = newValue;
-        }
-
-        set licenseUrl(newValue) {
-          this.shadowRoot.querySelector(".license").href = newValue;
-        }
-
-        set homepageUrl(newValue) {
-          this.shadowRoot.querySelector(".homepage").href = newValue;
+        populate(title, licenseUrl, homepageUrl) {
+          this.shadowRoot.querySelector(".title").innerText = title;
+          this.shadowRoot.querySelector(".license").href = licenseUrl;
+          this.shadowRoot.querySelector(".homepage").href = homepageUrl;
         }
       }
     );

--- a/app/templates/custom-elements/credit-entry.html
+++ b/app/templates/custom-elements/credit-entry.html
@@ -1,0 +1,56 @@
+<!-- Displays credit for a third-party dependency -->
+<template id="credit-entry-template">
+  <style>
+    @import "css/style.css";
+
+    .project {
+      margin-bottom: 0.2rem;
+    }
+
+    .title {
+      font-weight: bold;
+    }
+
+    .license {
+      font-size: 10pt;
+    }
+  </style>
+
+  <li class="project">
+    <a class="homepage" target="_blank" rel="noopener noreferrer">
+      <span class="title"></span> </a
+    >&nbsp;
+    <span>
+      (<a class="license" target="_blank" rel="noopener noreferrer">License</a>)
+    </span>
+  </li>
+</template>
+
+<script type="module">
+  (function () {
+    const template = document.querySelector("#credit-entry-template");
+
+    customElements.define(
+      "credit-entry",
+      class extends HTMLElement {
+        connectedCallback() {
+          this.attachShadow({ mode: "open" }).appendChild(
+            template.content.cloneNode(true)
+          );
+        }
+
+        set title(newValue) {
+          this.shadowRoot.querySelector(".title").innerText = newValue;
+        }
+
+        set licenseUrl(newValue) {
+          this.shadowRoot.querySelector(".license").href = newValue;
+        }
+
+        set homepageUrl(newValue) {
+          this.shadowRoot.querySelector(".homepage").href = newValue;
+        }
+      }
+    );
+  })();
+</script>

--- a/app/templates/custom-elements/credit-entry.html
+++ b/app/templates/custom-elements/credit-entry.html
@@ -1,8 +1,6 @@
 <!-- Displays credit for a third-party dependency -->
 <template id="credit-entry-template">
   <style>
-    @import "css/style.css";
-
     .project {
       margin-bottom: 0.2rem;
     }
@@ -11,16 +9,17 @@
       font-weight: bold;
     }
 
-    .license {
-      font-size: 10pt;
+    .license-wrapper {
+      margin-left: 0.2em;
+      font-size: 0.85em;
     }
   </style>
 
   <li class="project">
     <a class="homepage" target="_blank" rel="noopener noreferrer">
-      <span class="title"></span> </a
-    >&nbsp;
-    <span>
+      <span class="title"></span>
+    </a>
+    <span class="license-wrapper">
       (<a class="license" target="_blank" rel="noopener noreferrer">License</a>)
     </span>
   </li>


### PR DESCRIPTION
Previously, we broke our typical pattern for custom elements by placing the template for entries in the list of credits was in a template within the same file as the about page dialog rather than in its own file, as we normally do.

Combining the element had an unintended I overlooked: it duplicates the same `<style>` tag and rules ~40 times in the HTML.

![image](https://user-images.githubusercontent.com/7783288/170369106-f24e6768-28f0-41e2-8f9b-0eda659a5014.png)

I imagine there's a way to do this correctly without putting the template into a separate file, but I don't think it's worth the dev resources to dig into it at the moment.

This change ungroups the custom elements so that the template for entries in the credits has its own distinct file and follows our normal patterns for custom elements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/980)
<!-- Reviewable:end -->
