### PR TITLE
Add smoke test for bundle integrity.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,28 +257,16 @@ workflows:
       - check_style
       - build_python
       - build_javascript
-      - build_debian_package:
-          filters:
-            branches:
-              only: master
+      - build_debian_package
       - build_bundle:
           requires:
             - build_debian_package
-          filters:
-            branches:
-              only: master
       - check_bundle_integrity:
           requires:
             - build_bundle
-          filters:
-            branches:
-              only: master
       - upload_bundle:
           requires:
             - check_bundle_integrity
-          filters:
-            branches:
-              only: master
       - e2e:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,72 @@ jobs:
           root: ./bundler
           paths:
             - ./dist
+  check_bundle_integrity:
+    docker:
+      - image: cimg/base:2020.01
+    steps:
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Check bundle integrity
+          command: |
+            # Exit script on first failure.
+            set -e
+
+            # Echo commands to stdout.
+            set -x
+
+            # Exit on unset variable.
+            set -u
+
+            BUNDLE_FILE="$(ls dist/tinypilot*.tgz)"
+            readonly BUNDLE_FILE
+            BUNDLE_DIR="$(mktemp --tmpdir=/var/tmp --directory)"
+            readonly BUNDLE_DIR
+
+            # Check bundle size.
+            BUNDLE_SIZE_BYTES="$(wc -c <"${BUNDLE_FILE}")"
+            if [[ "${BUNDLE_SIZE_BYTES}" -eq 0 ]]; then
+              >&2 echo 'Bundle size is zero.'
+              exit 1
+            fi
+            if [[ "${BUNDLE_SIZE_BYTES}" -gt 5000000 ]]; then
+              >&2 echo 'Bundle size is larger than 5mb.'
+              exit 1
+            fi
+
+            # Extract tarball to temporary directory.
+            tar \
+              --gunzip \
+              --extract \
+              --file "${BUNDLE_FILE}" \
+              --directory "${BUNDLE_DIR}"
+            pushd "${BUNDLE_DIR}"
+
+            # Check that install script exists.
+            if [[ ! -f install ]]; then
+              >&2 echo 'Bundle is missing install script.'
+              exit 1
+            fi
+
+            # Check that Debian package exists.
+            if ! ls tinypilot*.deb 1> /dev/null 2>&1; then
+              >&2 echo 'Bundle is missing Debian package.'
+              exit 1
+            fi
+
+            # Check that Ansible roles exist.
+            readonly ANSIBLE_ROLES=(
+              ansible-role-nginx
+              ansible-role-tinypilot
+              ansible-role-ustreamer
+            )
+            for ANSIBLE_ROLE in "${ANSIBLE_ROLES[@]}"; do
+              if [[ ! -d "${ANSIBLE_ROLE}" ]]; then
+                >&2 echo "Missing Ansible role: ${ANSIBLE_ROLE}"
+                exit 1
+              fi
+            done
   upload_bundle:
     docker:
       - image: cimg/base:2020.01
@@ -201,9 +267,15 @@ workflows:
           filters:
             branches:
               only: master
-      - upload_bundle:
+      - check_bundle_integrity:
           requires:
             - build_bundle
+          filters:
+            branches:
+              only: master
+      - upload_bundle:
+          requires:
+            - check_bundle_integrity
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,16 +257,28 @@ workflows:
       - check_style
       - build_python
       - build_javascript
-      - build_debian_package
+      - build_debian_package:
+          filters:
+            branches:
+              only: master
       - build_bundle:
           requires:
             - build_debian_package
+          filters:
+            branches:
+              only: master
       - check_bundle_integrity:
           requires:
             - build_bundle
+          filters:
+            branches:
+              only: master
       - upload_bundle:
           requires:
             - check_bundle_integrity
+          filters:
+            branches:
+              only: master
       - e2e:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,28 +200,16 @@ workflows:
       - check_style
       - build_python
       - build_javascript
-      - build_debian_package:
-          filters:
-            branches:
-              only: master
+      - build_debian_package
       - build_bundle:
           requires:
             - build_debian_package
-          filters:
-            branches:
-              only: master
       - verify_bundle:
           requires:
             - build_bundle
-          filters:
-            branches:
-              only: master
       - upload_bundle:
           requires:
             - verify_bundle
-          filters:
-            branches:
-              only: master
       - e2e:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ jobs:
             )
             for ANSIBLE_ROLE in "${ANSIBLE_ROLES[@]}"; do
               if [[ ! -d "${ANSIBLE_ROLE}" ]]; then
-                >&2 echo "Missing Ansible role: ${ANSIBLE_ROLE}"
+                >&2 echo "Bundle is missing Ansible role: ${ANSIBLE_ROLE}"
                 exit 1
               fi
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,9 +183,9 @@ jobs:
               ansible-role-tinypilot
               ansible-role-ustreamer
             )
-            for ANSIBLE_ROLE in "${ANSIBLE_ROLES[@]}"; do
-              if [[ ! -d "${ANSIBLE_ROLE}" ]]; then
-                >&2 echo "Bundle is missing Ansible role: ${ANSIBLE_ROLE}"
+            for ansible_role in "${ANSIBLE_ROLES[@]}"; do
+              if [[ ! -d "${ansible_role}" ]]; then
+                >&2 echo "Bundle is missing Ansible role: ${ansible_role}"
                 exit 1
               fi
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,72 +123,15 @@ jobs:
           root: ./bundler
           paths:
             - ./dist
-  check_bundle_integrity:
+  verify_bundle:
     docker:
       - image: cimg/base:2020.01
     steps:
       - attach_workspace:
           at: ./
       - run:
-          name: Check bundle integrity
-          command: |
-            # Exit script on first failure.
-            set -e
-
-            # Echo commands to stdout.
-            set -x
-
-            # Exit on unset variable.
-            set -u
-
-            BUNDLE_FILE="$(ls dist/tinypilot*.tgz)"
-            readonly BUNDLE_FILE
-            BUNDLE_DIR="$(mktemp --tmpdir=/var/tmp --directory)"
-            readonly BUNDLE_DIR
-
-            # Check bundle size.
-            BUNDLE_SIZE_BYTES="$(wc -c <"${BUNDLE_FILE}")"
-            if [[ "${BUNDLE_SIZE_BYTES}" -eq 0 ]]; then
-              >&2 echo 'Bundle size is zero.'
-              exit 1
-            fi
-            if [[ "${BUNDLE_SIZE_BYTES}" -gt 5000000 ]]; then
-              >&2 echo 'Bundle size is larger than 5mb.'
-              exit 1
-            fi
-
-            # Extract tarball to temporary directory.
-            tar \
-              --gunzip \
-              --extract \
-              --file "${BUNDLE_FILE}" \
-              --directory "${BUNDLE_DIR}"
-            pushd "${BUNDLE_DIR}"
-
-            # Check that install script exists.
-            if [[ ! -f install ]]; then
-              >&2 echo 'Bundle is missing install script.'
-              exit 1
-            fi
-
-            # Check that Debian package exists.
-            if ! ls tinypilot*.deb 1> /dev/null 2>&1; then
-              >&2 echo 'Bundle is missing Debian package.'
-              exit 1
-            fi
-
-            # Check that Ansible roles exist.
-            readonly ANSIBLE_ROLES=(
-              ansible-role-nginx
-              ansible-role-tinypilot
-              ansible-role-ustreamer
-            )
-            for ansible_role in "${ANSIBLE_ROLES[@]}"; do
-              if [[ ! -d "${ansible_role}" ]]; then
-                >&2 echo "Bundle is missing Ansible role: ${ansible_role}"
-                exit 1
-              fi
-            done
+          name: Verify bundle integrity
+          command: ./bundler/verify-bundle
   upload_bundle:
     docker:
       - image: cimg/base:2020.01
@@ -267,7 +210,7 @@ workflows:
           filters:
             branches:
               only: master
-      - check_bundle_integrity:
+      - verify_bundle:
           requires:
             - build_bundle
           filters:
@@ -275,7 +218,7 @@ workflows:
               only: master
       - upload_bundle:
           requires:
-            - check_bundle_integrity
+            - verify_bundle
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,16 +201,28 @@ workflows:
       - check_style
       - build_python
       - build_javascript
-      - build_debian_package
+      - build_debian_package:
+          filters:
+            branches:
+              only: master
       - build_bundle:
           requires:
             - build_debian_package
+          filters:
+            branches:
+              only: master
       - verify_bundle:
           requires:
             - build_bundle
+          filters:
+            branches:
+              only: master
       - upload_bundle:
           requires:
             - verify_bundle
+          filters:
+            branches:
+              only: master
       - e2e:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ jobs:
     docker:
       - image: cimg/base:2020.01
     steps:
+      - checkout
       - attach_workspace:
           at: ./
       - run:

--- a/bundler/verify-bundle
+++ b/bundler/verify-bundle
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Verify the integrity of the TinyPilot installation bundle.
+
+# Exit script on first failure.
+set -e
+
+# Echo commands to stdout.
+set -x
+
+# Exit on unset variable.
+set -u
+
+BUNDLE_FILE="$(ls dist/tinypilot*.tgz)"
+readonly BUNDLE_FILE
+BUNDLE_DIR="$(mktemp --tmpdir=/var/tmp --directory)"
+readonly BUNDLE_DIR
+
+# Check bundle size.
+BUNDLE_SIZE_BYTES="$(wc -c <"${BUNDLE_FILE}")"
+if [[ "${BUNDLE_SIZE_BYTES}" -eq 0 ]]; then
+  >&2 echo 'Bundle size is zero.'
+  exit 1
+fi
+if [[ "${BUNDLE_SIZE_BYTES}" -gt 5000000 ]]; then
+  >&2 echo 'Bundle size is larger than 5mb.'
+  exit 1
+fi
+
+# Extract tarball to temporary directory.
+tar \
+  --gunzip \
+  --extract \
+  --file "${BUNDLE_FILE}" \
+  --directory "${BUNDLE_DIR}"
+pushd "${BUNDLE_DIR}"
+
+# Check that install script exists.
+if [[ ! -f install ]]; then
+  >&2 echo 'Bundle is missing install script.'
+  exit 1
+fi
+
+# Check that Debian package exists.
+if ! ls tinypilot*.deb 1> /dev/null 2>&1; then
+  >&2 echo 'Bundle is missing Debian package.'
+  exit 1
+fi
+
+# Check that Ansible roles exist.
+readonly ANSIBLE_ROLES=(
+  ansible-role-nginx
+  ansible-role-tinypilot
+  ansible-role-ustreamer
+)
+for ansible_role in "${ANSIBLE_ROLES[@]}"; do
+  if [[ ! -d "${ansible_role}" ]]; then
+    >&2 echo "Bundle is missing Ansible role: ${ansible_role}"
+    exit 1
+  fi
+done


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1006

This PR adds a `check_bundle_integrity` step to our CircleCI workflow. The checks include:
- Bundle size is `>0mb` but `<=5mb`
- Bundle contains `install` script
- Bundle contains Debian package
- Bundle contains Ansible roles

I've tested the new CircleCI workflow here:
https://app.circleci.com/pipelines/github/tiny-pilot/tinypilot/2374/workflows/68256900-3f8e-486f-a33a-a0f84a18a55d

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/1066)
<!-- Reviewable:end -->
