### PR TITLE
Compress TinyPilot bundle with gzip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
       - persist_to_workspace:
           root: ./releases
           paths:
-            - "*.deb"
+            - '*.deb'
   build_bundle:
     docker:
       - image: cimg/base:2020.01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ jobs:
               --noProgress \
               "${UPLOAD_BUCKET}" \
               dist/LATEST \
-              "${UPLOAD_PATH}/LATEST-scratch" \
+              "${UPLOAD_PATH}/LATEST" \
               > /dev/null # Hide output to avoid exposing bucket details in CI.
       - run:
           name: Print friendly upload URL
@@ -179,13 +179,22 @@ workflows:
       - check_bash
       - build_python
       - build_javascript
-      - build_debian_package
+      - build_debian_package:
+          filters:
+            branches:
+              only: master
       - build_bundle:
           requires:
             - build_debian_package
+          filters:
+            branches:
+              only: master
       - upload_bundle:
           requires:
             - build_bundle
+          filters:
+            branches:
+              only: master
       - e2e:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
       - persist_to_workspace:
           root: ./releases
           paths:
-            - '*.deb'
+            - "*.deb"
   build_bundle:
     docker:
       - image: cimg/base:2020.01
@@ -124,7 +124,7 @@ jobs:
           # The LATEST file contains the filename of the latest TinyPilot
           # bundle.
           name: Create LATEST file
-          command: cd dist && ls tinypilot*.tar | tee LATEST
+          command: cd dist && ls tinypilot*.tgz | tee LATEST
       - run:
           name: Download Backblaze CLI tool
           command: |
@@ -186,15 +186,9 @@ workflows:
       - build_bundle:
           requires:
             - build_debian_package
-          filters:
-            branches:
-              only: master
       - upload_bundle:
           requires:
             - build_bundle
-          filters:
-            branches:
-              only: master
       - e2e:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ jobs:
               --noProgress \
               "${UPLOAD_BUCKET}" \
               dist/LATEST \
-              "${UPLOAD_PATH}/LATEST" \
+              "${UPLOAD_PATH}/LATEST-scratch" \
               > /dev/null # Hide output to avoid exposing bucket details in CI.
       - run:
           name: Print friendly upload URL
@@ -179,10 +179,7 @@ workflows:
       - check_bash
       - build_python
       - build_javascript
-      - build_debian_package:
-          filters:
-            branches:
-              only: master
+      - build_debian_package
       - build_bundle:
           requires:
             - build_debian_package

--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -35,7 +35,7 @@ readonly TIMESTAMP
 TINYPILOT_VERSION="$(git rev-parse --short HEAD)"
 readonly TINYPILOT_VERSION
 readonly TINYPILOT_VARIANT='community'
-readonly BUNDLE_FILENAME="tinypilot-${TINYPILOT_VARIANT}-${TIMESTAMP}-${TINYPILOT_VERSION}.tar"
+readonly BUNDLE_FILENAME="tinypilot-${TINYPILOT_VARIANT}-${TIMESTAMP}-${TINYPILOT_VERSION}.tgz"
 
 # Enter working directory to set up the bundle’s inner structure.
 pushd "${BUNDLE_DIR}"
@@ -74,6 +74,7 @@ mkdir -p "${OUTPUT_DIR}"
 ls -lahR "${BUNDLE_DIR}" > "${OUTPUT_DIR}/files.txt"
 tar \
   --create \
+  --gzip \
   --file "${OUTPUT_DIR}/${BUNDLE_FILENAME}" \
   --directory "${BUNDLE_DIR}" \
   .

--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -28,8 +28,8 @@ readonly OUTPUT_DIR='dist'
 # 4. The build version: a git commit hash in short form for TinyPilot Community;
 #    a SemVer version for TinyPilot Pro.
 # Examples for bundle names:
-# - `tinypilot-community-20220620T1611Z-acd7316.tar` (Community)
-# - `tinypilot-pro-20220620T1713Z-2.4.1.tar` (Pro)
+# - `tinypilot-community-20220620T1611Z-acd7316.tgz` (Community)
+# - `tinypilot-pro-20220620T1713Z-2.4.1.tgz` (Pro)
 TIMESTAMP="$(date --iso-8601=minutes | sed 's/[:-]//g' | sed 's/+0000/Z/g')"
 readonly TIMESTAMP
 TINYPILOT_VERSION="$(git rev-parse --short HEAD)"

--- a/bundler/get-tinypilot.sh
+++ b/bundler/get-tinypilot.sh
@@ -18,8 +18,9 @@ readonly TEMP_FOLDER
 
 # Extract tarball to temporary folder and run install.
 tar \
+  --gunzip \
   --extract \
-  --file tinypilot.tar \
+  --file tinypilot.tgz \
   --directory "${TEMP_FOLDER}"
 pushd "${TEMP_FOLDER}"
 chmod +x install

--- a/bundler/get-tinypilot.sh
+++ b/bundler/get-tinypilot.sh
@@ -2,7 +2,7 @@
 
 # “Mock” version of the eventual `get-tinypilot.sh` script.
 # Instead of downloading the installation bundle on the fly, it expects a
-# tarball named `tinypilot.tar` to be present in the same directory.
+# tarball named `tinypilot.tgz` to be present in the same directory.
 
 # Exit on first error.
 set -e


### PR DESCRIPTION
It's not a huge space savings right now, but it costs basically nothing to compress, and it might have a more meaningful impact in the future if our bundle size increases. It's much easier to change formats now before anything is using the bundles, so we're changing to .tgz.

| Bundle | Size |
|------------|----------|
| [tinypilot-community-20220622T1634Z-725b1a1.tar](https://bundles.tinypilotkvm.com/community/tinypilot-community-20220622T1634Z-725b1a1.tar) | 800 KB |
| [tinypilot-community-20220624T1527Z-56e4671.tgz](https://bundles.tinypilotkvm.com/community/tinypilot-community-20220624T1527Z-56e4671.tgz) | 629 KB |

Related: https://github.com/tiny-pilot/gatekeeper/pull/37

Fixes #1002

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/1029)
<!-- Reviewable:end -->
