### PR TITLE
Fix recommended VS code extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,3 @@
 {
-  "recommendations": [
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
-    "octref.vetur"
-  ]
+  "recommendations": ["esbenp.prettier-vscode", "ms-python.python"]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["esbenp.prettier-vscode", "ms-python.python"]
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "ms-python.pylint",
+    "ms-python.python"
+  ]
 }


### PR DESCRIPTION
Updating VS Code's extensions to match what's in the actual project. vetur is a Vue plugin, so we don't need that. eslint might be useful, but we aren't integrated with it yet in any of the other project config, so we should exclude it until we decide to use it. python, we're currently using in settings.json, but we forgot to include it as a recommended extension.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1104"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>