### PR TITLE
Exclude `.deb` files in bundler directory from git

### DIFF
--- a/bundler/.gitignore
+++ b/bundler/.gitignore
@@ -1,6 +1,7 @@
 # Dynamic dependencies from dist/ folder.
 /bundle/tinypilot
 /bundle/ansible-role-*
+/bundle/tinypilot*.deb
 
 # Build artifacts.
 /dist


### PR DESCRIPTION
I think we missed to add the Debian package file to `.gitignore`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/999)
<!-- Reviewable:end -->
