### PR TITLE
Video Settings dialog: clean up / simplify component implementation

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -348,7 +348,7 @@ menuBar.addEventListener("wake-on-lan-dialog-requested", () => {
   document.getElementById("feature-pro-overlay").show();
 });
 menuBar.addEventListener("video-settings-dialog-requested", () => {
-  document.getElementById("video-settings-dialog").getSettings();
+  document.getElementById("video-settings-dialog").initialize();
   document.getElementById("video-settings-overlay").show();
 });
 menuBar.addEventListener("paste-requested", () => {

--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -116,9 +116,9 @@
         connectedCallback() {
           this.shadowRoot.appendChild(template.content.cloneNode(true));
           this.elements = {
-            buttonSave: this.shadowRoot.querySelector("#edit .save-btn"),
-            buttonClose: this.shadowRoot.querySelector(".close-btn"),
-            buttonRestore: this.shadowRoot.querySelector("#edit .restore-btn"),
+            saveButton: this.shadowRoot.querySelector("#edit .save-btn"),
+            closeButton: this.shadowRoot.querySelector(".close-btn"),
+            restoreButton: this.shadowRoot.querySelector("#edit .restore-btn"),
             fpsSlider: this.shadowRoot.querySelector("#fps-slider"),
             fpsValue: this.shadowRoot.querySelector("#fps-value"),
             jpegQualitySlider: this.shadowRoot.querySelector(
@@ -128,13 +128,13 @@
               "#jpeg-quality-value"
             ),
           };
-          this.elements.buttonClose.addEventListener("click", () =>
+          this.elements.closeButton.addEventListener("click", () =>
             this.dispatchEvent(new DialogClosedEvent())
           );
-          this.elements.buttonSave.addEventListener("click", () =>
+          this.elements.saveButton.addEventListener("click", () =>
             this._saveSettings()
           );
-          this.elements.buttonRestore.addEventListener("click", () =>
+          this.elements.restoreButton.addEventListener("click", () =>
             this._restoreSettings()
           );
           this.elements.fpsSlider.addEventListener("input", (event) => {

--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -37,8 +37,8 @@
       width: 350px;
     }
 
-    #video-fps-display,
-    #video-jpeg-quality-display {
+    #fps-value,
+    #jpeg-quality-value {
       display: inline-block;
       width: 50px;
     }
@@ -51,14 +51,14 @@
     <h3>Change Video Settings</h3>
     <div class="settings">
       <div class="input-container">
-        <label for="video-fps-slider">FPS</label>
-        <input type="range" id="video-fps-slider" min="1" max="30" />
-        <span id="video-fps-display"></span>
+        <label for="fps-slider">FPS</label>
+        <input type="range" id="fps-slider" min="1" max="30" />
+        <span id="fps-value"></span>
       </div>
       <div class="input-container">
-        <label for="video-jpeg-quality-slider">JPEG Quality</label>
-        <input type="range" id="video-jpeg-quality-slider" min="1" max="100" />
-        <span id="video-jpeg-quality-display"></span>
+        <label for="jpeg-quality-slider">JPEG Quality</label>
+        <input type="range" id="jpeg-quality-slider" min="1" max="100" />
+        <span id="jpeg-quality-value"></span>
       </div>
     </div>
     <button class="save-btn btn-success" type="button">
@@ -110,32 +110,39 @@
         constructor() {
           super();
           this.attachShadow({ mode: "open" });
-          this.defaultSettings = {};
+          this._defaultSettings = {};
         }
 
         connectedCallback() {
           this.shadowRoot.appendChild(template.content.cloneNode(true));
-          this.shadowRoot
-            .querySelector(".close-btn")
-            .addEventListener("click", () =>
-              this.dispatchEvent(new DialogClosedEvent())
-            );
-          this.shadowRoot
-            .querySelector("#edit .restore-btn")
-            .addEventListener("click", () => this._restoreSettings());
-          this.shadowRoot
-            .querySelector("#edit .save-btn")
-            .addEventListener("click", () => this._saveSettings());
-          this.shadowRoot
-            .querySelector("#video-fps-slider")
-            .addEventListener("input", (event) => {
-              this._setVideoFpsDisplay(event.target.value);
-            });
-          this.shadowRoot
-            .querySelector("#video-jpeg-quality-slider")
-            .addEventListener("input", (event) => {
-              this._setVideoJpegQualityDisplay(event.target.value);
-            });
+          this.elements = {
+            buttonSave: this.shadowRoot.querySelector("#edit .save-btn"),
+            buttonClose: this.shadowRoot.querySelector(".close-btn"),
+            buttonRestore: this.shadowRoot.querySelector("#edit .restore-btn"),
+            fpsSlider: this.shadowRoot.querySelector("#fps-slider"),
+            fpsValue: this.shadowRoot.querySelector("#fps-value"),
+            jpegQualitySlider: this.shadowRoot.querySelector(
+              "#jpeg-quality-slider"
+            ),
+            jpegQualityValue: this.shadowRoot.querySelector(
+              "#jpeg-quality-value"
+            ),
+          };
+          this.elements.buttonClose.addEventListener("click", () =>
+            this.dispatchEvent(new DialogClosedEvent())
+          );
+          this.elements.buttonSave.addEventListener("click", () =>
+            this._saveSettings()
+          );
+          this.elements.buttonRestore.addEventListener("click", () =>
+            this._restoreSettings()
+          );
+          this.elements.fpsSlider.addEventListener("input", (event) => {
+            this._setFps(parseInt(event.target.value, 10));
+          });
+          this.elements.jpegQualitySlider.addEventListener("input", (event) => {
+            this._setJpegQuality(parseInt(event.target.value, 10));
+          });
         }
 
         get state() {
@@ -151,160 +158,74 @@
           );
         }
 
-        _setVideoFpsDisplay(videoFps) {
-          const videoFpsDisplayElement = this.shadowRoot.querySelector(
-            "#video-fps-display"
-          );
-          videoFpsDisplayElement.innerHTML = videoFps;
-        }
-
-        _setVideoJpegQualityDisplay(videoJpegQuality) {
-          const videoJpegQualityDisplayElement = this.shadowRoot.querySelector(
-            "#video-jpeg-quality-display"
-          );
-          videoJpegQualityDisplayElement.innerHTML = videoJpegQuality;
-        }
-
-        _fetchVideoFps() {
-          return getVideoFps()
-            .then((videoFps) => {
-              this.shadowRoot.querySelector(
-                "#video-fps-slider"
-              ).value = videoFps;
-              this._setVideoFpsDisplay(videoFps);
-            })
-            .catch((error) => {
-              this.dispatchEvent(
-                new DialogFailedEvent({
-                  title: "Failed to Load Video FPS",
-                  details: error,
-                })
-              );
-              return Promise.reject(error);
-            });
-        }
-
-        _fetchVideoJpegQuality() {
-          return getVideoJpegQuality()
-            .then((videoJpegQuality) => {
-              this.shadowRoot.querySelector(
-                "#video-jpeg-quality-slider"
-              ).value = videoJpegQuality;
-              this._setVideoJpegQualityDisplay(videoJpegQuality);
-            })
-            .catch((error) => {
-              this.dispatchEvent(
-                new DialogFailedEvent({
-                  title: "Failed to Load Video JPEG Quality",
-                  details: error,
-                })
-              );
-              return Promise.reject(error);
-            });
-        }
-
-        getSettings() {
+        initialize() {
           this.state = this.states.LOADING;
           Promise.all([
-            this._fetchVideoFps(),
-            this._fetchVideoJpegQuality(),
-            this._fetchDefaultVideoFps(),
-            this._fetchDefaultVideoJpegQuality(),
+            getVideoFps(),
+            getDefaultVideoFps(),
+            getVideoJpegQuality(),
+            getDefaultVideoJpegQuality(),
           ])
-            .then(() => {
+            .then(([fps, defaultFps, jpegQuality, defaultJpegQuality]) => {
+              this._setFps(fps);
+              this._defaultSettings.fps = defaultFps;
+
+              this._setJpegQuality(jpegQuality);
+              this._defaultSettings.jpegQuality = defaultJpegQuality;
+
               this.state = this.states.EDIT;
             })
-            .catch(() => {
-              // Ignore errors here because they have already been handled by
-              // their individual setting load function.
-            });
-        }
-
-        _fetchDefaultVideoFps() {
-          return getDefaultVideoFps()
-            .then((videoFps) => {
-              this.defaultSettings.videoFps = videoFps;
-            })
             .catch((error) => {
               this.dispatchEvent(
                 new DialogFailedEvent({
-                  title: "Failed to Load Default Video FPS",
+                  title: "Failed to Load Video Settings",
                   details: error,
                 })
               );
-              return Promise.reject(error);
             });
         }
 
-        _fetchDefaultVideoJpegQuality() {
-          return getDefaultVideoJpegQuality()
-            .then((videoJpegQuality) => {
-              this.defaultSettings.videoJpegQuality = videoJpegQuality;
-            })
-            .catch((error) => {
-              this.dispatchEvent(
-                new DialogFailedEvent({
-                  title: "Failed to Load Default Video JPEG Quality",
-                  details: error,
-                })
-              );
-              return Promise.reject(error);
-            });
+        /**
+         * @returns {number}
+         */
+        _getFps() {
+          return parseInt(this.elements.fpsSlider.value, 10);
         }
 
-        _restoreVideoFps() {
-          this.shadowRoot.querySelector(
-            "#video-fps-slider"
-          ).value = this.defaultSettings.videoFps;
-          this._setVideoFpsDisplay(this.defaultSettings.videoFps);
+        /**
+         * @param fps {number}
+         */
+        _setFps(fps) {
+          this.elements.fpsSlider.value = fps;
+          this.elements.fpsValue.innerHTML = fps;
         }
 
-        _restoreVideoJpegQuality() {
-          this.shadowRoot.querySelector(
-            "#video-jpeg-quality-slider"
-          ).value = this.defaultSettings.videoJpegQuality;
-          this._setVideoJpegQualityDisplay(
-            this.defaultSettings.videoJpegQuality
-          );
+        /**
+         * @returns {number}
+         */
+        _getJpegQuality() {
+          return parseInt(this.elements.jpegQualitySlider.value, 10);
+        }
+
+        /**
+         * @param jpegQuality {number}
+         */
+        _setJpegQuality(jpegQuality) {
+          this.elements.jpegQualitySlider.value = jpegQuality;
+          this.elements.jpegQualityValue.innerHTML = jpegQuality;
         }
 
         _restoreSettings() {
-          this._restoreVideoFps();
-          this._restoreVideoJpegQuality();
-        }
-
-        _saveVideoFps() {
-          let videoFps = this.shadowRoot.querySelector("#video-fps-slider")
-            .value;
-          return setVideoFps(videoFps).catch((error) => {
-            this.dispatchEvent(
-              new DialogFailedEvent({
-                title: "Failed to Save Video FPS",
-                details: error,
-              })
-            );
-            return Promise.reject(error);
-          });
-        }
-
-        _saveVideoJpegQuality() {
-          let videoJpegQuality = this.shadowRoot.querySelector(
-            "#video-jpeg-quality-slider"
-          ).value;
-          return setVideoJpegQuality(videoJpegQuality).catch((error) => {
-            this.dispatchEvent(
-              new DialogFailedEvent({
-                title: "Failed to Save Video JPEG Quality",
-                details: error,
-              })
-            );
-            return Promise.reject(error);
-          });
+          this._setFps(this._defaultSettings.fps);
+          this._setJpegQuality(this._defaultSettings.jpegQuality);
         }
 
         _saveSettings() {
           this.state = this.states.SAVING;
-          Promise.all([this._saveVideoFps(), this._saveVideoJpegQuality()])
+          return Promise.all([
+            setVideoFps(this._getFps()),
+            setVideoJpegQuality(this._getJpegQuality()),
+          ])
             .then(applyVideoSettings)
             .then(() => {
               // Note: After the video stream stops, it doesn't try to
@@ -312,9 +233,13 @@
               // reload the page.
               location.reload();
             })
-            .catch(() => {
-              // Ignore errors here because they have already been handled by
-              // their individual setting save function.
+            .catch((error) => {
+              this.dispatchEvent(
+                new DialogFailedEvent({
+                  title: "Failed to Change Video Settings",
+                  details: error,
+                })
+              );
             });
         }
       }


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot/issues/1112.

This is a non-functional refactoring of the component’s JS implementation, which should help to extend the class with the upcoming functionality.

These are my thoughts behind the changes. Please don’t be scared by the amount of text, it’s (hopefully) all not as complicated as it might seem at first glance 🙈 … I thought it makes more sense to do this all in one collective PR, because many of the changes are related, and we also only need one round of QA’ing.

- I renamed `getSettings` to `initialize`. We are [not consistent with naming these entrypoint methods](https://github.com/tiny-pilot/tinypilot/blob/6073998459e21317800139df38166cd34396d4fd/app/static/js/app.js#L322-L353), but at least `initialize()` appears twice. I think it makes sense to have a uniform method name here, as the function is basically like the “constructor” of the dialog.
- I dropped all `video` prefixes from both the CSS and JS code. I think they create a lot of noise, and to me the purpose of the identifiers is sufficiently clear from the context.
- I’ve added `this.elements`, to avoid repeating CSS identifiers.
- I prefixed `this.defaultSettings` with an `_`, [according to our recently updated coding conventions](https://github.com/tiny-pilot/tinypilot/blob/6073998459e21317800139df38166cd34396d4fd/CONTRIBUTING.md?plain=1#L236-L238). Note that `this.elements` is [still an explicit exception](https://github.com/tiny-pilot/tinypilot/blob/6073998459e21317800139df38166cd34396d4fd/CONTRIBUTING.md?plain=1#L216). I’ve opened https://github.com/tiny-pilot/tinypilot/issues/1120 for tracking this inconsistency.
- I’ve simplified fetching and saving, because those two operations always happen for *all* settings. So I think the benefit of having individual methods (like `_fetchVideoFps()`) is not worth the amount of code that takes. One by-effect of this is that the error messages are not as fine-granular anymore, so if something fails it just says: “Failed to Change Video Settings” instead of “Failed to Save Video FPS”. To me, that’s okay, since this doesn’t make a practical difference for the end-user, and for debugging we can tell from the logs which one API request caused the failure.
- I’ve made the internal typing of the settings values more rigorous, since we mixed `number` and `string` throughout the code. E.g., the API returns a `30` (number) for the default JPEG quality, but when reading the current value from the slider element or the change event, we get a string `"30"` (string). This didn’t cause any troubles yet, because both JS and Python took care of the type conversion by itself – we actually even sent a string to the server in the JSON request body. Anyway: the type ambiguity might be confusing, and I also already noticed that strict typing [will become relevant when implementing the auto-disabled “Apply” button](https://github.com/tiny-pilot/tinypilot-pro/pull/598/files#diff-58e8fc422e36f9a87c5e645b8eab3c0dc660f3b7173978fbaf2289c60f0b99ebR272) (so that we can compare via `===` instead of `==`).
- `_setFps` (formerly `_setVideoFpsDisplay`) et al previously only set the value next to the slider. I think it makes more sense, though, to also adjust the slider value, to make the change atomic and to prevent potential inconsistency bugs. That means, that when `_setFps` is invoked from the slider element event handler, we effectively re-set the slider value down the line. That’s not very useful per se, of course, but I still think the `_setFps` implementation is more robust that way. Note, setting the `.value` property on an input element doesn’t re-trigger the `"change"` event handler, so we are safe in regards to an endless update loop.
- I’ve then also added matching `_get...` methods for the settings, just to separate and group the concerns a bit better.
- We previously [swallowed errors emitted by `applyVideoSettings`](https://github.com/tiny-pilot/tinypilot/compare/video-settings/refactor-js?expand=1#diff-58e8fc422e36f9a87c5e645b8eab3c0dc660f3b7173978fbaf2289c60f0b99ebL308), because the subsequent `catch` handler was empty. This is fixed now.

Fixes #1108

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1121"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>