### PR TITLE
Video Settings dialog: re-word labels, and display units

### DIFF
--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -15,32 +15,34 @@
       display: block;
     }
 
-    .settings {
-      margin: 2.5rem 0 1.5rem 0;
+    .settings-container {
+      margin: 2rem 0;
     }
 
-    .input-container {
-      display: inline-flex;
-      flex-direction: row;
-      margin-bottom: 1rem;
+    .setting {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      margin-bottom: 1.5rem;
     }
 
-    .input-container label {
-      display: inline-block;
+    .setting label {
+      display: block;
       text-align: right;
-      margin-right: 0.5rem;
-      width: 100px;
+      margin-right: 0.5em;
+      width: 6em;
     }
 
-    .input-container input {
-      display: inline-block;
-      width: 350px;
+    .setting input {
+      display: block;
+      flex: 1;
+      max-width: 28em;
     }
 
-    #video-fps-display,
-    #video-jpeg-quality-display {
-      display: inline-block;
-      width: 50px;
+    .setting-value {
+      width: 5em;
+      text-align: left;
+      margin-left: 0.75em;
     }
   </style>
   <div id="loading">
@@ -49,16 +51,16 @@
   </div>
   <div id="edit">
     <h3>Change Video Settings</h3>
-    <div class="settings">
-      <div class="input-container">
+    <div class="settings-container">
+      <div class="setting">
         <label for="video-fps-slider">FPS</label>
         <input type="range" id="video-fps-slider" min="1" max="30" />
-        <span id="video-fps-display"></span>
+        <div id="video-fps-display" class="setting-value"></div>
       </div>
-      <div class="input-container">
+      <div class="setting">
         <label for="video-jpeg-quality-slider">JPEG Quality</label>
         <input type="range" id="video-jpeg-quality-slider" min="1" max="100" />
-        <span id="video-jpeg-quality-display"></span>
+        <div id="video-jpeg-quality-display" class="setting-value"></div>
       </div>
     </div>
     <button class="save-btn btn-success" type="button">

--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -40,9 +40,9 @@
     }
 
     .setting-value {
-      width: 5em;
-      text-align: left;
-      margin-left: 0.75em;
+      width: 3.5em;
+      text-align: right;
+      margin-left: 0.25em;
     }
   </style>
   <div id="loading">

--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -53,12 +53,12 @@
     <h3>Change Video Settings</h3>
     <div class="settings-container">
       <div class="setting">
-        <label for="video-fps-slider">FPS</label>
+        <label for="video-fps-slider">Frame Rate</label>
         <input type="range" id="video-fps-slider" min="1" max="30" />
         <div id="video-fps-display" class="setting-value"></div>
       </div>
       <div class="setting">
-        <label for="video-jpeg-quality-slider">JPEG Quality</label>
+        <label for="video-jpeg-quality-slider">Quality</label>
         <input type="range" id="video-jpeg-quality-slider" min="1" max="100" />
         <div id="video-jpeg-quality-display" class="setting-value"></div>
       </div>
@@ -157,14 +157,14 @@
           const videoFpsDisplayElement = this.shadowRoot.querySelector(
             "#video-fps-display"
           );
-          videoFpsDisplayElement.innerHTML = videoFps;
+          videoFpsDisplayElement.innerHTML = `${videoFps} fps`;
         }
 
         _setVideoJpegQualityDisplay(videoJpegQuality) {
           const videoJpegQualityDisplayElement = this.shadowRoot.querySelector(
             "#video-jpeg-quality-display"
           );
-          videoJpegQualityDisplayElement.innerHTML = videoJpegQuality;
+          videoJpegQualityDisplayElement.innerHTML = `${videoJpegQuality} %`;
         }
 
         _fetchVideoFps() {


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot/issues/1112, and based on https://github.com/tiny-pilot/tinypilot/pull/1118.

- Instead of `fps`, we could also write `f/s`, but I think [the former is more widely recognized](https://en.wikipedia.org/wiki/Frame_rate).

<img width="876" alt="Screenshot 2022-09-30 at 09 26 59" src="https://user-images.githubusercontent.com/83721279/193215616-a18d64ed-c7ef-4186-b2d6-e859f7fdbb96.png">

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1119"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>