### PR TITLE
Specify custom temporary directory for use with `mktemp`

### DIFF
--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -52,10 +52,15 @@ if [[ "${HAS_PRO_INSTALLED}" = 1 ]]; then
   fi
 fi
 
-BUNDLE_FILENAME="$(mktemp --suffix .tgz)"
+# HACK: If we let mktemp use the default /tmp directory, the system purges the
+# file before the end of the script for some reason. We use /var/tmp as a
+# workaround.
+readonly TEMP_DIR='/var/tmp'
+
+BUNDLE_FILENAME="$(mktemp --tmpdir="${TEMP_DIR}" --suffix .tgz)"
 readonly BUNDLE_FILENAME
 
-BUNDLE_DIR="$(mktemp --directory)"
+BUNDLE_DIR="$(mktemp --tmpdir="${TEMP_DIR}" --directory)"
 readonly BUNDLE_DIR
 
 # Remove temporary files & directories.


### PR DESCRIPTION
Related to https://github.com/tiny-pilot/tinypilot/issues/1027

This PR was cherry-picked from https://github.com/tiny-pilot/tinypilot/commit/be853eb8eb60a22450f1a90575ed14b0ac9e81f0 to merge into `master` instead of `update-overhaul` ([see discussion here](https://github.com/tiny-pilot/tinypilot/pull/1048#issuecomment-1177622659)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/1049)
<!-- Reviewable:end -->
