### PR TITLE
Documentation for update mechanism

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,8 +62,12 @@ Modern browsers support MJPEG natively, but it has a few drawbacks:
 
 As of Feb. 2021, uStreamer's maintainer is working on a H264 option, expected to be available in Q1 or Q2 2021. This will likely alleviate issues around MJPEG.
 
-## Installation
+## Software Distribution (Installation, Updates)
 
-TinyPilot's installation process is somewhat unusual in that it depends on Ansible. The [`quick-install`](./quick-install) script bootstraps an Ansible environment on a Raspberry Pi and then uses [`ansible-role-tinypilot`](https://github.com/tiny-pilot/ansible-role-tinypilot) to install itself locally. `ansible-role-tinypilot` transitively includes other roles that TinyPilot depends on such as [`ansible-role-ustreamer`](https://github.com/mtlynch/ansible-role-ustreamer) and [`ansible-role-nginx`](https://github.com/geerlingguy/ansible-role-nginx).
+The TinyPilot software is distributed as a single-file tarball bundle, which is meant to be installed in a Raspberry Pi environment. On a high level, a bundle contains:
 
-The `quick-install` script is also responsible for version-to-version updates and configuration changes.
+- The code for the TinyPilot web service
+- The procedures for configuring the target system, e.g. writing settings files or setting up services.
+- Meta-data, e.g. the TinyPilot version.
+
+For more details, see [the `README` of the bundler](bundler/README.md).

--- a/bundler/README.md
+++ b/bundler/README.md
@@ -1,0 +1,53 @@
+# Bundler
+
+The bundler is responsible for creating a single-file distributable, with which TinyPilot can be installed on the target device.
+
+## Components
+
+### Bundle Structure
+
+The TinyPilot bundle is built from the [`bundle/`](bundle) folder by running the [`create-bundle`](create-bundle) script. At build time, it adds the following dependencies to the bundle:
+
+- The TinyPilot web service:
+  - Built from [`Dockerfile`](../Dockerfile) as Debian package
+  - On the device: installed to `/opt/tinypilot`
+- Several Ansible roles:
+  - Their responsibility is to configure the target system
+  - See e.g. [`ansible-role-tinypilot`](https://github.com/tiny-pilot/ansible-role-tinypilot)
+- Meta-data, e.g. Version information
+
+On the target system, the bundle is unpacked to the `/opt/tinypilot-updater` folder. This is necessary, so that the application can re-run the Ansible roles for applying config changes.
+
+### `get-tinypilot.sh` script
+
+[`get-tinypilot.sh`](../get-tinypilot.sh) is the “entrypoint” for performing a full install or update on the target device.
+
+- On a fresh device, the user runs the script manually.
+- On a device with an existing TinyPilot installation, the script is invoked “under the hood” throughout the update process.
+- When creating disk images with Packer, the script is invoked with a special, pre-configured license.
+
+### Gatekeeper Web Service
+
+Gatekeeper is our web service where the bundles are hosted and distributed. [See here](https://github.com/tiny-pilot/gatekeeper) for more info.
+
+New bundles get automatically uploaded via our build platform:
+
+- For Community, every commit to the `master` branch is released
+- For Pro, only release tags (e.g. `2.4.1`) are released
+
+## Installation / Update Process
+
+For installing TinyPilot on the target device, the `get-tinypilot.sh` script unpacks the bundle and invokes the [`install`](bundle/install) script.
+
+The `install` script performs the following steps. Note, that the procedure is slightly different between TinyPilot Community and Pro.
+
+1. **PRO** `get-tinypilot.sh` checks license.
+2. **PRO|COMMUNITY** `get-tinypilot.sh` script retrieves bundle from Gatekeeper.
+3. **PRO|COMMUNITY** `get-tinypilot.sh` script unpacks bundle to `/opt/tinypilot-updater` and invokes `install` script.
+4. ... (etc.; basically, take over the description from the overhaul document)
+
+## History
+
+### Legacy Update Flow
+
+(Briefly summarize the “old” update system; also reference the overhaul project)


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1007.

## Note (July 30th)

As [mentioned in the ticket](https://github.com/tiny-pilot/tinypilot/issues/1007#issuecomment-1195746761), I started to think about the documentation for the update mechanism:

- This PR contains an outline of the aspects I think would be worth capturing. For now, I only set up the headlines/sections, wrote a few short sentences, and set up some bullet points to get the idea across. If we are happy with scope and structure, I’d phrase things properly and accurately. (I hope it’s not too rough and confusing, I just wanted to briefly check-in actually…)
- I would only create a single instance of the documentation that covers things for both Community and Pro. (As opposed to covering the Pro-specific aspects only in the Pro repo.)
- For gatekeeper, I think we could elaborate a bit more in the [gatekeeper Readme](https://github.com/tiny-pilot/gatekeeper/blob/master/README.md), e.g. to give an overview how it integrates with Backblaze (e.g. the “special files” and our internal folder structure). Other than that, the project feels fairly self-explanatory for me, because of the code structure and comments.
- I’d also briefly summarize the legacy update flow. It might be that in 3 years some user files a bug ticket, because they updated their device from 2020 for the first time, and it might not be immediately obvious to future devs that the update mechanism used to work differently back then. I’d also add some “historic” references, e.g. to the overhaul document or to the mega ticket.