### PR TITLE
Add richer information into the bundle filename

### DIFF
--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -26,9 +26,34 @@ readonly REPO_ANSIBLE_USTREAMER='https://github.com/tiny-pilot/ansible-role-ustr
 readonly BUNDLE_DIR='bundle'
 readonly OUTPUT_DIR='dist'
 
+# Temporary workaround for applying the right naming schema to the TinyPilot
+# Debian package. We should fold this naming logic into the workflow for
+# creating the Debian package in
+# https://github.com/tiny-pilot/tinypilot-bundler/issues/9.
+rename_bundle_file() {
+  # The filename of the TinyPilot Debian package.
+  OLD_TINYPILOT_DEBIAN_PACKAGE="$(ls tinypilot*.deb)"
+  local OLD_TINYPILOT_DEBIAN_PACKAGE
+
+  # TODO: Move the package naming
+  TIMESTAMP="$(date --iso-8601=minutes | sed 's/://g' | sed 's/+0000/Z/g')"
+  local TIMESTAMP
+  BUILD_VERSION="$(git rev-parse --short HEAD)"
+  local BUILD_VERSION
+
+  local NEW_TINYPILOT_DEBIAN_PACKAGE="tinypilot-${TIMESTAMP}-${BUILD_VERSION}.deb"
+
+  mv "${OLD_TINYPILOT_DEBIAN_PACKAGE}" "${NEW_TINYPILOT_DEBIAN_PACKAGE}"
+  echo "${NEW_TINYPILOT_DEBIAN_PACKAGE}"
+}
+
 pushd "${BUNDLE_DIR}"
 
+# TODO: Remove this wget and rename once we're creating the Debian package in
+# the same workflow as the bundle.
+# https://github.com/tiny-pilot/tinypilot-bundler/issues/9
 wget "${PKG_URL_TINYPILOT}"
+TINYPILOT_DEBIAN_PACKAGE=rename_bundle_file
 
 # Copy each Ansible role dependency into the bundle and add a version file.
 for GIT_URL in $REPO_ANSIBLE_TINYPILOT $REPO_ANSIBLE_NGINX $REPO_ANSIBLE_USTREAMER
@@ -52,11 +77,9 @@ find . \
 
 popd
 
-# TODO: Create the build string when we generate the Debian package, and then
-# make the bundle filename just s/\.deb/\.tar/g from the Debian package.
-TIMESTAMP="$(date --iso-8601=minutes | sed 's/://g' | sed 's/+0000/Z/g')"
-BUILD_VERSION="$(git rev-parse --short HEAD)"
-BUNDLE_FILENAME="tinypilot-${TIMESTAMP}-${BUILD_VERSION}.tar"
+# Make the bundle filename the same as the Debian package but with a different
+# file extension.
+BUNDLE_FILENAME="${TINYPILOT_DEBIAN_PACKAGE//.deb/.tar}"
 readonly BUNDLE_FILENAME
 
 # Generate build output.

--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -52,11 +52,18 @@ find . \
 
 popd
 
+# TODO: Create the build string when we generate the Debian package, and then
+# make the bundle filename just s/\.deb/\.tar/g from the Debian package.
+TIMESTAMP="$(date --iso-8601=minutes | sed 's/://g' | sed 's/+0000/Z/g')"
+BUILD_VERSION="$(git rev-parse --short HEAD)"
+BUNDLE_FILENAME="tinypilot-${TIMESTAMP}-${BUILD_VERSION}.tar"
+readonly BUNDLE_FILENAME
+
 # Generate build output.
 mkdir -p "${OUTPUT_DIR}"
 ls -lahR "${BUNDLE_DIR}" > "${OUTPUT_DIR}/files.txt"
 tar \
   --create \
-  --file "${OUTPUT_DIR}/tinypilot.tar" \
+  --file "${OUTPUT_DIR}/${BUNDLE_FILENAME}.tar" \
   --directory "${BUNDLE_DIR}" \
   .

--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -32,14 +32,13 @@ readonly OUTPUT_DIR='dist'
 # https://github.com/tiny-pilot/tinypilot-bundler/issues/9.
 rename_bundle_file() {
   # The filename of the TinyPilot Debian package.
-  OLD_TINYPILOT_DEBIAN_PACKAGE="$(ls tinypilot*.deb)"
   local OLD_TINYPILOT_DEBIAN_PACKAGE
+  OLD_TINYPILOT_DEBIAN_PACKAGE="$(ls tinypilot*.deb)"
 
-  # TODO: Move the package naming
-  TIMESTAMP="$(date --iso-8601=minutes | sed 's/://g' | sed 's/+0000/Z/g')"
   local TIMESTAMP
-  BUILD_VERSION="$(git rev-parse --short HEAD)"
+  TIMESTAMP="$(date --iso-8601=minutes | sed 's/://g' | sed 's/+0000/Z/g')"
   local BUILD_VERSION
+  BUILD_VERSION="$(git rev-parse --short HEAD)"
 
   local NEW_TINYPILOT_DEBIAN_PACKAGE="tinypilot-${TIMESTAMP}-${BUILD_VERSION}.deb"
 

--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -64,6 +64,6 @@ mkdir -p "${OUTPUT_DIR}"
 ls -lahR "${BUNDLE_DIR}" > "${OUTPUT_DIR}/files.txt"
 tar \
   --create \
-  --file "${OUTPUT_DIR}/${BUNDLE_FILENAME}.tar" \
+  --file "${OUTPUT_DIR}/${BUNDLE_FILENAME}" \
   --directory "${BUNDLE_DIR}" \
   .

--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -53,7 +53,7 @@ pushd "${BUNDLE_DIR}"
 # the same workflow as the bundle.
 # https://github.com/tiny-pilot/tinypilot-bundler/issues/9
 wget "${PKG_URL_TINYPILOT}"
-TINYPILOT_DEBIAN_PACKAGE=rename_bundle_file
+TINYPILOT_DEBIAN_PACKAGE="$(rename_bundle_file)"
 
 # Copy each Ansible role dependency into the bundle and add a version file.
 for GIT_URL in $REPO_ANSIBLE_TINYPILOT $REPO_ANSIBLE_NGINX $REPO_ANSIBLE_USTREAMER


### PR DESCRIPTION
Adds metadata to the bundle filename so that the bundles have names like `tinypilot-2022-06-17T1706Z-6f23b05.tar` instead of just `tinypilot.tar`.

Ultimately, I think we should put this logic into the script for [generating the Debian package](https://github.com/tiny-pilot/tinypilot-bundler/issues/60), but in the meantime, this lets us upload distinct files to Backblaze (#990).

Fixes https://github.com/tiny-pilot/tinypilot-bundler/issues/9

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/992)
<!-- Reviewable:end -->
