### PR TITLE
Add `sudo` to install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ curl \
   --silent \
   --show-error \
   https://raw.githubusercontent.com/tiny-pilot/tinypilot/master/get-tinypilot.sh | \
-    bash - && \
+    sudo bash - && \
   sudo reboot
 ```
 


### PR DESCRIPTION
Related to https://github.com/tiny-pilot/tinypilot/issues/1025
Related to https://github.com/tiny-pilot/tinypilot/issues/1027

We no longer use `sudo` inside our [`install` script](https://github.com/tiny-pilot/tinypilot/blob/3e955488ae5e30117338f18c6625dec559ad0ee3/bundler/bundle/install#L81), so need the user to elevate privileges when running `get-tinypilot.sh`.

Without this change, user's will run into this error:
```bash
$ curl \
>   --silent \
>   --show-error \
>   https://raw.githubusercontent.com/tiny-pilot/tinypilot/update-overhaul/get-tinypilot.sh | \
>     bash - && \
>   sudo reboot
...
+ apt-get update --allow-releaseinfo-change-suite
Reading package lists... Done
E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)
E: Unable to lock directory /var/lib/apt/lists/
W: Problem unlinking the file /var/cache/apt/pkgcache.bin - RemoveCaches (13: Permission denied)
W: Problem unlinking the file /var/cache/apt/srcpkgcache.bin - RemoveCaches (13: Permission denied)
```