### PR TITLE
Handle `preinst` cleanly in Debian package.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,22 +191,13 @@ workflows:
       - check_style
       - build_python
       - build_javascript
-      - build_debian_package:
-          filters:
-            branches:
-              only: master
+      - build_debian_package
       - build_bundle:
           requires:
             - build_debian_package
-          filters:
-            branches:
-              only: master
       - upload_bundle:
           requires:
             - build_bundle
-          filters:
-            branches:
-              only: master
       - e2e:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,13 +191,22 @@ workflows:
       - check_style
       - build_python
       - build_javascript
-      - build_debian_package
+      - build_debian_package:
+          filters:
+            branches:
+              only: master
       - build_bundle:
           requires:
             - build_debian_package
+          filters:
+            branches:
+              only: master
       - upload_bundle:
           requires:
             - build_bundle
+          filters:
+            branches:
+              only: master
       - e2e:
           filters:
             branches:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# syntax=docker/dockerfile:1.4
+# Enable here-documents:
+# https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#here-documents
+
 FROM debian:bullseye-20220328-slim AS build
 
 # The canonical TinyPilot version. For TinyPilot Community, this is a git commit

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,9 @@ RUN echo "Package: ${PKG_NAME}" >> control && \
 
 RUN cat > preinst <<EOF
 #!/bin/bash
+
+# If a .git directory exists, the previous version was installed with the legacy
+# installer, so wipe the install location and the installer directory clean.
 if [[ -d /opt/tinypilot/.git ]]; then
   rm -rf /opt/tinypilot /opt/tinypilot-updater
 fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,13 @@ RUN echo "Package: ${PKG_NAME}" >> control && \
     echo "Homepage: https://tinypilotkvm.com" >> control && \
     echo "Description: Simple, easy-to-use KVM over IP" >> control
 
-RUN echo "#!/bin/bash" > preinst && \
-    echo "rm -rf /opt/tinypilot" >> preinst && \
-    chmod 0555 preinst
+RUN cat > preinst <<EOF
+#!/bin/bash
+if [[ -d /opt/tinypilot/.git ]]; then
+  rm -rf /opt/tinypilot /opt/tinypilot-updater
+fi
+EOF
+RUN chmod 0555 preinst
 
 RUN echo "#!/bin/bash" > postinst && \
     echo "chown -R tinypilot:tinypilot /opt/tinypilot" >> postinst && \


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1055
Dependent on https://github.com/tiny-pilot/tinypilot/pull/1061

This PR alters the Debian package `preinst` script to only remove `/opt/tinypilot` (& `/opt/tinypilot-updater`) when upgrading from the git-based update flow.

Notes:
1. I've enable [here-documents](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#here-documents) in our Dockerfile, like we have done in the [`janus-debian` Dockerfile](https://github.com/tiny-pilot/janus-debian/blob/2a8f0627476adc6bad1149a5a7e53a4f3aa07795/Dockerfile#L1-L3). This allows for cleaner looking multiline `RUN` commands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/1060)
<!-- Reviewable:end -->
