### PR TITLE
Clarify behaviour of primary actions in dialogs

### DIFF
--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -276,11 +276,11 @@
         in all headlines.
       </p>
 
-      <h2 class="section">Overlay</h2>
+      <h2 class="section">Overlay Dialogs</h2>
       <h3>Design</h3>
       <p>
-        Click on the buttons to learn how the overlay is supposed to be
-        designed.
+        Click on the buttons to learn how a dialog inside an overlay is supposed
+        to be designed.
       </p>
       <!-- Overlay with single call-to-action: -->
       <button id="show-overlay-with-primary-action-btn" class="btn-action">
@@ -396,6 +396,16 @@
           Contributing Guidelines
         </a>
         for details).
+      </p>
+      <h3>Primary Actions</h3>
+      <p>
+        The buttons for primary actions should be located at the bottom of the
+        dialog. These primary actions should either advance the dialog into a
+        different state, or they should terminate the dialog altogether.
+      </p>
+      <p>
+        If there is a primary button for closing or canceling the dialog, it
+        should always be the rightmost one.
       </p>
 
       <h2 class="section">Progress Indicator</h2>


### PR DESCRIPTION
Related to https://github.com/tiny-pilot/tinypilot/issues/1112, I noticed that two things can be clarified:

- In regards to terminology, an “overlay” is the container on the dark layer, and the “dialog” is what’s going inside that container. So we basically have dialogs inside overlays, or “overlay dialogs”. I think we don’t have to repeat this term everywhere, but I think it’s important for it to appear at least once.
- I also added an explicit section on the primary actions of a dialog. The previous (or rather: still current) “Restore Defaults” button in the `<video-settings>` dialog broke (breaks) this pattern. [This guideline is not new](https://github.com/tiny-pilot/tinypilot/blob/6073998459e21317800139df38166cd34396d4fd/app/templates/styleguide.html#L336-L338), but I think it could be more obvious.