### PR TITLE
Clarify coding conventions on underscore prefix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,9 +233,9 @@ connectedCallback() {
 };
 ```
 
-### Use underscore to represent private methods
+### Use an underscore-prefix to name private members
 
-Most of the functions in a web component are only intended for usage within the component. For these functions, prepend the function name with an underscore like `_upload() { ... }`. Functions that accept input from external callers should be prefix-free like `show()`.
+For internal class members (i.e., functions or fields) of a web component that are only supposed to be used within the component, prepend the member name with an underscore like `_upload() { ... }` or `this._port = 8080`. Public members, e.g. functions that are invoked from the outside, should be prefix-free like `show()`.
 
 ### Use free functions where possible
 


### PR DESCRIPTION
Our coding conventions only covered the underscore prefix for class functions, not for fields. Per discussion in https://github.com/tiny-pilot/tinypilot-pro/pull/583#pullrequestreview-1110732410, we also want to apply this convention for fields, though.

I’ve updated the instructions, and also clarified them a bit otherwise.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1101"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>