### PR TITLE
Specify custom TMPDIR for use with `mktemp`.

### DIFF
--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -11,6 +11,11 @@ set -u
 # Echo commands to stdout.
 set -x
 
+# HACK: If we let mktemp use the default /tmp directory, the system purges the
+# file before the end of the script for some reason. We use /var/tmp as a
+# workaround.
+export TMPDIR='/var/tmp'
+
 BUNDLE_FILENAME="$(mktemp --suffix .tgz)"
 readonly BUNDLE_FILENAME
 


### PR DESCRIPTION
Related to https://github.com/tiny-pilot/tinypilot/issues/1027

While testing the update overhaul, the [CircleCI `e2e` step was failing when running `get-tinypilot.sh`](https://app.circleci.com/pipelines/github/tiny-pilot/tinypilot/2311/workflows/a0d23ef4-f2e5-4283-820f-24fb5f9c651c/jobs/8705?invite=true#step-102-310) because the temporary directory being created just disappears before the end of the script. We've had this [problem before in `quick-install`](https://github.com/tiny-pilot/tinypilot/blob/16434c17e4f5e65bc9f00d8ec61870a62e1bf59a/quick-install#L50-L52), so this PR is just using the same hack solution.

I tested the fix [here and the e2e step completes successfully](https://app.circleci.com/pipelines/github/tiny-pilot/tinypilot/2312/workflows/c33d994b-710f-4621-8acb-fb51163ff7ff/jobs/8713?invite=true#step-102-299).