### PR TITLE
Remove TinyPilot Pro before installing Community.

### DIFF
--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -104,7 +104,7 @@ sudo chown root:root --recursive "${INSTALLER_DIR}"
 # the TinyPilot Community Debian package.
 # https://github.com/tiny-pilot/tinypilot-pro/issues/596
 if [[ "${HAS_PRO_INSTALLED}" -eq 1 ]]; then
-  sudo apt-get remove tinypilot --yes
+  sudo apt-get remove tinypilot --yes || true
 fi
 
 # Run install.


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot-pro/issues/596

This PR uninstalls the TinyPilot Pro Debian package (if installed) before installing the TinyPilot Community Debian package.

### Notes

* [Similar to what I mentioned here](https://github.com/tiny-pilot/gatekeeper/pull/71#issue-1383981923), if someone is downgrading from a legacy TinyPilot Pro version (before the update overhaul) then uninstalling the `tinypilot` Debian package would fail because it was never installed. To avoid this, [I just ignore any errors that that happen when attempting to uninstall `tinypilot`](https://github.com/tiny-pilot/tinypilot/blob/338e47ed00b44c499dbf4b09369b7077192be1fb/get-tinypilot.sh#L107). Not ideal.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1107"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>