### PR TITLE
Add `get-tinypilot.sh` to `.dockerignore` file.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,6 +26,7 @@
 /dev_app_settings.cfg
 /dev_requirements.txt
 /e2e
+/get-tinypilot.sh
 /hooks
 /node_modules
 /package.json


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot-pro/issues/495

The PR removes the `get-tinypilot.sh` script from the TinyPilot Debian package. [See full explanation here](https://github.com/tiny-pilot/tinypilot-pro/issues/495#issuecomment-1191416047).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/1064)
<!-- Reviewable:end -->
