### PR TITLE
Migrate off of CircleCI's deprecated node.js container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           command: ./dev-scripts/check-bash
   check_style:
     docker:
-      - image: circleci/node:14.17.5-stretch
+      - image: cimg/node:14.17.5
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
             ./dev-scripts/build-python
   build_javascript:
     docker:
-      - image: circleci/node:14.17.5-stretch
+      - image: cimg/node:14.17.5
     steps:
       - checkout
       - run:


### PR DESCRIPTION
circleci/* containers are now deprecated, so we should move to cimg/* containers:

https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1098"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>