### PR TITLE
Add a Privacy Policy to About page

### DIFF
--- a/app/find_files/find.py
+++ b/app/find_files/find.py
@@ -6,6 +6,7 @@ def all_frontend_files():
     return _find_files_by_pattern([
         ('./app/templates', '*.html'),
         ('./app/static/css', '*.css'),
+        ('./app/static/legal', '*'),
         ('./app/static/js', '*.js'),
     ])
 

--- a/app/find_files/find.py
+++ b/app/find_files/find.py
@@ -6,7 +6,7 @@ def all_frontend_files():
     return _find_files_by_pattern([
         ('./app/templates', '*.html'),
         ('./app/static/css', '*.css'),
-        ('./app/static/legal', '*'),
+        ('./app/static/legal', '*.txt'),
         ('./app/static/js', '*.js'),
     ])
 

--- a/app/static/legal/privacy-policy.txt
+++ b/app/static/legal/privacy-policy.txt
@@ -1,6 +1,6 @@
 PRIVACY POLICY
 
-Last updated: 2022-08-30
+Last updated: 2022-08-31
 
 This policy applies to the TinyPilot web application.
 

--- a/app/static/legal/privacy-policy.txt
+++ b/app/static/legal/privacy-policy.txt
@@ -1,0 +1,48 @@
+PRIVACY POLICY
+
+Last updated: 2022-08-30
+
+This policy applies to the TinyPilot web application.
+
+What data we collect and why
+----------------------------
+
+1. Device information: When you check for available updates, TinyPilot records information about the software running on your device in order to match your device with a compatible update. This information includes OS name, kernel version, TinyPilot software version, and IP address.
+
+2. Diagnostic log information: If you generate a shareable URL for your TinyPilot debug logs, your device will upload a copy of your recent application logs to TinyPilot servers. These logs may contain information such as hostnames, browser metadata, usernames, keystrokes or mouse movements. You have an opportunity to review all information before sharing it with us. TinyPilot also records the IP you use to upload this data to TinyPilot servers.
+
+We do NOT collect data for the purposes of marketing or in-app telemetry.
+
+When we access your data
+------------------------
+
+1. To troubleshoot a software issue you've reported: When you share diagnostic logs in the process of requesting technical support, we will review the logs that you share with us.
+
+2. When required by law: TinyPilot, LLC is a US company with all infrastructure located within the US. TinyPilot does not share information about users unless we are compelled by legal process or in the event of an emergency request.
+
+Who we share data with
+----------------------
+
+TinyPilot does not share your data with any other partners or services.
+
+In the event of a sale or merger of TinyPilot, LLC, customer data from the TinyPilot web application will be included in the merger or acquisition and become property of the new company.
+
+Where we store your data
+------------------------
+
+We store your data on servers in the United States.
+
+How long we store your data
+---------------------------
+
+We store your data indefinitely, unless you request removal.
+
+Requesting deletion
+-------------------
+
+You may request deletion of data associated with your TinyPilot device by contacting privacy@tinypilotkvm.com. We will honor deletion requests within 90 days of receipt.
+
+Contacting us
+-------------
+
+For questions about this policy, please contact privacy@tinypilotkvm.com.

--- a/app/static/legal/privacy-policy.txt
+++ b/app/static/legal/privacy-policy.txt
@@ -7,7 +7,7 @@ This policy applies to the TinyPilot web application.
 What data we collect and why
 ----------------------------
 
-1. Device information: When you check for available updates, TinyPilot records information about the software running on your device in order to match your device with a compatible update. This information includes OS name, kernel version, TinyPilot software version, and IP address.
+1. Device information: When you check for available updates, TinyPilot records information about the software running on your device in order to select a compatible update. This information includes OS name, kernel version, TinyPilot software version, and IP address.
 
 2. Diagnostic log information: If you generate a shareable URL for your TinyPilot debug logs, your device will upload a copy of your recent application logs to TinyPilot servers. These logs may contain information such as hostnames, browser metadata, usernames, keystrokes or mouse movements. You have an opportunity to review all information before sharing it with us. TinyPilot also records the IP you use to upload this data to TinyPilot servers.
 
@@ -18,14 +18,14 @@ When we access your data
 
 1. To troubleshoot a software issue you've reported: When you share diagnostic logs in the process of requesting technical support, we will review the logs that you share with us.
 
-2. When required by law: TinyPilot, LLC is a US company with all infrastructure located within the US. TinyPilot does not share information about users unless we are compelled by legal process or in the event of an emergency request.
+2. When required by law: TinyPilot, LLC is a US company with all infrastructure located within the US. TinyPilot does not share information about users unless we are compelled by a legal process or in the event of an emergency government request.
 
 Who we share data with
 ----------------------
 
 TinyPilot does not share your data with any other partners or services.
 
-In the event of a sale or merger of TinyPilot, LLC, customer data from the TinyPilot web application will be included in the merger or acquisition and become property of the new company.
+In the event of a sale or merger of TinyPilot, LLC, customer data from the TinyPilot web application will be included in the merger or acquisition and will become property of the new company.
 
 Where we store your data
 ------------------------

--- a/app/templates/custom-elements/about-dialog.html
+++ b/app/templates/custom-elements/about-dialog.html
@@ -54,7 +54,7 @@
       <a href="/licensing/TinyPilot/license" target="_blank">MIT license</a
       ><br />
       <strong>Privacy:</strong>
-      <a href="/privacy-policy" target="_blank">Privacy Policy</a>
+      <a href="/legal/privacy-policy.txt" target="_blank">Privacy Policy</a>
     </p>
 
     <p>

--- a/app/templates/custom-elements/about-dialog.html
+++ b/app/templates/custom-elements/about-dialog.html
@@ -51,7 +51,10 @@
         >https://tinypilotkvm.com</a
       ><br />
       <strong>License:</strong>
-      <a href="/licensing/TinyPilot/license" target="_blank">MIT license</a>
+      <a href="/licensing/TinyPilot/license" target="_blank">MIT license</a
+      ><br />
+      <strong>Privacy:</strong>
+      <a href="/privacy-policy" target="_blank">Privacy Policy</a>
     </p>
 
     <p>


### PR DESCRIPTION
Add a privacy policy to cover the types of data we collect from TinyPilot and link to it from the About page.

We don't collect OS and software version in the Community version yet, but we've included language for it in the privacy policy in case we decide to collect that in the future.

TinyPilot Pro will have adjustments to this policy, as it collects additional information for license checking.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1096"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>