### PR TITLE
Add Debian package `prerm` script.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,22 +191,13 @@ workflows:
       - check_style
       - build_python
       - build_javascript
-      - build_debian_package:
-          filters:
-            branches:
-              only: master
+      - build_debian_package
       - build_bundle:
           requires:
             - build_debian_package
-          filters:
-            branches:
-              only: master
       - upload_bundle:
           requires:
             - build_bundle
-          filters:
-            branches:
-              only: master
       - e2e:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,13 +191,22 @@ workflows:
       - check_style
       - build_python
       - build_javascript
-      - build_debian_package
+      - build_debian_package:
+          filters:
+            branches:
+              only: master
       - build_bundle:
           requires:
             - build_debian_package
+          filters:
+            branches:
+              only: master
       - upload_bundle:
           requires:
             - build_bundle
+          filters:
+            branches:
+              only: master
       - e2e:
           filters:
             branches:

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN cat > prerm <<EOF
 #!/bin/bash
 find /opt/tinypilot \
   -type f \
-  -name '*.py[co]' \
+  -name *.pyc \
   -delete \
   -or \
   -type d \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# syntax=docker/dockerfile:1.4
+# Enable here-documents:
+# https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#here-documents
+
 FROM debian:bullseye-20220328-slim AS build
 
 # The canonical TinyPilot version. For TinyPilot Community, this is a git commit

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,19 +58,18 @@ RUN echo "#!/bin/bash" > postinst && \
     echo "chown -R tinypilot:tinypilot /opt/tinypilot" >> postinst && \
     chmod 0555 postinst
 
-RUN echo "#/bin/bash" > prerm && \
-    echo "set -e" >> prerm && \
-    echo "cd /opt/tinypilot" >> prerm && \
-    echo "rm -rf venv app_settings.cfg" >> prerm && \
-    echo "find . \
--type f \
--name '*.py[co]' \
--delete \
--or \
--type d \
--name __pycache__ \
--delete" >> prerm && \
-    chmod 0555 prerm
+RUN cat > prerm <<EOF
+#!/bin/bash
+find /opt/tinypilot \
+  -type f \
+  -name '*.py[co]' \
+  -delete \
+  -or \
+  -type d \
+  -name __pycache__ \
+  -delete
+EOF
+RUN chmod 0555 prerm
 
 RUN dpkg --build "/releases/${PKG_ID}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,20 @@ RUN echo "#!/bin/bash" > postinst && \
     echo "chown -R tinypilot:tinypilot /opt/tinypilot" >> postinst && \
     chmod 0555 postinst
 
+RUN echo "#/bin/bash" > prerm && \
+    echo "set -e" >> prerm && \
+    echo "cd /opt/tinypilot" >> prerm && \
+    echo "rm -rf venv app_settings.cfg" >> prerm && \
+    echo "find . \
+-type f \
+-name '*.py[co]' \
+-delete \
+-or \
+-type d \
+-name __pycache__ \
+-delete" >> prerm && \
+    chmod 0555 prerm
+
 RUN dpkg --build "/releases/${PKG_ID}"
 
 FROM scratch as artifact

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,13 @@ RUN echo "Package: ${PKG_NAME}" >> control && \
     echo "Homepage: https://tinypilotkvm.com" >> control && \
     echo "Description: Simple, easy-to-use KVM over IP" >> control
 
-RUN echo "#!/bin/bash" > preinst && \
-    echo "rm -rf /opt/tinypilot" >> preinst && \
-    chmod 0555 preinst
+RUN cat > preinst <<EOF
+#!/bin/bash
+if [[ -d /opt/tinypilot/.git ]]; then
+  rm -rf /opt/tinypilot /opt/tinypilot-updater
+fi
+EOF
+RUN chmod 0555 preinst
 
 RUN echo "#!/bin/bash" > postinst && \
     echo "chown -R tinypilot:tinypilot /opt/tinypilot" >> postinst && \


### PR DESCRIPTION
Related to https://github.com/tiny-pilot/tinypilot/issues/1027
Resolves https://github.com/tiny-pilot/tinypilot/issues/1056

This PR adds a `prerm` script to our Debian package that removes `__pycache__` directories and `.pyc` files when the Debian package is removed via `apt-get remove tinypilot`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/1062)
<!-- Reviewable:end -->
