### PR TITLE
Style guide: document when font settings can be adjusted

### DIFF
--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -50,12 +50,18 @@
         up the brand, such as colours, fonts, patterns or UI components.
       </p>
 
-      <h2 class="section">Typeface</h2>
+      <h2 class="section">Text</h2>
+      <h3>Typeface</h3>
       <p>
         We use “Overpass” for regular text. Technical text (e.g. logs or error
         messages) is set in the monospace variant “<span class="monospace"
           >Overpass Mono</span
         >”.
+      </p>
+      <h3>Text style</h3>
+      <p>
+        To make subsidiary elements look less prominent (e.g., hints or labels),
+        the font size and/or darkness of the text can be slightly reduced.
       </p>
 
       <h2 class="section">Colors</h2>


### PR DESCRIPTION
Related to https://github.com/tiny-pilot/tinypilot/pull/1126, I actually think it makes more sense to document the font rules in its own section, rather than just to mention it as an aside of the text button. We already apply this pattern in various places in the app, so it’s worth covering it in the style guide.

I’d probably prefer to have this as a mere soft rule in the style guide, rather than trying to invent a `.subsidiary` CSS class with hard-coded `font-size` and `color`, so that the exact parameters can be tweaked according to the context.

<img width="551" alt="Screenshot 2022-10-03 at 11 04 15" src="https://user-images.githubusercontent.com/83721279/193541116-e96566f9-5c8e-49a0-9aa0-9903d7b33c5a.png">

<img width="353" alt="Screenshot 2022-10-03 at 11 05 25" src="https://user-images.githubusercontent.com/83721279/193541121-9c1e15cd-9360-4c75-be05-23d6bbce4948.png">

<img width="196" alt="Screenshot 2022-10-03 at 11 05 43" src="https://user-images.githubusercontent.com/83721279/193541133-7f6f938b-96db-4b7f-b29d-8a2becf1ede1.png">

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1129"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>