### PR TITLE
Use the CircleCI base convenience image for build_bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,12 +50,12 @@ jobs:
           command: ./dev-scripts/build-javascript
   build_bundle:
     docker:
-      - image: debian:buster-20220527
+      - image: cimg/base:2020.01
     steps:
       - checkout
       - run:
           name: Install dependencies
-          command: apt-get update && apt-get install -y git libffi-dev libssl-dev python3-dev python3-venv wget
+          command: sudo apt-get update && sudo apt-get install -y git libffi-dev libssl-dev python3-dev python3-venv wget
       - run:
           name: Create the bundle
           command: cd bundler && ./create-bundle


### PR DESCRIPTION
Our convention is to default to the CircleCI base image when we don't need anything specific in the Docker image, so this changes the build_bundle CI step to use cimg/base.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/991)
<!-- Reviewable:end -->
