### PR TITLE
Style guide: add text button

### DIFF
--- a/app/static/css/button.css
+++ b/app/static/css/button.css
@@ -87,3 +87,8 @@ button:disabled,
 .btn-danger:disabled {
   background-color: var(--brand-red-light);
 }
+
+.btn-text {
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -198,6 +198,17 @@
         <input type="checkbox" />
         <span class="toggle-slider"></span>
       </label>
+      <h3>Text Button</h3>
+      <p>
+        A button that is just regular text. Only use this for minor actions, and
+        in a context where the default button would look too prominent. Just
+        like with regular text, it’s okay to slightly reduce font size and
+        darkness, if sensible. The text button doesn’t have a disabled state;
+        instead, it should be hidden.
+      </p>
+      <p>
+        <span class="btn-text">Click Me</span>
+      </p>
 
       <h2 class="section">Input</h2>
       <ul>


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot/issues/1112.

Since [the text button from the UI mockups](https://github.com/tiny-pilot/tinypilot-pro/pull/598) is a new element, we should explain its usage in the style guide.

<img width="699" alt="Screenshot 2022-09-30 at 18 39 42" src="https://user-images.githubusercontent.com/83721279/193317312-22f78ace-be6b-4a88-aedd-695406df128b.png">
