### PR TITLE
Revert "Add `sudo` to install instructions."

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ curl \
   --silent \
   --show-error \
   https://raw.githubusercontent.com/tiny-pilot/tinypilot/master/get-tinypilot.sh | \
-    sudo bash - && \
+    bash - && \
   sudo reboot
 ```
 


### PR DESCRIPTION
Reverts tiny-pilot/tinypilot#1045
Replaced by https://github.com/tiny-pilot/tinypilot/pull/1058

We're going to move the use of `sudo` to within the `get-tinypilot.sh` script ([see discussion here](https://github.com/tiny-pilot/tinypilot/pull/1053#pullrequestreview-1037631949)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/1057)
<!-- Reviewable:end -->
