### PR TITLE
Remove pkg-resources from list of quick-install requirements

### DIFF
--- a/bundler/bundle/requirements.txt
+++ b/bundler/bundle/requirements.txt
@@ -6,7 +6,6 @@ cffi==1.14.4
 cryptography==35.0.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
-pkg-resources==0.0.0
 pycparser==2.20
 pyOpenSSL==20.0.1
 PyYAML==5.3.1

--- a/quick-install
+++ b/quick-install
@@ -156,7 +156,6 @@ cffi==1.14.4
 cryptography==35.0.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
-pkg-resources==0.0.0
 pycparser==2.20
 pyOpenSSL==20.0.1
 PyYAML==5.3.1


### PR DESCRIPTION
According to this thread, this line was always erroneous and we should just remove it: https://github.com/pypa/pip/issues/4022

It doesn't seem to harm anything on Raspberry Pi OS, but it causes problems on other distros.

Fixes #1031
Fixes #1015

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/1032)
<!-- Reviewable:end -->
