### PR TITLE
Pylint 2.14.2 using with

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -25,8 +25,6 @@ unsafe-load-any-extension=no
 disable=
   # Remove when we fix https://github.com/tiny-pilot/tinypilot/issues/995
   consider-using-f-string,
-  # Remove when we fix https://github.com/tiny-pilot/tinypilot/issues/997
-  consider-using-with,
   # Remove when we fix https://github.com/tiny-pilot/tinypilot/issues/996
   unspecified-encoding,
   fixme,

--- a/app/atomic_file_test.py
+++ b/app/atomic_file_test.py
@@ -14,6 +14,9 @@ class CallerError(Exception):
 class AtomicFileTest(unittest.TestCase):
 
     def setUp(self):
+        # Ignore pylint because we perform a tear down
+        # and assert the temporary files are gone.
+        # pylint: disable=consider-using-with
         self.destination_dir = tempfile.TemporaryDirectory()
 
         self.temp_dir = tempfile.TemporaryDirectory()

--- a/app/update/launcher.py
+++ b/app/update/launcher.py
@@ -33,5 +33,6 @@ def start_async():
 
     update.result_store.clear()
 
-    subprocess.Popen(
-        ('sudo', '/usr/sbin/service', 'tinypilot-updater', 'start'))
+    with subprocess.Popen(
+        ('sudo', '/usr/sbin/service', 'tinypilot-updater', 'start')) as proc:
+        proc.wait()

--- a/app/update/result_store_test.py
+++ b/app/update/result_store_test.py
@@ -11,6 +11,9 @@ import update.result_store
 class ResultStoreReadTest(unittest.TestCase):
 
     def setUp(self):
+        # Ignore pylint because we perform a tear down
+        # and assert the temporary files are gone.
+        # pylint: disable=consider-using-with
         self.mock_result_dir = tempfile.TemporaryDirectory()
 
         result_path_patch = mock.patch.object(
@@ -100,6 +103,9 @@ class ResultStoreReadTest(unittest.TestCase):
 class ResultStoreClearTest(unittest.TestCase):
 
     def setUp(self):
+        # Ignore pylint because we perform a tear down
+        # and assert the temporary files are gone.
+        # pylint: disable=consider-using-with
         self.mock_result_dir = tempfile.TemporaryDirectory()
 
         result_file_dir_patch = mock.patch.object(update.result_store,
@@ -176,6 +182,9 @@ class ResultStoreClearTest(unittest.TestCase):
 class ResultStoreWriteTest(unittest.TestCase):
 
     def setUp(self):
+        # Ignore pylint because we perform a tear down
+        # and assert the temporary files are gone.
+        # pylint: disable=consider-using-with
         self.mock_result_dir = tempfile.TemporaryDirectory()
 
         result_dir_patch = mock.patch.object(update.result_store,

--- a/app/update/settings_test.py
+++ b/app/update/settings_test.py
@@ -11,6 +11,10 @@ class UpdateSettingsTest(unittest.TestCase):
     def setUp(self):
         # Mock out the path to the settings.yml file so that it points to a file
         # path that the test controls.
+
+        # Ignore pylint because we perform a tear down
+        # and assert the temporary files are gone.
+        # pylint: disable=consider-using-with
         self.mock_settings_dir = tempfile.TemporaryDirectory()
         self.settings_file_path = os.path.join(self.mock_settings_dir.name,
                                                'settings.yml')


### PR DESCRIPTION
pylint now has a suggestion for using the with keyword in places where the code allocates resources. This change adds 'with' or bypasses the check for test cases that perform a manual tear down of allocated resources.

for app/update/launcher.py , used 'with' and a redundant `proc.wait()` (I think 'with' already waits on the process before exiting). I noticed a timeout already assigned upstream in scripts/update-service, but a timeout could be assigned to the launcher too.

Fixes #997 

I'm a newcomer to oss so thank you for the tag:good first issue !

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/1013)
<!-- Reviewable:end -->
