### PR TITLE
Preserve `FORCE_DOWNGRADE` during `sudo` install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ curl \
   --silent \
   --show-error \
   https://raw.githubusercontent.com/tiny-pilot/tinypilot/master/get-tinypilot.sh | \
-    sudo bash - && \
+    sudo --preserve-env=FORCE_DOWNGRADE bash - && \
   sudo reboot
 ```
 


### PR DESCRIPTION
Related to https://github.com/tiny-pilot/tinypilot/issues/1027

Now that we're running the `get-tinypilot.sh` script with `sudo`, the script can no longer read [exported environment variables like `FORCE_DOWNGRADE`](https://github.com/tiny-pilot/tinypilot/blob/58fb6c5145443cf8157113c1673fa4bfda3b2d99/get-tinypilot.sh#L51) because the variable would have been exported in a seperate user environment.

This PR preserves only the `FORCE_DOWNGRADE` environment variable to be accessible by the root user.

Caveats:
* This makes the installation command a little more ugly.
* The [sudo manual](https://man7.org/linux/man-pages/man8/sudo.8.html) says that using `--preserve-env=X` might fail.
    
    > --preserve-env=list
    Indicates to the security policy that the user wishes
    to add the comma-separated list of environment
    variables to those preserved from the user's
    environment.  The security policy may return an error
    if the user does not have permission to preserve the
    environment.  This option may be specified multiple
    times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/1053)
<!-- Reviewable:end -->
