### PR TITLE
Use full window width to display remote screen

### DIFF
--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -8,36 +8,6 @@
       object-fit: contain;
     }
 
-    @media screen and (min-width: 800px) {
-      .screen {
-        max-width: 99%;
-      }
-    }
-
-    @media screen and (min-width: 1000px) {
-      .screen {
-        max-width: 97%;
-      }
-    }
-
-    @media screen and (min-width: 1200px) {
-      .screen {
-        max-width: 96%;
-      }
-    }
-
-    @media screen and (min-width: 1300px) {
-      .screen {
-        max-width: 93%;
-      }
-    }
-
-    @media screen and (min-width: 1400px) {
-      .screen {
-        max-width: 90%;
-      }
-    }
-
     @media screen and (min-height: 450px) {
       .screen {
         max-height: 80vh;


### PR DESCRIPTION
I spoke to a customer who pointed out that this is wasted space, especially when the window size is reduced, and we could just use the full width of the window.

I originally kept the margins just because it looked a little tidier not to have it extend completely into the edges, but testing the full bleed behavior does look about the same aesthetically, and it seems like an improvement pragmatically.

---

### Before

https://user-images.githubusercontent.com/7783288/187705066-b63e452c-06d0-44e5-9de8-c5e17bb08f95.mp4

---

### After

https://user-images.githubusercontent.com/7783288/187705089-3e8971cc-2e4f-4a66-8a73-e5e7c664263d.mp4

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1092"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>