### PR TITLE
Make automatic PRs more human-like

### DIFF
--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -21,8 +21,7 @@ jobs:
           set +e
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
           git fetch upstream jdeanwallace/test-auto-PR-1
-          git checkout upstream/jdeanwallace/test-auto-PR-1
-          git checkout -b temp-community-changes-${{ github.sha }}
+          git reset --hard upstream/jdeanwallace/test-auto-PR-1
           git merge origin/jdeanwallace/test-auto-PR-2 --no-edit --allow-unrelated-histories
           if [[ $? -ne 0 ]]; then
             git merge --abort

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -31,7 +31,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.PR_BOT_PAT }}
-          base: master
+          base: auto-PR
           branch: community-changes-${{ github.sha }}
           delete-branch: true
           # If the committer to the community repo (github.actor) has no access

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -22,7 +22,7 @@ jobs:
           set +e
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
           git fetch upstream jdeanwallace/test-auto-PR-1
-          git checkout -b temp-community-changes-${{ github.sha }} upstream/jdeanwallace/test-auto-PR-1
+          git checkout -b community-changes-${{ github.sha }} upstream/jdeanwallace/test-auto-PR-1
           git merge origin/jdeanwallace/test-auto-PR-2 --no-edit
           if [[ $? -ne 0 ]]; then
             git merge --abort

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: tiny-pilot/tinypilot-pro
+          ref: auto-PR
           token: ${{ secrets.PR_BOT_PAT }}
       - name: Set git config
         run: |

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -22,7 +22,7 @@ jobs:
           set +e
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
           git fetch upstream jdeanwallace/test-auto-PR-1
-          git checkout -b community-changes-${{ github.sha }} upstream/jdeanwallace/test-auto-PR-1
+          git checkout -b temp-community-changes-${{ github.sha }} upstream/jdeanwallace/test-auto-PR-1
           git merge origin/jdeanwallace/test-auto-PR-2 --no-edit
           if [[ $? -ne 0 ]]; then
             git merge --abort

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -21,7 +21,7 @@ jobs:
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
           git fetch upstream jdeanwallace/test-auto-PR-1
           git reset --hard upstream/jdeanwallace/test-auto-PR-1
-          git merge origin/master --no-edit --allow-unrelated-histories
+          git merge origin/master --no-edit
           if [[ $? -eq 1 ]]; then
             git merge --abort
             exit 0

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -22,7 +22,7 @@ jobs:
           set +e
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
           git fetch upstream jdeanwallace/test-auto-PR-1
-          git checkout -b community-changes-${{ github.sha }} upstream/jdeanwallace/test-auto-PR-1
+          git checkout --detach upstream/jdeanwallace/test-auto-PR-1
           git merge origin/jdeanwallace/test-auto-PR-2 --no-edit
           if [[ $? -ne 0 ]]; then
             git merge --abort

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: tiny-pilot/tinypilot-pro
-          ref: jdeanwallace/test-auto-PR-without-conflicts
+          ref: jdeanwallace/test-auto-PR-with-conflicts
           token: ${{ secrets.PR_BOT_PAT }}
       - name: Set git config
         run: |
@@ -22,7 +22,7 @@ jobs:
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
           git fetch upstream jdeanwallace/test-auto-PR-1
           git reset --hard upstream/jdeanwallace/test-auto-PR-1
-          git merge origin/jdeanwallace/test-auto-PR-without-conflicts --no-edit --allow-unrelated-histories
+          git merge origin/jdeanwallace/test-auto-PR-with-conflicts --no-edit --allow-unrelated-histories
           if [[ $? -ne 0 ]]; then
             git merge --abort
           fi
@@ -31,13 +31,13 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.PR_BOT_PAT }}
-          base: jdeanwallace/test-auto-PR-without-conflicts
+          base: jdeanwallace/test-auto-PR-with-conflicts
           branch: community-changes-${{ github.sha }}
           delete-branch: true
           # If the committer to the community repo (github.actor) has no access
           # to the pro repo, the PR will be unassigned.
           assignees: ${{ github.actor }}
-          title: Community changes jdeanwallace test without conflicts
+          title: Community changes jdeanwallace test with conflicts
           body: |
             Merge the last changes from community repository :
 

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -17,7 +17,7 @@ jobs:
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
           git fetch upstream jdeanwallace/test-auto-PR-1
           git checkout upstream/jdeanwallace/test-auto-PR-1
-          git merge origin/master --no-edit
+          git merge origin/master --no-edit --allow-unrelated-histories
           if [[ $? -eq 1 ]]; then
             git merge --abort
             exit 0

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -20,7 +20,7 @@ jobs:
           set +e
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
           git fetch upstream jdeanwallace/test-auto-PR-1
-          git checkout upstream/jdeanwallace/test-auto-PR-1
+          git reset --hard upstream/jdeanwallace/test-auto-PR-1
           git merge origin/master --no-edit --allow-unrelated-histories
           if [[ $? -eq 1 ]]; then
             git merge --abort

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: tiny-pilot/tinypilot-pro
-          ref: jdeanwallace/test-auto-PR-with-conflicts
+          ref: jdeanwallace/test-auto-PR-2
           token: ${{ secrets.PR_BOT_PAT }}
       - name: Set git config
         run: |
@@ -22,7 +22,7 @@ jobs:
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
           git fetch upstream jdeanwallace/test-auto-PR-1
           git reset --hard upstream/jdeanwallace/test-auto-PR-1
-          git merge origin/jdeanwallace/test-auto-PR-with-conflicts --no-edit --allow-unrelated-histories
+          git merge origin/jdeanwallace/test-auto-PR-2 --no-edit --allow-unrelated-histories
           if [[ $? -ne 0 ]]; then
             git merge --abort
           fi
@@ -31,13 +31,13 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.PR_BOT_PAT }}
-          base: jdeanwallace/test-auto-PR-with-conflicts
+          base: jdeanwallace/test-auto-PR-2
           branch: community-changes-${{ github.sha }}
           delete-branch: true
           # If the committer to the community repo (github.actor) has no access
           # to the pro repo, the PR will be unassigned.
           assignees: ${{ github.actor }}
-          title: Community changes jdeanwallace test with conflicts
+          title: Community changes jdeanwallace test
           body: |
             Merge the last changes from community repository :
 

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -21,7 +21,7 @@ jobs:
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
           git fetch upstream jdeanwallace/test-auto-PR-1
           git reset --hard upstream/jdeanwallace/test-auto-PR-1
-          git merge origin/master --no-edit
+          git merge origin/master --no-edit --allow-unrelated-histories
           if [[ $? -eq 1 ]]; then
             git merge --abort
             exit 0

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -11,6 +11,10 @@ jobs:
         with:
           repository: tiny-pilot/tinypilot-pro
           token: ${{ secrets.PR_BOT_PAT }}
+      - name: Set git config
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
       - name: Merge origin into upstream
         run: |
           set +e

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: tiny-pilot/tinypilot-pro
-          ref: jdeanwallace/test-auto-PR-2
+          ref: master
           fetch-depth: 0
           token: ${{ secrets.PR_BOT_PAT }}
       - name: Set git config
@@ -21,18 +21,14 @@ jobs:
         run: |
           set +e
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
-          git fetch upstream jdeanwallace/test-auto-PR-1
-          git checkout --detach upstream/jdeanwallace/test-auto-PR-1
-          git merge origin/jdeanwallace/test-auto-PR-2 --no-edit
-          if [[ $? -ne 0 ]]; then
-            git merge --abort
-          fi
-          exit $?
+          git fetch upstream master
+          git checkout upstream/master
+          git merge origin/master --no-edit || git merge --abort
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.PR_BOT_PAT }}
-          base: jdeanwallace/test-auto-PR-2
+          base: master
           branch: community-changes-${{ github.sha }}
           delete-branch: true
           # If the committer to the community repo (github.actor) has no access

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -26,7 +26,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.PR_BOT_PAT }}
-          base: master
+          base: auto-PR
           branch: community-changes-${{ github.sha }}
           delete-branch: true
           # If the committer to the community repo (github.actor) has no access

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -21,7 +21,8 @@ jobs:
           set +e
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
           git fetch upstream jdeanwallace/test-auto-PR-1
-          git reset --hard upstream/jdeanwallace/test-auto-PR-1
+          git checkout upstream/jdeanwallace/test-auto-PR-1
+          git checkout -b temp-community-changes-${{ github.sha }}
           git merge origin/jdeanwallace/test-auto-PR-2 --no-edit --allow-unrelated-histories
           if [[ $? -ne 0 ]]; then
             git merge --abort

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -23,9 +23,8 @@ jobs:
           git fetch upstream jdeanwallace/test-auto-PR-1
           git reset --hard upstream/jdeanwallace/test-auto-PR-1
           git merge origin/auto-PR --no-edit --allow-unrelated-histories
-          if [[ $? -eq 1 ]]; then
+          if [[ $? -ne 0 ]]; then
             git merge --abort
-            exit 0
           fi
           exit $?
       - name: Create Pull Request

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -23,6 +23,7 @@ jobs:
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
           git fetch upstream master
           git checkout upstream/master
+          git checkout -b community-changes-${{ github.sha }}
           git merge origin/master --no-edit || git merge --abort
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -26,6 +26,7 @@ jobs:
             git merge --abort
             exit 0
           fi
+          exit $?
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -22,7 +22,7 @@ jobs:
           set +e
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
           git fetch upstream jdeanwallace/test-auto-PR-1
-          git checkout upstream/jdeanwallace/test-auto-PR-1
+          git checkout -b community-changes-${{ github.sha }} upstream/jdeanwallace/test-auto-PR-1
           git merge origin/jdeanwallace/test-auto-PR-2 --no-edit
           if [[ $? -ne 0 ]]; then
             git merge --abort

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -37,7 +37,7 @@ jobs:
           # If the committer to the community repo (github.actor) has no access
           # to the pro repo, the PR will be unassigned.
           assignees: ${{ github.actor }}
-          title: Merge changes from community repository
+          title: Community changes jdeanwallace test
           body: |
             Merge the last changes from community repository :
 

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -21,7 +21,7 @@ jobs:
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
           git fetch upstream jdeanwallace/test-auto-PR-1
           git reset --hard upstream/jdeanwallace/test-auto-PR-1
-          git merge origin/master --no-edit --allow-unrelated-histories
+          git merge origin/auto-PR --no-edit --allow-unrelated-histories
           if [[ $? -eq 1 ]]; then
             git merge --abort
             exit 0

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -2,7 +2,7 @@ name: Merge community changes into pro repo
 on:
   push:
     branches:
-      - master
+      - jdeanwallace/test-auto-PR-1
 jobs:
   updateFork:
     runs-on: ubuntu-latest
@@ -11,22 +11,22 @@ jobs:
         with:
           repository: tiny-pilot/tinypilot-pro
           token: ${{ secrets.PR_BOT_PAT }}
-      - name: Reset the default branch with upstream changes
+      - name: Merge origin into upstream
         run: |
+          set +e
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
-          git checkout -b community-changes-${{ github.sha }}
-          git fetch upstream master
-          git merge upstream/master --no-edit
-          if [[ $? -eq 0 ]]; then
-            HAS_CONFLICTS='No'
-          else
-            HAS_CONFLICTS='Yes'
+          git fetch upstream jdeanwallace/test-auto-PR-1
+          git checkout upstream/jdeanwallace/test-auto-PR-1
+          git merge origin/master --no-edit
+          if [[ $? -eq 1 ]]; then
+            git merge --abort
+            exit 0
           fi
-          echo "has_conflicts="${HAS_CONFLICTS}"" >> "${GITHUB_ENV}"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.PR_BOT_PAT }}
+          base: master
           branch: community-changes-${{ github.sha }}
           delete-branch: true
           # If the committer to the community repo (github.actor) has no access
@@ -37,8 +37,6 @@ jobs:
             Merge the last changes from community repository :
 
             https://github.com/tiny-pilot/tinypilot/commit/${{ github.sha }}
-
-            Conflicts: ${{ env.has_conflicts }}
 
             **Do not use "Squash and merge" !**
             Merge this PR with a merge commit, keeping the commit history.

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: tiny-pilot/tinypilot-pro
-          ref: auto-PR
+          ref: jdeanwallace/test-auto-PR-without-conflicts
           token: ${{ secrets.PR_BOT_PAT }}
       - name: Set git config
         run: |
@@ -22,7 +22,7 @@ jobs:
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
           git fetch upstream jdeanwallace/test-auto-PR-1
           git reset --hard upstream/jdeanwallace/test-auto-PR-1
-          git merge origin/auto-PR --no-edit --allow-unrelated-histories
+          git merge origin/jdeanwallace/test-auto-PR-without-conflicts --no-edit --allow-unrelated-histories
           if [[ $? -ne 0 ]]; then
             git merge --abort
           fi
@@ -31,13 +31,13 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.PR_BOT_PAT }}
-          base: auto-PR
+          base: jdeanwallace/test-auto-PR-without-conflicts
           branch: community-changes-${{ github.sha }}
           delete-branch: true
           # If the committer to the community repo (github.actor) has no access
           # to the pro repo, the PR will be unassigned.
           assignees: ${{ github.actor }}
-          title: Community changes jdeanwallace test
+          title: Community changes jdeanwallace test without conflicts
           body: |
             Merge the last changes from community repository :
 

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -26,7 +26,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.PR_BOT_PAT }}
-          base: auto-PR
+          base: master
           branch: community-changes-${{ github.sha }}
           delete-branch: true
           # If the committer to the community repo (github.actor) has no access

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -11,6 +11,7 @@ jobs:
         with:
           repository: tiny-pilot/tinypilot-pro
           ref: jdeanwallace/test-auto-PR-2
+          fetch-depth: 0
           token: ${{ secrets.PR_BOT_PAT }}
       - name: Set git config
         run: |
@@ -21,8 +22,8 @@ jobs:
           set +e
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
           git fetch upstream jdeanwallace/test-auto-PR-1
-          git reset --hard upstream/jdeanwallace/test-auto-PR-1
-          git merge origin/jdeanwallace/test-auto-PR-2 --no-edit --allow-unrelated-histories
+          git checkout upstream/jdeanwallace/test-auto-PR-1
+          git merge origin/jdeanwallace/test-auto-PR-2 --no-edit
           if [[ $? -ne 0 ]]; then
             git merge --abort
           fi

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -14,8 +14,15 @@ jobs:
       - name: Reset the default branch with upstream changes
         run: |
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
-          git fetch upstream master:upstream-master
-          git reset --hard upstream-master
+          git checkout -b community-changes-${{ github.sha }}
+          git fetch upstream master
+          git merge upstream/master --no-edit
+          if [[ $? -eq 0 ]]; then
+            HAS_CONFLICTS='No'
+          else
+            HAS_CONFLICTS='Yes'
+          fi
+          echo "has_conflicts="${HAS_CONFLICTS}"" >> "${GITHUB_ENV}"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
@@ -30,6 +37,8 @@ jobs:
             Merge the last changes from community repository :
 
             https://github.com/tiny-pilot/tinypilot/commit/${{ github.sha }}
+
+            Conflicts: ${{ env.has_conflicts }}
 
             **Do not use "Squash and merge" !**
             Merge this PR with a merge commit, keeping the commit history.


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot-pro/issues/398

This PR revisits the way we auto-generate the PRs that keep `tinypilot-pro` up-to-date with `tinypilot` community changes by:
1. Auto-generating PRs in a more human-like way.

    We originally wanted to follow a git workflow like:

    ```bash
    git clone https://github.com/tiny-pilot/tinypilot-pro.git .
    git remote add upstream https://github.com/tiny-pilot/tinypilot.git
    git checkout -b merge-from-upstream
    git pull upstream
    # Resolve merge conflicts
    # Create PR
    ```

    However, the Github action we use to create PRs seems to only create a PR when the [git `HEAD` is reset to the upstream branch](https://github.com/tiny-pilot/tinypilot/blob/c7820aafd8243a07b265cb124218fb64a3eca342/.github/workflows/merge-pro.yml#L24) (like in their [usage example](https://github.com/peter-evans/create-pull-request/blob/main/docs/examples.md#keep-a-fork-up-to-date-with-its-upstream)).

1. Avoid creating [giant merge commits](https://github.com/tiny-pilot/tinypilot-pro/commit/f17df7c4cc31d555048e10a80be5bf9f6c9a2644) in auto-generated PRs.

   I'm not 100% sure why this works, but automatically merging the upstream changes (when there are no conflicts) seems to get rid of any giant merge commit. I tested this PR via a Github Action with and without merge conflicts:
    * With conflicts: https://github.com/tiny-pilot/tinypilot-pro/pull/472 
    * Without conflicts: https://github.com/tiny-pilot/tinypilot-pro/pull/471
       In this case we could cleanly auto merge inside the Github action. It still creates a merge commit (as expected), but once you click through to the [details of the commit it seems empty](https://github.com/tiny-pilot/tinypilot-pro/pull/471/commits/064ac3088085c4cd8bc8393074b488a53a433f71).

Notes:
1. This PR still references [test branches](https://github.com/tiny-pilot/tinypilot/blob/c7820aafd8243a07b265cb124218fb64a3eca342/.github/workflows/merge-pro.yml#L5). I'll remove it once we're happy with the current approach.
2. [I needed to set git config for the name and email address of the commit author](https://github.com/tiny-pilot/tinypilot/blob/c7820aafd8243a07b265cb124218fb64a3eca342/.github/workflows/merge-pro.yml#L15-L18) before I was [allowed to commit changes (via a merge)](https://github.com/tiny-pilot/tinypilot/runs/6861825830?check_suite_focus=true#step:3:45). I just copied what [our Github Action already does here](https://github.com/tiny-pilot/tinypilot/runs/6918574431?check_suite_focus=true#step:5:48).
3. I needed to add the [`--allow-unrelated-histories` flag to the merge](https://github.com/tiny-pilot/tinypilot/blob/c7820aafd8243a07b265cb124218fb64a3eca342/.github/workflows/merge-pro.yml#L25) otherwise it would [fail](https://github.com/tiny-pilot/tinypilot/runs/6831108920?check_suite_focus=true#step:4:18):
    ```bash
    fatal: refusing to merge unrelated histories
    ```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/984)
<!-- Reviewable:end -->
