### PR TITLE
Use Debian package `prerm` script to remove `venv` directory.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,13 @@ RUN echo "#!/bin/bash" > postinst && \
 
 RUN cat > prerm <<EOF
 #!/bin/bash
-find /opt/tinypilot \
+
+# Exit script on first failure.
+set -e
+
+cd /opt/tinypilot
+rm -rf venv
+find . \
   -type f \
   -name *.pyc \
   -delete \


### PR DESCRIPTION
Related to https://github.com/tiny-pilot/tinypilot/issues/1027
Related https://github.com/tiny-pilot/tinypilot/issues/1056

I forgot to add a line to https://github.com/tiny-pilot/tinypilot/pull/1062 that also removes the `venv` directory.