### PR TITLE
Limit CI bundle builds/uploads to the master branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,13 +179,22 @@ workflows:
       - check_bash
       - build_python
       - build_javascript
-      - build_debian_package
+      - build_debian_package:
+          filters:
+            branches:
+              only: master
       - build_bundle:
           requires:
             - build_debian_package
+          filters:
+            branches:
+              only: master
       - upload_bundle:
           requires:
             - build_bundle
+          filters:
+            branches:
+              only: master
       - e2e:
           filters:
             branches:


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1000

This PR adds a CircleCI filter to only build and upload bundles in the `master` branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/1014)
<!-- Reviewable:end -->
