### PR TITLE
Video Settings dialog: CSS/HTML refactoring

### DIFF
--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -15,32 +15,34 @@
       display: block;
     }
 
-    .settings {
-      margin: 2.5rem 0 1.5rem 0;
+    .settings-container {
+      margin: 2rem 0;
     }
 
-    .input-container {
-      display: inline-flex;
-      flex-direction: row;
-      margin-bottom: 1rem;
+    .setting {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      margin-bottom: 1.5rem;
     }
 
-    .input-container label {
-      display: inline-block;
+    .setting label {
+      display: block;
       text-align: right;
-      margin-right: 0.5rem;
-      width: 100px;
+      margin-right: 0.5em;
+      width: 6em;
     }
 
-    .input-container input {
-      display: inline-block;
-      width: 350px;
+    .setting input {
+      display: block;
+      flex: 1;
+      max-width: 28em;
     }
 
-    #video-fps-display,
-    #video-jpeg-quality-display {
-      display: inline-block;
-      width: 50px;
+    .setting-value {
+      width: 5em;
+      text-align: left;
+      margin-left: 0.75em;
     }
   </style>
   <div id="loading">
@@ -49,16 +51,16 @@
   </div>
   <div id="edit">
     <h3>Change Video Settings</h3>
-    <div class="settings">
-      <div class="input-container">
+    <div class="settings-container">
+      <div class="setting">
         <label for="video-fps-slider">FPS</label>
         <input type="range" id="video-fps-slider" min="1" max="30" />
-        <span id="video-fps-display"></span>
+        <div id="video-fps-display" class="setting-value"></div>
       </div>
-      <div class="input-container">
+      <div class="setting">
         <label for="video-jpeg-quality-slider">JPEG Quality</label>
         <input type="range" id="video-jpeg-quality-slider" min="1" max="100" />
-        <span id="video-jpeg-quality-display"></span>
+        <div id="video-jpeg-quality-display" class="setting-value"></div>
       </div>
     </div>
     <button class="save-btn btn-success" type="button">


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot/issues/1112.

I did a minor refactoring of the CSS/HTML in the video settings dialog (with almost no visual effect), which I believe will help me make it easier to implement all the upcoming changes.

- Rename CSS classes
- Use `flex` instead of `inline-flex`, for simplicity
- Use `<div>` instead of `<span>` for the value, so we can drop `display: block`.
- Assign CSS class to value’s `<div>`, to avoid having to enumerate (repeat) the individual ids
- For the width and spacing of the `.setting`, use `em` instead of `px`, so that the sizes are relative to the element’s font size. So, e.g., if we increased the font size, the width of the label element would grow automatically.
- Slightly increase the spacing between both settings, and re-align the surrounding container by a tiny bit.

<img width="872" alt="Screenshot 2022-09-30 at 09 26 25" src="https://user-images.githubusercontent.com/83721279/193215067-530a7fbd-a97e-4434-aebf-468ccef22975.png">

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1118"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>