### PR TITLE
Run e2e testing after bundle upload.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,6 +208,8 @@ workflows:
             branches:
               only: master
       - e2e:
+          requires:
+            - upload_bundle
           filters:
             branches:
               only: master


### PR DESCRIPTION
Related to https://github.com/tiny-pilot/tinypilot/issues/1027
Resolves https://github.com/tiny-pilot/tinypilot/issues/1067

This PR makes sure that our CircleCI `e2e` step will use the correct bundle build file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot/1068)
<!-- Reviewable:end -->
