### PR TITLE
Bring back permanent `/opt/tinypilot-updater` folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,9 @@ RUN cat > preinst <<EOF
 #!/bin/bash
 
 # If a .git directory exists, the previous version was installed with the legacy
-# installer, so wipe the install location and the installer directory clean.
+# installer, so wipe the install location.
 if [[ -d /opt/tinypilot/.git ]]; then
-  rm -rf /opt/tinypilot /opt/tinypilot-updater
+  rm -rf /opt/tinypilot
 fi
 EOF
 RUN chmod 0555 preinst

--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -32,12 +32,9 @@ readonly USTREAMER_SETTINGS_FILE='/home/ustreamer/config.yml'
 TINYPILOT_DEBIAN_PACKAGE="$(ls tinypilot*.deb)"
 readonly TINYPILOT_DEBIAN_PACKAGE
 
-VIRTUALENV_DIR="$(mktemp --tmpdir="${TEMP_DIR}" --directory)"
-readonly VIRTUALENV_DIR
-
 # Remove temporary files & directories.
 clean_up() {
-  rm -rf "${INSTALL_SETTINGS_FILE}" "${VIRTUALENV_DIR}"
+  rm -rf "${INSTALL_SETTINGS_FILE}"
 }
 
 # Always clean up before exiting.
@@ -103,9 +100,9 @@ apt-get install -y \
   python3-dev \
   python3-venv
 
-python3 -m venv "${VIRTUALENV_DIR}"
-# shellcheck disable=SC1091,SC1090 # Don’t follow dynamically sourced script.
-. "${VIRTUALENV_DIR}/bin/activate"
+python3 -m venv venv
+# shellcheck disable=SC1091 # Don’t follow sourced script.
+. venv/bin/activate
 # Ensure we're using a version of pip that can use binary wheels where available
 # instead of building the packages locally.
 pip install "pip>=21.3.1"

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -89,15 +89,18 @@ if [[ "${HTTP_CODE}" != "200" ]]; then
   exit 1
 fi
 
-# Extract tarball to installer directory and run install.
+# Extract tarball to installer directory. The installer directory and all its
+# content must have root ownership.
 sudo rm -rf "${INSTALLER_DIR}"
 sudo mkdir -p "${INSTALLER_DIR}"
-sudo chown "$(whoami):$(whoami)" --recursive "${INSTALLER_DIR}"
-tar \
+sudo tar \
   --gunzip \
   --extract \
   --file "${BUNDLE_FILENAME}" \
   --directory "${INSTALLER_DIR}"
+sudo chown "$(whoami):$(whoami)" --recursive "${INSTALLER_DIR}"
+
+# Run install.
 pushd "${INSTALLER_DIR}"
 sudo ./install
 

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -84,7 +84,7 @@ if [[ "${HTTP_CODE}" != "200" ]]; then
   exit 1
 fi
 
-# Extract tarball to temporary directory and run install.
+# Extract tarball to installer directory and run install.
 rm -rf "${INSTALLER_DIR}"
 mkdir -p "${INSTALLER_DIR}"
 tar \

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -92,6 +92,7 @@ fi
 # Extract tarball to installer directory and run install.
 sudo rm -rf "${INSTALLER_DIR}"
 sudo mkdir -p "${INSTALLER_DIR}"
+sudo chown "$(whoami):$(whoami)" --recursive "${INSTALLER_DIR}"
 tar \
   --gunzip \
   --extract \

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -90,8 +90,8 @@ if [[ "${HTTP_CODE}" != "200" ]]; then
 fi
 
 # Extract tarball to installer directory and run install.
-rm -rf "${INSTALLER_DIR}"
-mkdir -p "${INSTALLER_DIR}"
+sudo rm -rf "${INSTALLER_DIR}"
+sudo mkdir -p "${INSTALLER_DIR}"
 tar \
   --gunzip \
   --extract \

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -62,6 +62,11 @@ readonly TEMP_DIR='/var/tmp'
 BUNDLE_FILENAME="$(mktemp --tmpdir="${TEMP_DIR}" --suffix .tgz)"
 readonly BUNDLE_FILENAME
 
+# The installer directory needs to be `/opt/tinypilot-updater`, because other
+# parts of the application rely on the ansible roles being present in that
+# location. In theory, we could otherwise also extract to a temporary and
+# ephemeral folder, and run the installation from there. We might refactor and
+# change this setup in the future.
 readonly INSTALLER_DIR='/opt/tinypilot-updater'
 
 # Remove temporary files & directories.

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -62,12 +62,11 @@ readonly TEMP_DIR='/var/tmp'
 BUNDLE_FILENAME="$(mktemp --tmpdir="${TEMP_DIR}" --suffix .tgz)"
 readonly BUNDLE_FILENAME
 
-BUNDLE_DIR="$(mktemp --tmpdir="${TEMP_DIR}" --directory)"
-readonly BUNDLE_DIR
+readonly INSTALLER_DIR='/opt/tinypilot-updater'
 
 # Remove temporary files & directories.
 clean_up() {
-  rm -rf "${BUNDLE_FILENAME}" "${BUNDLE_DIR}"
+  rm -rf "${BUNDLE_FILENAME}"
 }
 
 # Always clean up before exiting.
@@ -86,12 +85,14 @@ if [[ "${HTTP_CODE}" != "200" ]]; then
 fi
 
 # Extract tarball to temporary directory and run install.
+rm -rf "${INSTALLER_DIR}"
+mkdir -p "${INSTALLER_DIR}"
 tar \
   --gunzip \
   --extract \
   --file "${BUNDLE_FILENAME}" \
-  --directory "${BUNDLE_DIR}"
-pushd "${BUNDLE_DIR}"
+  --directory "${INSTALLER_DIR}"
+pushd "${INSTALLER_DIR}"
 sudo ./install
 
 } # Prevent the script from executing until the client downloads the full file.


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/ansible-role-tinypilot/issues/206.

As discussed in the ticket, we bring back the permanent `/opt/tinypilot-updater` folder, to stay backwards compatible with code that still relies on that path. I also had to “revert” the recent [`venv`-related changes](https://github.com/tiny-pilot/tinypilot/pull/1059), because in order for the privileged scripts to run the ansible roles, [they expect the `venv` folder to exist](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/14cc40e7e53260628be09597799533e080bfc7f9/files/update-video-settings#L57-L60).

With the changes from this branch, I was able to produce a TinyPilot installation on a fresh device with functioning video settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/1065)
<!-- Reviewable:end -->
