### PR TITLE
Upgrade pip to a minimum version rather than a specific version

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -148,7 +148,7 @@ python3 -m venv venv
 . venv/bin/activate
 # Upgrade to a recent version of pip so that we can use binary wheels where
 # available instead of building the packages locally.
-pip install pip==21.3.1
+pip install "pip>=21.3.1"
 
 # When modifying dependencies, update the credit in app/license_notice.py.
 echo 'ansible==2.9.10


### PR DESCRIPTION
We added a requirement on pip 21.3.1 when the standard pip that shipped with Raspberry Pi OS was older than 21.3.1, and we wanted a newer feature. Now, Raspberry Pi OS ships a newer version of pip and we're forcing the system to our particular version, which is unnecessary.

This change relaxes the requirement on the pip version to be 21.3.1 or later, so we only have to reinstall pip if the system's version is pretty old.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/1033)
<!-- Reviewable:end -->
