### PR TITLE
Use bash basename to convert URLs to folder names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
       - persist_to_workspace:
           root: ./releases
           paths:
-            - '*.deb'
+            - "*.deb"
   build_bundle:
     docker:
       - image: cimg/base:2020.01
@@ -149,16 +149,6 @@ jobs:
               "${UPLOAD_PREFIX}/${BUNDLE_FILENAME}" \
               > /dev/null # Hide output to avoid exposing bucket details in CI.
       - run:
-          name: Update LATEST file to Backblaze
-          command: |
-            set -u
-            ./b2 upload-file \
-              --noProgress \
-              "${UPLOAD_BUCKET}" \
-              dist/LATEST \
-              "${UPLOAD_PREFIX}/version-index/LATEST" \
-              > /dev/null # Hide output to avoid exposing bucket details in CI.
-      - run:
           name: Print friendly upload URL
           command: |
             set -u
@@ -186,15 +176,9 @@ workflows:
       - build_bundle:
           requires:
             - build_debian_package
-          filters:
-            branches:
-              only: master
       - upload_bundle:
           requires:
             - build_bundle
-          filters:
-            branches:
-              only: master
       - e2e:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
       - persist_to_workspace:
           root: ./releases
           paths:
-            - "*.deb"
+            - '*.deb'
   build_bundle:
     docker:
       - image: cimg/base:2020.01
@@ -149,6 +149,16 @@ jobs:
               "${UPLOAD_PREFIX}/${BUNDLE_FILENAME}" \
               > /dev/null # Hide output to avoid exposing bucket details in CI.
       - run:
+          name: Update LATEST file to Backblaze
+          command: |
+            set -u
+            ./b2 upload-file \
+              --noProgress \
+              "${UPLOAD_BUCKET}" \
+              dist/LATEST \
+              "${UPLOAD_PREFIX}/version-index/LATEST" \
+              > /dev/null # Hide output to avoid exposing bucket details in CI.
+      - run:
           name: Print friendly upload URL
           command: |
             set -u
@@ -169,13 +179,22 @@ workflows:
       - check_bash
       - build_python
       - build_javascript
-      - build_debian_package
+      - build_debian_package:
+          filters:
+            branches:
+              only: master
       - build_bundle:
           requires:
             - build_debian_package
+          filters:
+            branches:
+              only: master
       - upload_bundle:
           requires:
             - build_bundle
+          filters:
+            branches:
+              only: master
       - e2e:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,10 +169,7 @@ workflows:
       - check_bash
       - build_python
       - build_javascript
-      - build_debian_package:
-          filters:
-            branches:
-              only: master
+      - build_debian_package
       - build_bundle:
           requires:
             - build_debian_package

--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -53,7 +53,7 @@ do
     --depth 1 \
     --branch master \
     "${GIT_URL}"
-  FOLDER_NAME="$(echo "${GIT_URL}" | sed 's|https://github.com/tiny-pilot/||' | sed 's|.git||')"
+  FOLDER_NAME="$(basename "${GIT_URL}" .git)"
   pushd "${FOLDER_NAME}"
   git rev-parse --short HEAD > VERSION
   popd


### PR DESCRIPTION
create-bundle needs to translate Git URLs to folder names after cloning. Previously, we were doing it hackily with string replacement, but @jdeanwallace pointed out that we can do it with the basename bash utility, so this switches to basename.

I tried a test build, and it built successfully:

https://bundles.tinypilotkvm.com/community/tinypilot-community-20220630T1652Z-1b17e24.tgz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/1042)
<!-- Reviewable:end -->
