### PR TITLE
Upload completed bundle to Backblaze

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,18 @@ jobs:
           command: cd bundler && ./create-bundle
       - store_artifacts:
           path: bundler/dist/
+      - persist_to_workspace:
+          root: ./bundler
+          paths:
+            - ./dist
+  upload_bundle:
+    docker:
+      - image: debian:buster-20220527
+    steps:
+      - attach_workspace:
+          at: ./
+      - run:
+          command: ls -l
   e2e:
     machine:
       image: ubuntu-2004:202010-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,9 @@ workflows:
       - build_python
       - build_javascript
       - build_bundle
+      - upload_bundle:
+          requires:
+            - build_bundle
       - e2e:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,14 @@ jobs:
           at: ./
       - run:
           command: ls -l
+      - run:
+          name: download Backblaze CLI tool
+          command: |
+            apt-get update && apt-get install -y wget
+            wget https://github.com/Backblaze/B2_Command_Line_Tool/releases/download/v3.4.0/b2-linux
+            chmod +x ./b2-linux
+            ./b2-linux version
+
   e2e:
     machine:
       image: ubuntu-2004:202010-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           command: ./dev-scripts/build-javascript
   build_bundle:
     docker:
-      - image: debian:buster-20220527
+      - image: cimg/base:2020.01
     steps:
       - checkout
       - run:
@@ -67,15 +67,16 @@ jobs:
             - ./dist
   upload_bundle:
     docker:
-      - image: debian:buster-20220527
+      - image: cimg/base:2020.01
     environment:
       UPLOAD_PATH: community/
+    working_directory: /workspace/dist
     steps:
       - attach_workspace:
-          at: ./dist
+          at: /workpsace
       - run:
           name: create LATEST file
-          command: echo "$(ls tinypilot*.deb)" > LATEST
+          command: echo "$(ls tinypilot*.tar)" > LATEST
       - run:
           name: download Backblaze CLI tool
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,12 +50,12 @@ jobs:
           command: ./dev-scripts/build-javascript
   build_bundle:
     docker:
-      - image: cimg/base:2020.01
+      - image: debian:buster-20220527
     steps:
       - checkout
       - run:
           name: Install dependencies
-          command: sudo apt-get update && sudo apt-get install -y git libffi-dev libssl-dev python3-dev python3-venv wget
+          command: apt-get update && apt-get install -y git libffi-dev libssl-dev python3-dev python3-venv wget
       - run:
           name: Create the bundle
           command: cd bundler && ./create-bundle
@@ -74,22 +74,24 @@ jobs:
       - attach_workspace:
           at: ./
       - run:
-          name: create LATEST file
+          # The LATEST file contains the filename of the latest TinyPilot
+          # bundle.
+          name: Create LATEST file
           command: cd dist && ls tinypilot*.tar | tee LATEST
       - run:
-          name: download Backblaze CLI tool
+          name: Download Backblaze CLI tool
           command: |
             sudo apt-get update && sudo apt-get install -y wget
             wget https://github.com/Backblaze/B2_Command_Line_Tool/releases/download/v3.4.0/b2-linux --output-document=b2
             chmod +x ./b2
             ./b2 version
       - run:
-          name: authorize Backblaze CLI tool
+          name: Authorize Backblaze CLI tool
           command: |
             set -u
             ./b2 authorize-account "${BACKBLAZE_KEY_ID}" "${BACKBLAZE_KEY}"
       - run:
-          name: upload bundle to Backblaze
+          name: Upload bundle to Backblaze
           command: |
             set -u
             BUNDLE_FILENAME="$(cat dist/LATEST)"
@@ -100,7 +102,7 @@ jobs:
               "${UPLOAD_PATH}/${BUNDLE_FILENAME}" \
               > /dev/null # Hide output to avoid exposing bucket details in CI.
       - run:
-          name: update LATEST file to Backblaze
+          name: Update LATEST file to Backblaze
           command: |
             set -u
             ./b2 upload-file \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - checkout
       - run:
           name: Install dependencies
-          command: apt-get update && apt-get install -y git libffi-dev libssl-dev python3-dev python3-venv wget
+          command: sudo apt-get update && sudo apt-get install -y git libffi-dev libssl-dev python3-dev python3-venv wget
       - run:
           name: Create the bundle
           command: cd bundler && ./create-bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,15 +70,14 @@ jobs:
       - image: cimg/base:2020.01
     environment:
       UPLOAD_PATH: community/
-    working_directory: /home/circleci/dist
     steps:
       - attach_workspace:
-          at: ./dist
+          at: ./
       - run: # DEBUG
-          command: pwd && ls -l
+          command: cd dist && pwd && ls -l
       - run:
           name: create LATEST file
-          command: ls tinypilot*.tar | tee LATEST
+          command: cd dist && ls tinypilot*.tar | tee LATEST
       - run:
           name: download Backblaze CLI tool
           command: |
@@ -91,10 +90,10 @@ jobs:
           command: ./b2 authorize-account "${BACKBLAZE_KEY_ID}" "${BACKBLAZE_KEY}"
       - run:
           name: upload bundle to Backblaze
-          command: ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" "$(cat LATEST)" "${UPLOAD_PATH}/"
+          command: ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" "dist/$(cat dist/LATEST)" "${UPLOAD_PATH}/"
       - run:
           name: update LATEST file in bucket
-          command: ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" LATEST "${UPLOAD_PATH}/"
+          command: ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" dist/LATEST "${UPLOAD_PATH}/"
   e2e:
     machine:
       image: ubuntu-2004:202010-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,9 @@ jobs:
             ./b2 version
       - run:
           name: authorize Backblaze CLI tool
-          command: set -u && ./b2 authorize-account "${BACKBLAZE_KEY_ID}" "${BACKBLAZE_KEY}"
+          command: |
+            set -u
+            ./b2 authorize-account "${BACKBLAZE_KEY_ID}" "${BACKBLAZE_KEY}"
       - run:
           name: upload bundle to Backblaze
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,8 @@ jobs:
       - run:
           name: create LATEST file
           command: cd dist && ls tinypilot*.tar | tee LATEST
+      - run: # DEBUG
+          command: set -u BUNDLE_FILENAME="$(cat dist/LATEST)" echo "bundle=${BUNDLE_FILENAME}"
       - run:
           name: download Backblaze CLI tool
           command: |
@@ -87,13 +89,13 @@ jobs:
             ./b2 version
       - run:
           name: authorize Backblaze CLI tool
-          command: ./b2 authorize-account "${BACKBLAZE_KEY_ID}" "${BACKBLAZE_KEY}"
+          command: set -u ./b2 authorize-account "${BACKBLAZE_KEY_ID}" "${BACKBLAZE_KEY}"
       - run:
           name: upload bundle to Backblaze
-          command: BUNDLE_FILENAME="$(cat dist/LATEST)" ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" "dist/${BUNDLE_FILENAME}" "${UPLOAD_PATH}/${BUNDLE_FILENAME}"
+          command: set -u BUNDLE_FILENAME="$(cat dist/LATEST)" ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" "dist/${BUNDLE_FILENAME}" "${UPLOAD_PATH}/${BUNDLE_FILENAME}"
       - run:
           name: update LATEST file in bucket
-          command: ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" dist/LATEST "${UPLOAD_PATH}/LATEST"
+          command: set -u ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" dist/LATEST "${UPLOAD_PATH}/LATEST"
   e2e:
     machine:
       image: ubuntu-2004:202010-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
     docker:
       - image: cimg/base:2020.01
     environment:
-      UPLOAD_PATH: community/
+      UPLOAD_PATH: community
     steps:
       - attach_workspace:
           at: ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,11 @@ jobs:
     steps:
       - attach_workspace:
           at: ./dist
+      - run: # DEBUG
+          command: pwd && ls -l
       - run:
           name: create LATEST file
-          command: echo "$(ls tinypilot*.tar)" | tee LATEST
+          command: set -x echo "$(ls tinypilot*.tar)" | tee LATEST
       - run:
           name: download Backblaze CLI tool
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
           command: pwd && ls -l
       - run:
           name: create LATEST file
-          command: set -x echo "$(ls tinypilot*.tar)" | tee LATEST
+          command: ls tinypilot*.tar | tee LATEST
       - run:
           name: download Backblaze CLI tool
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,13 +73,9 @@ jobs:
     steps:
       - attach_workspace:
           at: ./
-      - run: # DEBUG
-          command: cd dist && pwd && ls -l
       - run:
           name: create LATEST file
           command: cd dist && ls tinypilot*.tar | tee LATEST
-      - run: # DEBUG
-          command: set -u && BUNDLE_FILENAME="$(cat dist/LATEST)" && echo "bundle=${BUNDLE_FILENAME}"
       - run:
           name: download Backblaze CLI tool
           command: |
@@ -97,12 +93,28 @@ jobs:
           command: |
             set -u
             BUNDLE_FILENAME="$(cat dist/LATEST)"
-            ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" "dist/${BUNDLE_FILENAME}" "${UPLOAD_PATH}/${BUNDLE_FILENAME}"
+            ./b2 upload-file \
+              --noProgress \
+              "${UPLOAD_BUCKET}" \
+              "dist/${BUNDLE_FILENAME}" \
+              "${UPLOAD_PATH}/${BUNDLE_FILENAME}" \
+              > /dev/null # Hide output to avoid exposing bucket details in CI.
       - run:
           name: update LATEST file to Backblaze
           command: |
             set -u
-            ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" dist/LATEST "${UPLOAD_PATH}/LATEST"
+            ./b2 upload-file \
+              --noProgress \
+              "${UPLOAD_BUCKET}" \
+              dist/LATEST \
+              "${UPLOAD_PATH}/LATEST" \
+              > /dev/null # Hide output to avoid exposing bucket details in CI.
+      - run:
+          name: Print friendly upload URL
+          command: |
+            set -u
+            BUNDLE_FILENAME="$(cat dist/LATEST)"
+            echo "Upload complete to https://bundles.tinypilotkvm.com/${UPLOAD_PATH}/${BUNDLE_FILENAME}"
   e2e:
     machine:
       image: ubuntu-2004:202010-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,10 +70,10 @@ jobs:
       - image: cimg/base:2020.01
     environment:
       UPLOAD_PATH: community/
-    working_directory: /workspace/dist
+    working_directory: /tmp/workspace/dist
     steps:
       - attach_workspace:
-          at: /workpsace
+          at: /tmp/workpsace
       - run:
           name: create LATEST file
           command: echo "$(ls tinypilot*.tar)" > LATEST

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
           name: Download Backblaze CLI tool
           command: |
             sudo apt-get update && sudo apt-get install -y wget
-            wget https://github.com/Backblaze/B2_Command_Line_Tool/releases/download/v3.4.0/b2-linux --output-document=b2
+            wget https://github.com/Backblaze/B2_Command_Line_Tool/releases/download/v3.4.0/b2-linux --output-document=./b2
             chmod +x ./b2
             ./b2 version
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
             BUNDLE_FILENAME="$(cat dist/LATEST)"
             ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" "dist/${BUNDLE_FILENAME}" "${UPLOAD_PATH}/${BUNDLE_FILENAME}"
       - run:
-          name: update LATEST file in bucket
+          name: update LATEST file to Backblaze
           command: |
             set -u
             ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" dist/LATEST "${UPLOAD_PATH}/LATEST"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           name: create LATEST file
           command: cd dist && ls tinypilot*.tar | tee LATEST
       - run: # DEBUG
-          command: set -u && BUNDLE_FILENAME="$(cat dist/LATEST)" echo "bundle=${BUNDLE_FILENAME}"
+          command: set -u && BUNDLE_FILENAME="$(cat dist/LATEST)" && echo "bundle=${BUNDLE_FILENAME}"
       - run:
           name: download Backblaze CLI tool
           command: |
@@ -92,10 +92,15 @@ jobs:
           command: set -u && ./b2 authorize-account "${BACKBLAZE_KEY_ID}" "${BACKBLAZE_KEY}"
       - run:
           name: upload bundle to Backblaze
-          command: set -u && BUNDLE_FILENAME="$(cat dist/LATEST)" ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" "dist/${BUNDLE_FILENAME}" "${UPLOAD_PATH}/${BUNDLE_FILENAME}"
+          command: |
+            set -u
+            BUNDLE_FILENAME="$(cat dist/LATEST)"
+            ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" "dist/${BUNDLE_FILENAME}" "${UPLOAD_PATH}/${BUNDLE_FILENAME}"
       - run:
           name: update LATEST file in bucket
-          command: set -u && ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" dist/LATEST "${UPLOAD_PATH}/LATEST"
+          command: |
+            set -u
+            ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" dist/LATEST "${UPLOAD_PATH}/LATEST"
   e2e:
     machine:
       image: ubuntu-2004:202010-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
           name: Create the bundle
           command: cd bundler && ./create-bundle
       - store_artifacts:
-          path: bundler/dist/
+          path: bundler/dist/files.txt
       - persist_to_workspace:
           root: ./bundler
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,19 +68,30 @@ jobs:
   upload_bundle:
     docker:
       - image: debian:buster-20220527
+    environment:
+      UPLOAD_PATH: community/
     steps:
       - attach_workspace:
-          at: ./
+          at: ./dist
       - run:
-          command: ls -l
+          name: create LATEST file
+          command: echo "$(ls tinypilot*.deb)" > LATEST
       - run:
           name: download Backblaze CLI tool
           command: |
             apt-get update && apt-get install -y wget
-            wget https://github.com/Backblaze/B2_Command_Line_Tool/releases/download/v3.4.0/b2-linux
-            chmod +x ./b2-linux
-            ./b2-linux version
-
+            wget https://github.com/Backblaze/B2_Command_Line_Tool/releases/download/v3.4.0/b2-linux --output-document=b2
+            chmod +x ./b2
+            ./b2 version
+      - run:
+          name: authorize Backblaze CLI tool
+          command: ./b2 authorize-account "${BACKBLAZE_KEY_ID}" "${BACKBLAZE_KEY}"
+      - run:
+          name: upload bundle to Backblaze
+          command: ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" "$(cat LATEST)" "${UPLOAD_PATH}/"
+      - run:
+          name: update LATEST file in bucket
+          command: ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" LATEST "${UPLOAD_PATH}/"
   e2e:
     machine:
       image: ubuntu-2004:202010-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,10 +90,10 @@ jobs:
           command: ./b2 authorize-account "${BACKBLAZE_KEY_ID}" "${BACKBLAZE_KEY}"
       - run:
           name: upload bundle to Backblaze
-          command: ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" "dist/$(cat dist/LATEST)" "${UPLOAD_PATH}/"
+          command: BUNDLE_FILENAME="$(cat dist/LATEST)" ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" "dist/${BUNDLE_FILENAME}" "${UPLOAD_PATH}/${BUNDLE_FILENAME}"
       - run:
           name: update LATEST file in bucket
-          command: ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" dist/LATEST "${UPLOAD_PATH}/"
+          command: ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" dist/LATEST "${UPLOAD_PATH}/LATEST"
   e2e:
     machine:
       image: ubuntu-2004:202010-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           name: create LATEST file
           command: cd dist && ls tinypilot*.tar | tee LATEST
       - run: # DEBUG
-          command: set -u BUNDLE_FILENAME="$(cat dist/LATEST)" echo "bundle=${BUNDLE_FILENAME}"
+          command: set -u && BUNDLE_FILENAME="$(cat dist/LATEST)" echo "bundle=${BUNDLE_FILENAME}"
       - run:
           name: download Backblaze CLI tool
           command: |
@@ -89,13 +89,13 @@ jobs:
             ./b2 version
       - run:
           name: authorize Backblaze CLI tool
-          command: set -u ./b2 authorize-account "${BACKBLAZE_KEY_ID}" "${BACKBLAZE_KEY}"
+          command: set -u && ./b2 authorize-account "${BACKBLAZE_KEY_ID}" "${BACKBLAZE_KEY}"
       - run:
           name: upload bundle to Backblaze
-          command: set -u BUNDLE_FILENAME="$(cat dist/LATEST)" ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" "dist/${BUNDLE_FILENAME}" "${UPLOAD_PATH}/${BUNDLE_FILENAME}"
+          command: set -u && BUNDLE_FILENAME="$(cat dist/LATEST)" ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" "dist/${BUNDLE_FILENAME}" "${UPLOAD_PATH}/${BUNDLE_FILENAME}"
       - run:
           name: update LATEST file in bucket
-          command: set -u ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" dist/LATEST "${UPLOAD_PATH}/LATEST"
+          command: set -u && ./b2 upload-file --noProgress "${UPLOAD_BUCKET}" dist/LATEST "${UPLOAD_PATH}/LATEST"
   e2e:
     machine:
       image: ubuntu-2004:202010-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,13 +70,13 @@ jobs:
       - image: cimg/base:2020.01
     environment:
       UPLOAD_PATH: community/
-    working_directory: /tmp/workspace/dist
+    working_directory: /home/circleci/dist
     steps:
       - attach_workspace:
-          at: /tmp/workpsace
+          at: ./dist
       - run:
           name: create LATEST file
-          command: echo "$(ls tinypilot*.tar)" > LATEST
+          command: echo "$(ls tinypilot*.tar)" | tee LATEST
       - run:
           name: download Backblaze CLI tool
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
       - run:
           name: download Backblaze CLI tool
           command: |
-            apt-get update && apt-get install -y wget
+            sudo apt-get update && sudo apt-get install -y wget
             wget https://github.com/Backblaze/B2_Command_Line_Tool/releases/download/v3.4.0/b2-linux --output-document=b2
             chmod +x ./b2
             ./b2 version


### PR DESCRIPTION
Add a CircleCI job to upload completed builds to our storage bucket on Backblaze.

Currently, our bundles are always named `tinypilot.tar`, so we'll keep overwriting the same file. The upload logic uses wildcard matching so that once we [change the bundle names](https://github.com/tiny-pilot/tinypilot-bundler/issues/9), this will start uploading bundles to distinct locations and shouldn't need to be updated.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/990)
<!-- Reviewable:end -->
