### PR TITLE
Add logic for building TinyPilot install bundles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           command: apt-get update && apt-get install -y git libffi-dev libssl-dev python3-dev python3-venv wget
       - run:
           name: Create the bundle
-          command: cd budler && ./create-bundle
+          command: cd bundler && ./create-bundle
       - store_artifacts:
           path: bundler/dist/
   e2e:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           command: apt-get update && apt-get install -y git libffi-dev libssl-dev python3-dev python3-venv wget
       - run:
           name: Create the bundle
-          command: ./bundler/create-bundle
+          command: cd budler && ./create-bundle
       - store_artifacts:
           path: bundler/dist/
   e2e:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,19 @@ jobs:
       - run:
           name: Run build script
           command: ./dev-scripts/build-javascript
+  build_bundle:
+    docker:
+      - image: debian:buster-20220527
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: apt-get update && apt-get install -y git libffi-dev libssl-dev python3-dev python3-venv wget
+      - run:
+          name: Create the bundle
+          command: ./bundler/create-bundle
+      - store_artifacts:
+          path: bundler/dist/
   e2e:
     machine:
       image: ubuntu-2004:202010-01
@@ -63,6 +76,7 @@ workflows:
       - check_bash
       - build_python
       - build_javascript
+      - build_bundle
       - e2e:
           filters:
             branches:

--- a/bundler/.gitignore
+++ b/bundler/.gitignore
@@ -1,0 +1,6 @@
+# Dynamic dependencies from dist/ folder.
+/bundle/tinypilot
+/bundle/ansible-role-*
+
+# Build artifacts.
+/dist

--- a/bundler/bundle/ansible.cfg
+++ b/bundler/bundle/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+roles_path = $PWD
+interpreter_python = /usr/bin/python3

--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# Installs TinyPilot and all dependencies.
+
+# Exit on first error.
+set -e
+
+# Exit on unset variable.
+set -u
+
+# Echo commands to stdout.
+set -x
+
+# shellcheck disable=SC1091 # Don’t follow sourced script.
+. lib.sh
+
+# Temporary file for installation settings.
+readonly INSTALL_SETTINGS_FILE='settings.yml'
+
+# The eventual, permanent settings files. Note, that these might not exist
+# yet before Ansible has run for the very first time.
+readonly TINYPILOT_SETTINGS_FILE='/home/tinypilot/settings.yml'
+readonly USTREAMER_SETTINGS_FILE='/home/ustreamer/config.yml'
+
+# The filename of the TinyPilot Debian package.
+TINYPILOT_DEBIAN_PACKAGE="$(ls tinypilot*.deb)"
+readonly TINYPILOT_DEBIAN_PACKAGE
+
+# Prevent installation on the 64-bit version of Raspberry Pi OS.
+# https://github.com/tiny-pilot/tinypilot/issues/929
+if [[ "$(uname -m)" == 'aarch64' && "$(lsb_release --id --short)" == 'Debian' ]]; then
+  echo '64-bit Raspberry Pi OS is not yet supported.' >&2
+  echo 'Please use the 32-bit version of Raspberry Pi OS.' >&2
+  exit 1
+fi
+
+# Check if there's already a settings file with extra installation settings.
+if [[ -f "${TINYPILOT_SETTINGS_FILE}" ]]; then
+  echo "Using settings file at: ${TINYPILOT_SETTINGS_FILE}"
+  cp "${TINYPILOT_SETTINGS_FILE}" "${INSTALL_SETTINGS_FILE}"
+else
+  echo "No pre-existing settings file found at: ${TINYPILOT_SETTINGS_FILE}"
+fi
+
+# Set default installation settings
+yaml_set_if_undefined "${INSTALL_SETTINGS_FILE}" "ustreamer_port" "8001"
+yaml_set_if_undefined "${INSTALL_SETTINGS_FILE}" "ustreamer_persistent" "true"
+
+# Check if this system uses the TC358743 HDMI to CSI capture bridge.
+USE_TC358743_DEFAULTS=false
+if grep --silent "^ustreamer_capture_device:" "${INSTALL_SETTINGS_FILE}"; then
+  if grep --silent "^ustreamer_capture_device: tc358743$" "${INSTALL_SETTINGS_FILE}"; then
+    USE_TC358743_DEFAULTS=true
+  fi
+# Only check the existing config file if user has not set
+# ustreamer_capture_device install variable.
+elif [ -f "${USTREAMER_SETTINGS_FILE}" ] \
+     && grep --silent 'capture_device: "tc358743"' "${USTREAMER_SETTINGS_FILE}"; then
+  USE_TC358743_DEFAULTS=true
+fi
+
+# Write uStreamer settings.
+if "${USE_TC358743_DEFAULTS}"; then
+  yaml_set_if_undefined "${INSTALL_SETTINGS_FILE}" "ustreamer_encoder" "omx"
+  yaml_set_if_undefined "${INSTALL_SETTINGS_FILE}" "ustreamer_format" "uyvy"
+  yaml_set_if_undefined "${INSTALL_SETTINGS_FILE}" "ustreamer_workers" "3"
+  yaml_set_if_undefined "${INSTALL_SETTINGS_FILE}" "ustreamer_use_dv_timings" "true"
+  yaml_set_if_undefined "${INSTALL_SETTINGS_FILE}" "ustreamer_drop_same_frames" "30"
+else
+  # If this system does not use a TC358743 capture chip, assume defaults for a
+  # MacroSilicon MS2109-based HDMI-to-USB capture dongle.
+  yaml_set_if_undefined "${INSTALL_SETTINGS_FILE}" "ustreamer_encoder" "hw"
+  yaml_set_if_undefined "${INSTALL_SETTINGS_FILE}" "ustreamer_format" "jpeg"
+  yaml_set_if_undefined "${INSTALL_SETTINGS_FILE}" "ustreamer_resolution" "1920x1080"
+fi
+
+echo "Final install settings:"
+cat "${INSTALL_SETTINGS_FILE}"
+
+# Bootstrap environment for installation.
+apt-get update --allow-releaseinfo-change-suite
+apt-get install -y \
+  git \
+  libffi-dev \
+  libssl-dev \
+  python3-dev \
+  python3-venv
+
+python3 -m venv venv
+# shellcheck disable=SC1091 # Don’t follow sourced script.
+. venv/bin/activate
+pip install pip==21.3.1
+pip install -r requirements.txt
+
+# Run Ansible.
+ansible-playbook \
+  --inventory localhost, \
+  install.yml \
+  --extra-vars "@${INSTALL_SETTINGS_FILE}" \
+  --extra-vars "tinypilot_debian_package_path=${PWD}/${TINYPILOT_DEBIAN_PACKAGE}"
+
+# Persist installation settings.
+cp "${INSTALL_SETTINGS_FILE}" "${TINYPILOT_SETTINGS_FILE}"
+chown tinypilot:tinypilot "${TINYPILOT_SETTINGS_FILE}"

--- a/bundler/bundle/install.yml
+++ b/bundler/bundle/install.yml
@@ -1,0 +1,6 @@
+- hosts: localhost
+  connection: local
+  become: true
+  become_method: sudo
+  roles:
+    - role: ansible-role-tinypilot

--- a/bundler/bundle/lib.sh
+++ b/bundler/bundle/lib.sh
@@ -1,0 +1,17 @@
+#######################################
+# Adds a setting to the YAML settings file, if it's not yet defined.
+# Arguments:
+#   Path of target file.
+#   Key to define.
+#   Value to set.
+# Outputs:
+#   The line appended to the settings file, if the variable wasn't yet defined.
+#######################################
+yaml_set_if_undefined() {
+  local file_path="$1"
+  local key="$2"
+  local value="$3"
+  if ! grep --silent "^${key}:" "${file_path}"; then
+    echo "${key}: ${value}" | tee --append "${file_path}"
+  fi
+}

--- a/bundler/bundle/requirements.txt
+++ b/bundler/bundle/requirements.txt
@@ -1,0 +1,13 @@
+# Minimal set of dependencies to bootstrap an Ansible virtualenv.
+# When modifying dependencies, update the credit in /app/license_notice.py
+
+ansible==2.9.10
+cffi==1.14.4
+cryptography==35.0.0
+Jinja2==2.11.2
+MarkupSafe==1.1.1
+pkg-resources==0.0.0
+pycparser==2.20
+pyOpenSSL==20.0.1
+PyYAML==5.3.1
+six==1.15.0

--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -30,20 +30,18 @@ pushd "${BUNDLE_DIR}"
 
 wget "${PKG_URL_TINYPILOT}"
 
-git clone \
-  --depth 1 \
-  --branch master \
-  "${REPO_ANSIBLE_TINYPILOT}"
-
-git clone \
-  --depth 1 \
-  --branch master \
-  "${REPO_ANSIBLE_NGINX}"
-
-git clone \
-  --depth 1 \
-  --branch master \
-  "${REPO_ANSIBLE_USTREAMER}"
+# Copy each Ansible role dependency into the bundle and add a version file.
+for GIT_URL in $REPO_ANSIBLE_TINYPILOT $REPO_ANSIBLE_NGINX $REPO_ANSIBLE_USTREAMER
+do
+  git clone \
+    --depth 1 \
+    --branch master \
+    "${GIT_URL}"
+  FOLDER_NAME="$(echo "${GIT_URL}" | sed 's|https://github.com/tiny-pilot/||' | sed 's|.git||')"
+  pushd "${FOLDER_NAME}"
+  git rev-parse --short HEAD > VERSION
+  popd
+done
 
 # Remove all `.git/` folders.
 find . \

--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Creates a TinyPilot installation bundle from the bundle/ folder.
+# Fetches all required dependencies automatically.
+
+# Exit on first error.
+set -e
+
+# Exit on unset variable.
+set -u
+
+# Echo commands to stdout.
+set -x
+
+# TODO (jotaen): parameterize script to make the installation work for
+#                TinyPilot Pro as well.
+
+# TODO: Adjust the workflow so that we build Debian packages as part of the same
+# workflow on the same system that we build the bundle so that we don't have to
+# retrieve the Debian package file from a remote URL.
+readonly PKG_URL_TINYPILOT='https://packages.tinypilotkvm.com/community/tinypilot-1.7.1-1-armhf.deb'
+readonly REPO_ANSIBLE_TINYPILOT='https://github.com/tiny-pilot/ansible-role-tinypilot.git'
+readonly REPO_ANSIBLE_NGINX='https://github.com/tiny-pilot/ansible-role-nginx'
+readonly REPO_ANSIBLE_USTREAMER='https://github.com/tiny-pilot/ansible-role-ustreamer'
+
+readonly BUNDLE_DIR='bundle'
+readonly OUTPUT_DIR='dist'
+
+pushd "${BUNDLE_DIR}"
+
+wget "${PKG_URL_TINYPILOT}"
+
+git clone \
+  --depth 1 \
+  --branch master \
+  "${REPO_ANSIBLE_TINYPILOT}"
+
+git clone \
+  --depth 1 \
+  --branch master \
+  "${REPO_ANSIBLE_NGINX}"
+
+git clone \
+  --depth 1 \
+  --branch master \
+  "${REPO_ANSIBLE_USTREAMER}"
+
+# Remove all `.git/` folders.
+find . \
+  -type d \
+  -name .git \
+  -prune \
+  -exec rm -rf {} \;
+
+popd
+
+# Generate build output.
+mkdir -p "${OUTPUT_DIR}"
+ls -lahR "${BUNDLE_DIR}" > "${OUTPUT_DIR}/files.txt"
+tar \
+  --create \
+  --file "${OUTPUT_DIR}/tinypilot.tar" \
+  --directory "${BUNDLE_DIR}" \
+  .

--- a/bundler/get-tinypilot.sh
+++ b/bundler/get-tinypilot.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# “Mock” version of the eventual `get-tinypilot.sh` script.
+# Instead of downloading the installation bundle on the fly, it expects a
+# tarball named `tinypilot.tar` to be present in the same directory.
+
+# Exit on first error.
+set -e
+
+# Exit on unset variable.
+set -u
+
+# Echo commands to stdout.
+set -x
+
+TEMP_FOLDER="$(mktemp -d)"
+readonly TEMP_FOLDER
+
+# Extract tarball to temporary folder and run install.
+tar \
+  --extract \
+  --file tinypilot.tar \
+  --directory "${TEMP_FOLDER}"
+pushd "${TEMP_FOLDER}"
+chmod +x install
+./install
+popd
+
+# Clean up.
+rm -rf "${TEMP_FOLDER}"


### PR DESCRIPTION
This merges the https://github.com/tiny-pilot/tinypilot-bundler repo into this repo, per discussion in https://github.com/tiny-pilot/tinypilot-bundler/issues/19.

Changes:

* Changed paths to reflect the placement within the new repo.
* Deleted the README
* Deleted the `dev-scripts` folder as the same scripts already existed in this repo.
* Deleted the `check_bash` and `check_whitespace` CircleCI jobs as they already existed in this repo.

After we merge this in, the tinypilot-bundler repo will become obsolete and we'll mark it as read-only.

Fixes https://github.com/tiny-pilot/tinypilot-bundler/issues/19

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/986)
<!-- Reviewable:end -->
