### PR TITLE
Read local version from `VERSION` file.

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -135,7 +135,7 @@ def version_get():
 
         Example:
         {
-            "version": "bf07bfe72941457cf068ca0a44c6b0d62dd9ef05",
+            "version": "bf07bfe",
         }
 
         Returns error object on failure.

--- a/app/version.py
+++ b/app/version.py
@@ -11,7 +11,7 @@ class GitError(Error):
     pass
 
 
-class FileError(Error):
+class VersionFileError(Error):
     pass
 
 
@@ -32,7 +32,7 @@ def local_version():
         A version string.
 
     Raises:
-        FileError: If an error occurred while accessing the version file.
+        VersionFileError: If an error occurred while accessing the version file.
     """
     if _is_debug():
         return '0000000'
@@ -41,9 +41,10 @@ def local_version():
         with open(_VERSION_FILE, encoding='utf-8') as file:
             version = file.read().strip()
     except (IOError, UnicodeDecodeError) as e:
-        raise FileError('Failed to check local version: %s' % str(e)) from e
+        raise VersionFileError('Failed to check local version: %s' %
+                               str(e)) from e
     if version == '':
-        raise FileError('The local version file cannot be empty.')
+        raise VersionFileError('The local version file cannot be empty.')
     return version
 
 

--- a/app/version.py
+++ b/app/version.py
@@ -40,7 +40,7 @@ def local_version():
     try:
         with open(_VERSION_FILE, encoding='utf-8') as file:
             version = file.read().strip()
-    except IOError as e:
+    except (IOError, UnicodeDecodeError) as e:
         raise FileError('Failed to check local version: %s' % str(e)) from e
     if version == '':
         raise FileError('The local version file cannot be empty.')

--- a/app/version.py
+++ b/app/version.py
@@ -39,9 +39,12 @@ def local_version():
 
     try:
         with open(_VERSION_FILE, encoding='utf-8') as file:
-            return file.read().strip()
+            version = file.read().strip()
     except IOError as e:
         raise FileError('Failed to check local version: %s' % str(e)) from e
+    if version == '':
+        raise FileError('The local version file cannot be empty.')
+    return version
 
 
 def latest_version():

--- a/app/version.py
+++ b/app/version.py
@@ -1,3 +1,5 @@
+import flask
+
 import git
 
 
@@ -9,11 +11,37 @@ class GitError(Error):
     pass
 
 
+class FileError(Error):
+    pass
+
+
+_VERSION_FILE = './VERSION'
+
+
+def _is_debug():
+    return flask.current_app.debug
+
+
 def local_version():
+    """Read the current local version string from the version file.
+
+    If run locally, in development, where a version file is not present then a
+    dummy version string is returned.
+
+    Returns:
+        A version string.
+
+    Raises:
+        FileError: If an error occurred while accessing the version file.
+    """
+    if _is_debug():
+        return '0000000'
+
     try:
-        return git.local_head_commit_id()
-    except git.Error as e:
-        raise GitError('Failed to check local version: %s' % str(e)) from e
+        with open(_VERSION_FILE, encoding='utf-8') as file:
+            return file.read().strip()
+    except IOError as e:
+        raise FileError('Failed to check local version: %s' % str(e)) from e
 
 
 def latest_version():

--- a/app/version.py
+++ b/app/version.py
@@ -40,7 +40,10 @@ def local_version():
     try:
         with open(_VERSION_FILE, encoding='utf-8') as file:
             version = file.read().strip()
-    except (IOError, UnicodeDecodeError) as e:
+    except UnicodeDecodeError as e:
+        raise VersionFileError(
+            'The local version file must only contain UTF-8 characters.') from e
+    except IOError as e:
         raise VersionFileError('Failed to check local version: %s' %
                                str(e)) from e
     if version == '':

--- a/app/version_test.py
+++ b/app/version_test.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 from unittest import TestCase
 from unittest import mock
@@ -42,11 +41,7 @@ class VersionTest(TestCase):
                 self.assertEqual('1234567', version.local_version())
 
     def test_local_version_raises_file_error_when_file_doesnt_exist(self):
-        with tempfile.TemporaryDirectory() as mock_version_dir:
-            mock_version_file_name = os.path.join(mock_version_dir,
-                                                  'version-file')
-
-            with mock.patch.object(version, '_VERSION_FILE',
-                                   mock_version_file_name):
-                with self.assertRaises(version.FileError):
-                    version.local_version()
+        with mock.patch.object(version, '_VERSION_FILE',
+                               'non-existent-file.txt'):
+            with self.assertRaises(version.FileError):
+                version.local_version()

--- a/app/version_test.py
+++ b/app/version_test.py
@@ -8,7 +8,16 @@ import version
 
 class VersionTest(TestCase):
 
+    def setUp(self):
+        # Run all unit tests with debug mode disabled.
+        is_debug_patch = mock.patch.object(version,
+                                           '_is_debug',
+                                           return_value=False)
+        self.addCleanup(is_debug_patch.stop)
+        is_debug_patch.start()
+
     def test_local_version_returns_dummy_version_when_in_debug_mode(self):
+        # Enable debug mode.
         with mock.patch.object(version, '_is_debug', return_value=True):
             self.assertEqual('0000000', version.local_version())
 
@@ -19,9 +28,7 @@ class VersionTest(TestCase):
             mock_version_file.flush()
 
             with mock.patch.object(version, '_VERSION_FILE',
-                                   mock_version_file.name), mock.patch.object(
-                                       version, '_is_debug',
-                                       return_value=False):
+                                   mock_version_file.name):
                 self.assertEqual('1234567', version.local_version())
 
     def test_local_version_strips_leading_trailing_whitespace(self):
@@ -31,9 +38,7 @@ class VersionTest(TestCase):
             mock_version_file.flush()
 
             with mock.patch.object(version, '_VERSION_FILE',
-                                   mock_version_file.name), mock.patch.object(
-                                       version, '_is_debug',
-                                       return_value=False):
+                                   mock_version_file.name):
                 self.assertEqual('1234567', version.local_version())
 
     def test_local_version_raises_file_error_when_file_doesnt_exist(self):
@@ -42,8 +47,6 @@ class VersionTest(TestCase):
                                                   'version-file')
 
             with mock.patch.object(version, '_VERSION_FILE',
-                                   mock_version_file_name), mock.patch.object(
-                                       version, '_is_debug',
-                                       return_value=False):
+                                   mock_version_file_name):
                 with self.assertRaises(version.FileError):
                     version.local_version()

--- a/app/version_test.py
+++ b/app/version_test.py
@@ -45,3 +45,13 @@ class VersionTest(TestCase):
                                'non-existent-file.txt'):
             with self.assertRaises(version.FileError):
                 version.local_version()
+
+    def test_local_version_raises_file_error_when_file_is_empty(self):
+        with tempfile.NamedTemporaryFile('w',
+                                         encoding='utf-8') as mock_version_file:
+
+            with mock.patch.object(version, '_VERSION_FILE',
+                                   mock_version_file.name):
+                with self.assertRaises(version.FileError):
+                    version.local_version()
+

--- a/app/version_test.py
+++ b/app/version_test.py
@@ -1,0 +1,49 @@
+import os
+import tempfile
+from unittest import TestCase
+from unittest import mock
+
+import version
+
+
+class VersionTest(TestCase):
+
+    def test_local_version_returns_dummy_version_when_in_debug_mode(self):
+        with mock.patch.object(version, '_is_debug', return_value=True):
+            self.assertEqual('0000000', version.local_version())
+
+    def test_local_version_when_file_exists(self):
+        with tempfile.NamedTemporaryFile('w',
+                                         encoding='utf-8') as mock_version_file:
+            mock_version_file.write('1234567')
+            mock_version_file.flush()
+
+            with mock.patch.object(version, '_VERSION_FILE',
+                                   mock_version_file.name), mock.patch.object(
+                                       version, '_is_debug',
+                                       return_value=False):
+                self.assertEqual('1234567', version.local_version())
+
+    def test_local_version_strips_leading_trailing_whitespace(self):
+        with tempfile.NamedTemporaryFile('w',
+                                         encoding='utf-8') as mock_version_file:
+            mock_version_file.write('    1234567   \n')
+            mock_version_file.flush()
+
+            with mock.patch.object(version, '_VERSION_FILE',
+                                   mock_version_file.name), mock.patch.object(
+                                       version, '_is_debug',
+                                       return_value=False):
+                self.assertEqual('1234567', version.local_version())
+
+    def test_local_version_raises_file_error_when_file_doesnt_exist(self):
+        with tempfile.TemporaryDirectory() as mock_version_dir:
+            mock_version_file_name = os.path.join(mock_version_dir,
+                                                  'version-file')
+
+            with mock.patch.object(version, '_VERSION_FILE',
+                                   mock_version_file_name), mock.patch.object(
+                                       version, '_is_debug',
+                                       return_value=False):
+                with self.assertRaises(version.FileError):
+                    version.local_version()

--- a/app/version_test.py
+++ b/app/version_test.py
@@ -55,3 +55,12 @@ class VersionTest(TestCase):
                 with self.assertRaises(version.FileError):
                     version.local_version()
 
+    def test_local_version_raises_file_error_when_file_is_not_utf_8(self):
+        with tempfile.NamedTemporaryFile() as mock_version_file:
+            mock_version_file.write(b'\xff')
+            mock_version_file.flush()
+
+            with mock.patch.object(version, '_VERSION_FILE',
+                                   mock_version_file.name):
+                with self.assertRaises(version.FileError):
+                    version.local_version()

--- a/app/version_test.py
+++ b/app/version_test.py
@@ -43,7 +43,7 @@ class VersionTest(TestCase):
     def test_local_version_raises_file_error_when_file_doesnt_exist(self):
         with mock.patch.object(version, '_VERSION_FILE',
                                'non-existent-file.txt'):
-            with self.assertRaises(version.FileError):
+            with self.assertRaises(version.VersionFileError):
                 version.local_version()
 
     def test_local_version_raises_file_error_when_file_is_empty(self):
@@ -52,7 +52,7 @@ class VersionTest(TestCase):
 
             with mock.patch.object(version, '_VERSION_FILE',
                                    mock_version_file.name):
-                with self.assertRaises(version.FileError):
+                with self.assertRaises(version.VersionFileError):
                     version.local_version()
 
     def test_local_version_raises_file_error_when_file_is_not_utf_8(self):
@@ -62,5 +62,5 @@ class VersionTest(TestCase):
 
             with mock.patch.object(version, '_VERSION_FILE',
                                    mock_version_file.name):
-                with self.assertRaises(version.FileError):
+                with self.assertRaises(version.VersionFileError):
                     version.local_version()

--- a/app/version_test.py
+++ b/app/version_test.py
@@ -15,11 +15,6 @@ class VersionTest(TestCase):
         self.addCleanup(is_debug_patch.stop)
         is_debug_patch.start()
 
-    def test_local_version_returns_dummy_version_when_in_debug_mode(self):
-        # Enable debug mode.
-        with mock.patch.object(version, '_is_debug', return_value=True):
-            self.assertEqual('0000000', version.local_version())
-
     def test_local_version_when_file_exists(self):
         with tempfile.NamedTemporaryFile('w',
                                          encoding='utf-8') as mock_version_file:
@@ -64,3 +59,11 @@ class VersionTest(TestCase):
                                    mock_version_file.name):
                 with self.assertRaises(version.VersionFileError):
                     version.local_version()
+
+
+class DebugModeVersionTest(TestCase):
+
+    def test_local_version_returns_dummy_version_when_in_debug_mode(self):
+        # Enable debug mode.
+        with mock.patch.object(version, '_is_debug', return_value=True):
+            self.assertEqual('0000000', version.local_version())


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1021

Notes:
1. In local development mode (i.e. debug mode) we return [a dummy version hash `0000000`](https://github.com/tiny-pilot/tinypilot/blob/bb8c7f7999544961dba5e6e58149e940058393cb/app/version.py#L38).
2. In order to detect if we're in dev mode, we access `flask.current_app.debug`. This makes it notoriously difficult to write tests because we need to initialize a new Flask `app` to be able to give the unit test an application context. Anyway, instead of doing that I just pulled the `flask.current_app.debug` into its own function (i.e. [`_is_debug`](https://github.com/tiny-pilot/tinypilot/blob/bb8c7f7999544961dba5e6e58149e940058393cb/app/version.py#L21-L22)) and [mocked that instead](https://github.com/tiny-pilot/tinypilot/blob/bb8c7f7999544961dba5e6e58149e940058393cb/app/version_test.py#L12).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/1040)
<!-- Reviewable:end -->
