### PR TITLE
Switch back to main branch for `ansible-role-tinypilot`

### DIFF
--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -15,7 +15,7 @@ set -u
 set -x
 
 readonly ANSIBLE_ROLE_TINYPILOT_REPO='https://github.com/tiny-pilot/ansible-role-tinypilot'
-readonly ANSIBLE_ROLE_TINYPILOT_VERSION='update-overhaul'
+readonly ANSIBLE_ROLE_TINYPILOT_VERSION='master'
 
 readonly BUNDLE_DIR='bundle'
 readonly OUTPUT_DIR='dist'


### PR DESCRIPTION
After having merged both https://github.com/tiny-pilot/tinypilot/pull/1046 and https://github.com/tiny-pilot/ansible-role-tinypilot/pull/214, we need to switch back the dependency to the main branch.