### PR TITLE
Prevent users from accidentally downgrading from TinyPilot Pro to Community

### DIFF
--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -11,6 +11,38 @@ set -u
 # Echo commands to stdout.
 set -x
 
+# Check if the user is accidentally downgrading from TinyPilot Pro.
+HAS_PRO_INSTALLED=0
+
+# Detect TinyPilot Pro if the README file has a TinyPilot Pro header.
+TINYPILOT_README="/opt/tinypilot/README.md"
+if [ -f "$TINYPILOT_README" ]; then
+  if [ "$(head -n 1 $TINYPILOT_README)" = "# TinyPilot Pro" ]; then
+    HAS_PRO_INSTALLED=1
+  fi
+fi
+
+if [ "$HAS_PRO_INSTALLED" = 1 ]; then
+  set +u # Don't exit if FORCE_DOWNGRADE is unset.
+  if [ "$FORCE_DOWNGRADE" = 1 ]; then
+    echo "Downgrading from TinyPilot Pro to TinyPilot Community Edition"
+    set -u
+  else
+    set +x
+    printf "You are trying to downgrade from TinyPilot Pro to TinyPilot "
+    printf "Community Edition.\n\n"
+    printf "You probably want to update to the latest version of TinyPilot "
+    printf "Pro instead:\n\n"
+    printf "  /opt/tinypilot/scripts/upgrade && sudo reboot\n"
+    printf "\n"
+    printf "If you *really* want to downgrade to TinyPilot Community Edition, "
+    printf "type the following:\n\n"
+    printf "  export FORCE_DOWNGRADE=1\n\n"
+    printf "And then run your previous command again.\n"
+    exit 255
+  fi
+fi
+
 BUNDLE_FILENAME="$(mktemp --suffix .tgz)"
 readonly BUNDLE_FILENAME
 

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -14,8 +14,15 @@ set -x
 # Check if the user is accidentally downgrading from TinyPilot Pro.
 HAS_PRO_INSTALLED=0
 
+SCRIPT_DIR="$(dirname "$0")"
+# If they're piping this script in from stdin, guess that TinyPilot is
+# in the default location.
+if [ "$SCRIPT_DIR" = "." ]; then
+  SCRIPT_DIR="/opt/tinypilot"
+fi
+
 # Detect TinyPilot Pro if the README file has a TinyPilot Pro header.
-TINYPILOT_README="/opt/tinypilot/README.md"
+TINYPILOT_README="${SCRIPT_DIR}/README.md"
 if [ -f "$TINYPILOT_README" ]; then
   if [ "$(head -n 1 $TINYPILOT_README)" = "# TinyPilot Pro" ]; then
     HAS_PRO_INSTALLED=1

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -17,21 +17,23 @@ HAS_PRO_INSTALLED=0
 SCRIPT_DIR="$(dirname "$0")"
 # If they're piping this script in from stdin, guess that TinyPilot is
 # in the default location.
-if [ "$SCRIPT_DIR" = "." ]; then
+if [[ "$SCRIPT_DIR" = "." ]]; then
   SCRIPT_DIR="/opt/tinypilot"
 fi
+readonly SCRIPT_DIR
 
 # Detect TinyPilot Pro if the README file has a TinyPilot Pro header.
-TINYPILOT_README="${SCRIPT_DIR}/README.md"
-if [ -f "$TINYPILOT_README" ]; then
-  if [ "$(head -n 1 $TINYPILOT_README)" = "# TinyPilot Pro" ]; then
+readonly TINYPILOT_README="${SCRIPT_DIR}/README.md"
+if [[ -f "${TINYPILOT_README}" ]]; then
+  if [[ "$(head -n 1 ${TINYPILOT_README})" = "# TinyPilot Pro" ]]; then
     HAS_PRO_INSTALLED=1
   fi
 fi
+readonly HAS_PRO_INSTALLED
 
-if [ "$HAS_PRO_INSTALLED" = 1 ]; then
+if [[ "${HAS_PRO_INSTALLED}" = 1 ]]; then
   set +u # Don't exit if FORCE_DOWNGRADE is unset.
-  if [ "$FORCE_DOWNGRADE" = 1 ]; then
+  if [[ "${FORCE_DOWNGRADE}" = 1 ]]; then
     echo "Downgrading from TinyPilot Pro to TinyPilot Community Edition"
     set -u
   else


### PR DESCRIPTION
We have this check in our legacy quick-install script (https://github.com/tiny-pilot/tinypilot/blob/fa2a5fed814e3ae80415b58918d71e28fbcd10c7/quick-install#L95L132) but we haven't ported it over to our new flow.

We still need this to make sure that Pro users don't accidentally downgrade to Community when trying to update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/1039)
<!-- Reviewable:end -->
