### PR TITLE
Use `sudo` when installing bundle.

### DIFF
--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -67,7 +67,7 @@ readonly BUNDLE_DIR
 
 # Remove temporary files & directories.
 clean_up() {
-  sudo rm -rf "${BUNDLE_FILENAME}" "${BUNDLE_DIR}"
+  rm -rf "${BUNDLE_FILENAME}" "${BUNDLE_DIR}"
 }
 
 # Always clean up before exiting.

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -92,6 +92,6 @@ tar \
   --file "${BUNDLE_FILENAME}" \
   --directory "${BUNDLE_DIR}"
 pushd "${BUNDLE_DIR}"
-./install
+sudo ./install
 
 } # Prevent the script from executing until the client downloads the full file.

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -67,7 +67,7 @@ readonly BUNDLE_DIR
 
 # Remove temporary files & directories.
 clean_up() {
-  rm -rf "${BUNDLE_FILENAME}" "${BUNDLE_DIR}"
+  sudo rm -rf "${BUNDLE_FILENAME}" "${BUNDLE_DIR}"
 }
 
 # Always clean up before exiting.


### PR DESCRIPTION
Related to https://github.com/tiny-pilot/tinypilot/issues/1027
Reimplements https://github.com/tiny-pilot/tinypilot/pull/1045

Instead of calling `get-tinypilot.sh` with `sudo`, we rather use sudo within `get-tinypilot.sh`. This way we preserve environment variables like `$FORCE_DOWNGRADE` that can be read by `get-tinypilot.sh`.

Notes:
1. <s>We also need to use `sudo` when cleaning up the temp directory because it contains files owned by the root user. For example:
    ```bash
    ...
    Operation cancelled by user
    + clean_up
    + rm -rf /var/tmp/tmp.QilazmMevp.tgz /var/tmp/tmp.Vqsl9SLjqM
    rm: cannot remove '/var/tmp/tmp.Vqsl9SLjqM/venv/share/python-wheels/retrying-1.3.3-py2.py3-none-any.whl': Permission denied
    rm: cannot remove '/var/tmp/tmp.Vqsl9SLjqM/venv/share/python-wheels/distro-1.3.0-py2.py3-none-any.whl': Permission denied
    rm: cannot remove '/var/tmp/tmp.Vqsl9SLjqM/venv/share/python-wheels/ipaddress-0.0.0-py2.py3-none-any.whl': Permission denied
    rm: cannot remove '/var/tmp/tmp.Vqsl9SLjqM/venv/share/python-wheels/wheel-0.32.3-py2.py3-none-any.whl': Permission denied
    ...
    ```
    </s>

    https://github.com/tiny-pilot/tinypilot/pull/1059

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/1058)
<!-- Reviewable:end -->
