### PR TITLE
Add test case for update settings

### DIFF
--- a/app/update/settings_test.py
+++ b/app/update/settings_test.py
@@ -70,6 +70,21 @@ ustreamer_desired_fps: 25
 ustreamer_desired_fps: 10
 """.lstrip(), self.read_mock_settings_file())
 
+    def test_adds_additional_property_to_existing_file(self):
+        self.make_mock_settings_file("""
+ustreamer_desired_fps: 25
+""".lstrip())
+
+        settings = update.settings.load()
+        settings.ustreamer_quality = 50
+        update.settings.save(settings)
+
+        self.assertMultiLineEqual(
+            """
+ustreamer_desired_fps: 25
+ustreamer_quality: 50
+""".lstrip(), self.read_mock_settings_file())
+
     def test_leaves_unrecognized_settings_intact(self):
         self.make_mock_settings_file("""
 unrecognized_setting: dummyvalue


### PR DESCRIPTION
While working on https://github.com/tiny-pilot/tinypilot/pull/1102, I noticed that there is one test scenario that we didn’t cover yet, so I’ve added it here. (Note, this PR goes into the other one.)
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1103"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>