### PR TITLE
Disable pylint's too-many-lines rule

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -35,6 +35,7 @@ disable=
   too-many-public-methods,
   missing-class-docstring,
   superfluous-parens,
+  too-many-lines,       # We can decide on our own which files are too long
   multiple-imports,     # We're using isort to lint imports
   ungrouped-imports,    # We're using isort to lint imports
   wrong-import-order,   # We're using isort to lint imports


### PR DESCRIPTION
For a project of our scale, we don't need the linter to point out when a file is too long. We can consciously decide to let a line grow long for other reasons.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1100"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>