### PR TITLE
Remove support for obsolete update setting `tinypilot_repo_branch`

### DIFF
--- a/app/update/settings.py
+++ b/app/update/settings.py
@@ -8,7 +8,6 @@ allows TinyPilot code to modify it cleanly.
 Typical usage example:
 
     settings = update_settings.load()
-    settings.tinypilot_repo_branch = '2.1.5'
     update_settings.save(settings)
 """
 
@@ -40,23 +39,6 @@ class Settings:
 
     def as_dict(self):
         return self._data
-
-    # Note: tinypilot_repo_branch is confusingly named. It should really be
-    # tinypilot_repo_version, but this class just reflects the names in the
-    # TinyPilot Ansible role.
-    @property
-    def tinypilot_repo_branch(self):
-        return self._data['tinypilot_repo_branch']
-
-    @tinypilot_repo_branch.setter
-    def tinypilot_repo_branch(self, value):
-        """Sets the value of tinypilot_repo_branch in update settings.
-
-        Args:
-            value: A string value of a branch or tag name like '2.1.0' or
-                'virtual-storage'.
-        """
-        self._data['tinypilot_repo_branch'] = value
 
     @property
     def ustreamer_desired_fps(self):

--- a/app/update/settings.py
+++ b/app/update/settings.py
@@ -8,6 +8,7 @@ allows TinyPilot code to modify it cleanly.
 Typical usage example:
 
     settings = update_settings.load()
+    settings.ustreamer_desired_fps = 15
     update_settings.save(settings)
 """
 

--- a/app/update/settings_test.py
+++ b/app/update/settings_test.py
@@ -70,6 +70,21 @@ ustreamer_desired_fps: 25
 ustreamer_desired_fps: 10
 """.lstrip(), self.read_mock_settings_file())
 
+    def test_adds_additional_property_to_existing_file(self):
+        self.make_mock_settings_file("""
+ustreamer_desired_fps: 25
+""".lstrip())
+
+        settings = update.settings.load()
+        settings.ustreamer_quality = 50
+        update.settings.save(settings)
+
+        self.assertMultiLineEqual(
+            """
+ustreamer_desired_fps: 25
+ustreamer_quality: 50
+""".lstrip(), self.read_mock_settings_file())
+
     def test_leaves_unrecognized_settings_intact(self):
         self.make_mock_settings_file("""
 unrecognized_setting: dummyvalue

--- a/app/update/settings_test.py
+++ b/app/update/settings_test.py
@@ -46,44 +46,42 @@ class UpdateSettingsTest(unittest.TestCase):
 
         self.assertEqual('', self.read_mock_settings_file())
 
-    def test_populates_empty_file_with_branch_name(self):
+    def test_populates_empty_file_with_initial_data(self):
         self.make_mock_settings_file('')
 
         settings = update.settings.load()
-        settings.tinypilot_repo_branch = 'dummy-branch-name'
+        settings.ustreamer_desired_fps = 25
         update.settings.save(settings)
 
-        self.assertMultiLineEqual(
-            """
-tinypilot_repo_branch: dummy-branch-name
+        self.assertMultiLineEqual("""
+ustreamer_desired_fps: 25
 """.lstrip(), self.read_mock_settings_file())
 
-    def test_overwrites_existing_branch_name(self):
+    def test_overwrites_value_of_existing_property(self):
         self.make_mock_settings_file("""
-tinypilot_repo_branch: branch-name-to-overwrite
+ustreamer_desired_fps: 25
 """.lstrip())
 
         settings = update.settings.load()
-        settings.tinypilot_repo_branch = 'dummy-branch-name'
+        settings.ustreamer_desired_fps = 10
         update.settings.save(settings)
 
-        self.assertMultiLineEqual(
-            """
-tinypilot_repo_branch: dummy-branch-name
+        self.assertMultiLineEqual("""
+ustreamer_desired_fps: 10
 """.lstrip(), self.read_mock_settings_file())
 
     def test_leaves_unrecognized_settings_intact(self):
         self.make_mock_settings_file("""
-tinypilot_repo_branch: branch-name-to-overwrite
 unrecognized_setting: dummyvalue
+ustreamer_desired_fps: 25
 """.lstrip())
 
         settings = update.settings.load()
-        settings.tinypilot_repo_branch = 'dummy-branch-name'
+        settings.ustreamer_desired_fps = 10
         update.settings.save(settings)
 
         self.assertMultiLineEqual(
             """
-tinypilot_repo_branch: dummy-branch-name
 unrecognized_setting: dummyvalue
+ustreamer_desired_fps: 10
 """.lstrip(), self.read_mock_settings_file())


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot-pro/issues/496. **Only to be merged after https://github.com/tiny-pilot/tinypilot-pro/pull/589 is in, to not break the Pro repo.**

We don’t need the `tinypilot_repo_branch` setting any longer, and we also [don’t need to support it for backwards compatibility](https://github.com/tiny-pilot/tinypilot-pro/pull/564#issuecomment-1232120564), so it can go away.

I made the test titles more generic, to indicate that they are not really about testing individual properties (such as `tinypilot_repo_branch`), but rather about the general functionality.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1102"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>