### PR TITLE
Video Settings dialog: disable “Apply” button unless there are changes

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -348,7 +348,7 @@ menuBar.addEventListener("wake-on-lan-dialog-requested", () => {
   document.getElementById("feature-pro-overlay").show();
 });
 menuBar.addEventListener("video-settings-dialog-requested", () => {
-  document.getElementById("video-settings-dialog").getSettings();
+  document.getElementById("video-settings-dialog").initialize();
   document.getElementById("video-settings-overlay").show();
 });
 menuBar.addEventListener("paste-requested", () => {

--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -111,6 +111,7 @@
           super();
           this.attachShadow({ mode: "open" });
           this._defaultSettings = {};
+          this._initialSettings = {};
         }
 
         connectedCallback() {
@@ -168,11 +169,14 @@
           ])
             .then(([fps, defaultFps, jpegQuality, defaultJpegQuality]) => {
               this._setFps(fps);
+              this._initialSettings.fps = fps;
               this._defaultSettings.fps = defaultFps;
 
               this._setJpegQuality(jpegQuality);
+              this._initialSettings.jpegQuality = jpegQuality;
               this._defaultSettings.jpegQuality = defaultJpegQuality;
 
+              this._refreshApplyButton();
               this.state = this.states.EDIT;
             })
             .catch((error) => {
@@ -198,6 +202,7 @@
         _setFps(fps) {
           this.elements.fpsSlider.value = fps;
           this.elements.fpsValue.innerHTML = fps;
+          this._refreshApplyButton();
         }
 
         /**
@@ -213,11 +218,20 @@
         _setJpegQuality(jpegQuality) {
           this.elements.jpegQualitySlider.value = jpegQuality;
           this.elements.jpegQualityValue.innerHTML = jpegQuality;
+          this._refreshApplyButton();
         }
 
         _restoreSettings() {
           this._setFps(this._defaultSettings.fps);
           this._setJpegQuality(this._defaultSettings.jpegQuality);
+        }
+
+        _refreshApplyButton() {
+          const hasChangedValues = [
+            [this._getFps(), this._initialSettings.fps],
+            [this._getJpegQuality(), this._initialSettings.jpegQuality],
+          ].some(([actual, initial]) => actual !== initial);
+          this.elements.buttonSave.disabled = !hasChangedValues;
         }
 
         _saveSettings() {

--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -37,8 +37,8 @@
       width: 350px;
     }
 
-    #video-fps-display,
-    #video-jpeg-quality-display {
+    #fps-value,
+    #jpeg-quality-value {
       display: inline-block;
       width: 50px;
     }
@@ -51,14 +51,14 @@
     <h3>Change Video Settings</h3>
     <div class="settings">
       <div class="input-container">
-        <label for="video-fps-slider">FPS</label>
-        <input type="range" id="video-fps-slider" min="1" max="30" />
-        <span id="video-fps-display"></span>
+        <label for="fps-slider">FPS</label>
+        <input type="range" id="fps-slider" min="1" max="30" />
+        <span id="fps-value"></span>
       </div>
       <div class="input-container">
-        <label for="video-jpeg-quality-slider">JPEG Quality</label>
-        <input type="range" id="video-jpeg-quality-slider" min="1" max="100" />
-        <span id="video-jpeg-quality-display"></span>
+        <label for="jpeg-quality-slider">JPEG Quality</label>
+        <input type="range" id="jpeg-quality-slider" min="1" max="100" />
+        <span id="jpeg-quality-value"></span>
       </div>
     </div>
     <button class="save-btn btn-success" type="button">
@@ -110,32 +110,39 @@
         constructor() {
           super();
           this.attachShadow({ mode: "open" });
-          this.defaultSettings = {};
+          this._defaultSettings = {};
         }
 
         connectedCallback() {
           this.shadowRoot.appendChild(template.content.cloneNode(true));
-          this.shadowRoot
-            .querySelector(".close-btn")
-            .addEventListener("click", () =>
-              this.dispatchEvent(new DialogClosedEvent())
-            );
-          this.shadowRoot
-            .querySelector("#edit .restore-btn")
-            .addEventListener("click", () => this._restoreSettings());
-          this.shadowRoot
-            .querySelector("#edit .save-btn")
-            .addEventListener("click", () => this._saveSettings());
-          this.shadowRoot
-            .querySelector("#video-fps-slider")
-            .addEventListener("input", (event) => {
-              this._setVideoFpsDisplay(event.target.value);
-            });
-          this.shadowRoot
-            .querySelector("#video-jpeg-quality-slider")
-            .addEventListener("input", (event) => {
-              this._setVideoJpegQualityDisplay(event.target.value);
-            });
+          this.elements = {
+            buttonSave: this.shadowRoot.querySelector("#edit .save-btn"),
+            buttonClose: this.shadowRoot.querySelector(".close-btn"),
+            buttonRestore: this.shadowRoot.querySelector("#edit .restore-btn"),
+            fpsSlider: this.shadowRoot.querySelector("#fps-slider"),
+            fpsValue: this.shadowRoot.querySelector("#fps-value"),
+            jpegQualitySlider: this.shadowRoot.querySelector(
+              "#jpeg-quality-slider"
+            ),
+            jpegQualityValue: this.shadowRoot.querySelector(
+              "#jpeg-quality-value"
+            ),
+          };
+          this.elements.buttonClose.addEventListener("click", () =>
+            this.dispatchEvent(new DialogClosedEvent())
+          );
+          this.elements.buttonSave.addEventListener("click", () =>
+            this._saveSettings()
+          );
+          this.elements.buttonRestore.addEventListener("click", () =>
+            this._restoreSettings()
+          );
+          this.elements.fpsSlider.addEventListener("input", (event) => {
+            this._setFps(parseInt(event.target.value, 10));
+          });
+          this.elements.jpegQualitySlider.addEventListener("input", (event) => {
+            this._setJpegQuality(parseInt(event.target.value, 10));
+          });
         }
 
         get state() {
@@ -151,160 +158,74 @@
           );
         }
 
-        _setVideoFpsDisplay(videoFps) {
-          const videoFpsDisplayElement = this.shadowRoot.querySelector(
-            "#video-fps-display"
-          );
-          videoFpsDisplayElement.innerHTML = videoFps;
-        }
-
-        _setVideoJpegQualityDisplay(videoJpegQuality) {
-          const videoJpegQualityDisplayElement = this.shadowRoot.querySelector(
-            "#video-jpeg-quality-display"
-          );
-          videoJpegQualityDisplayElement.innerHTML = videoJpegQuality;
-        }
-
-        _fetchVideoFps() {
-          return getVideoFps()
-            .then((videoFps) => {
-              this.shadowRoot.querySelector(
-                "#video-fps-slider"
-              ).value = videoFps;
-              this._setVideoFpsDisplay(videoFps);
-            })
-            .catch((error) => {
-              this.dispatchEvent(
-                new DialogFailedEvent({
-                  title: "Failed to Load Video FPS",
-                  details: error,
-                })
-              );
-              return Promise.reject(error);
-            });
-        }
-
-        _fetchVideoJpegQuality() {
-          return getVideoJpegQuality()
-            .then((videoJpegQuality) => {
-              this.shadowRoot.querySelector(
-                "#video-jpeg-quality-slider"
-              ).value = videoJpegQuality;
-              this._setVideoJpegQualityDisplay(videoJpegQuality);
-            })
-            .catch((error) => {
-              this.dispatchEvent(
-                new DialogFailedEvent({
-                  title: "Failed to Load Video JPEG Quality",
-                  details: error,
-                })
-              );
-              return Promise.reject(error);
-            });
-        }
-
-        getSettings() {
+        initialize() {
           this.state = this.states.LOADING;
           Promise.all([
-            this._fetchVideoFps(),
-            this._fetchVideoJpegQuality(),
-            this._fetchDefaultVideoFps(),
-            this._fetchDefaultVideoJpegQuality(),
+            getVideoFps(),
+            getDefaultVideoFps(),
+            getVideoJpegQuality(),
+            getDefaultVideoJpegQuality(),
           ])
-            .then(() => {
+            .then(([fps, defaultFps, jpegQuality, defaultJpegQuality]) => {
+              this._setFps(fps);
+              this._defaultSettings.fps = defaultFps;
+
+              this._setJpegQuality(jpegQuality);
+              this._defaultSettings.jpegQuality = defaultJpegQuality;
+
               this.state = this.states.EDIT;
             })
-            .catch(() => {
-              // Ignore errors here because they have already been handled by
-              // their individual setting load function.
-            });
-        }
-
-        _fetchDefaultVideoFps() {
-          return getDefaultVideoFps()
-            .then((videoFps) => {
-              this.defaultSettings.videoFps = videoFps;
-            })
             .catch((error) => {
               this.dispatchEvent(
                 new DialogFailedEvent({
-                  title: "Failed to Load Default Video FPS",
+                  title: "Failed to Load Video Settings",
                   details: error,
                 })
               );
-              return Promise.reject(error);
             });
         }
 
-        _fetchDefaultVideoJpegQuality() {
-          return getDefaultVideoJpegQuality()
-            .then((videoJpegQuality) => {
-              this.defaultSettings.videoJpegQuality = videoJpegQuality;
-            })
-            .catch((error) => {
-              this.dispatchEvent(
-                new DialogFailedEvent({
-                  title: "Failed to Load Default Video JPEG Quality",
-                  details: error,
-                })
-              );
-              return Promise.reject(error);
-            });
+        /**
+         * @returns {number}
+         */
+        _getFps() {
+          return parseInt(this.elements.fpsSlider.value, 10);
         }
 
-        _restoreVideoFps() {
-          this.shadowRoot.querySelector(
-            "#video-fps-slider"
-          ).value = this.defaultSettings.videoFps;
-          this._setVideoFpsDisplay(this.defaultSettings.videoFps);
+        /**
+         * @param fps {number}
+         */
+        _setFps(fps) {
+          this.elements.fpsSlider.value = fps;
+          this.elements.fpsValue.innerHTML = fps;
         }
 
-        _restoreVideoJpegQuality() {
-          this.shadowRoot.querySelector(
-            "#video-jpeg-quality-slider"
-          ).value = this.defaultSettings.videoJpegQuality;
-          this._setVideoJpegQualityDisplay(
-            this.defaultSettings.videoJpegQuality
-          );
+        /**
+         * @returns {number}
+         */
+        _getJpegQuality() {
+          return parseInt(this.elements.jpegQualitySlider.value, 10);
+        }
+
+        /**
+         * @param jpegQuality {number}
+         */
+        _setJpegQuality(jpegQuality) {
+          this.elements.jpegQualitySlider.value = jpegQuality;
+          this.elements.jpegQualityValue.innerHTML = jpegQuality;
         }
 
         _restoreSettings() {
-          this._restoreVideoFps();
-          this._restoreVideoJpegQuality();
-        }
-
-        _saveVideoFps() {
-          let videoFps = this.shadowRoot.querySelector("#video-fps-slider")
-            .value;
-          return setVideoFps(videoFps).catch((error) => {
-            this.dispatchEvent(
-              new DialogFailedEvent({
-                title: "Failed to Save Video FPS",
-                details: error,
-              })
-            );
-            return Promise.reject(error);
-          });
-        }
-
-        _saveVideoJpegQuality() {
-          let videoJpegQuality = this.shadowRoot.querySelector(
-            "#video-jpeg-quality-slider"
-          ).value;
-          return setVideoJpegQuality(videoJpegQuality).catch((error) => {
-            this.dispatchEvent(
-              new DialogFailedEvent({
-                title: "Failed to Save Video JPEG Quality",
-                details: error,
-              })
-            );
-            return Promise.reject(error);
-          });
+          this._setFps(this._defaultSettings.fps);
+          this._setJpegQuality(this._defaultSettings.jpegQuality);
         }
 
         _saveSettings() {
           this.state = this.states.SAVING;
-          Promise.all([this._saveVideoFps(), this._saveVideoJpegQuality()])
+          return Promise.all([
+            setVideoFps(this._getFps()),
+            setVideoJpegQuality(this._getJpegQuality()),
+          ])
             .then(applyVideoSettings)
             .then(() => {
               // Note: After the video stream stops, it doesn't try to
@@ -312,9 +233,13 @@
               // reload the page.
               location.reload();
             })
-            .catch(() => {
-              // Ignore errors here because they have already been handled by
-              // their individual setting save function.
+            .catch((error) => {
+              this.dispatchEvent(
+                new DialogFailedEvent({
+                  title: "Failed to Change Video Settings",
+                  details: error,
+                })
+              );
             });
         }
       }


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot/issues/1112, and based on https://github.com/tiny-pilot/tinypilot/pull/1121.

- Track the initial settings in the same way as we store the default settings.
- For every update in the UI, refresh the “Apply” button and conditionally enable or disable it.

https://user-images.githubusercontent.com/83721279/193251496-b0f4981f-7201-4d40-aaf6-6da940726117.mov

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1122"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>