### PR TITLE
H264: enable/disable H264 from the backend

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -380,6 +380,29 @@ def settings_video_jpeg_quality_default_get():
         {'videoJpegQuality': video_settings.DEFAULT_JPEG_QUALITY})
 
 
+@api_blueprint.route('/settings/video/h264', methods=['PUT'])
+def settings_video_h264_put():
+    """Turns H264 on or off.
+
+    Expects a JSON data structure in the request body that contains the
+    desired H264 state as a boolean. Example:
+    {
+        "h264": true
+    }
+
+    Returns:
+        Empty response on success, error object otherwise.
+    """
+    try:
+        h264_enabled = True  # TODO parse actual value from request body
+        settings = update.settings.load()
+        settings.set_h264_status(h264_enabled)
+        update.settings.save(settings)
+    except update.settings.SaveSettingsError as e:
+        return json_response.error(e), 500
+    return json_response.success()
+
+
 @api_blueprint.route('/settings/video/apply', methods=['POST'])
 def settings_video_apply_post():
     """Applies the current video settings found in the settings file.

--- a/app/update/settings.py
+++ b/app/update/settings.py
@@ -67,6 +67,25 @@ class Settings:
         if 'ustreamer_quality' in self._data:
             del self._data['ustreamer_quality']
 
+    def set_h264_status(self, is_enabled):
+        if is_enabled:
+            self._data['ustreamer_h264_sink'] = 'tinypilot::ustreamer::h264'
+            self._data['ustreamer_h264_sink_mode'] = 777
+            self._data['ustreamer_h264_sink_rm'] = True
+        else:
+            if 'ustreamer_h264_sink' in self._data:
+                del self._data['ustreamer_h264_sink']
+            if 'ustreamer_h264_sink_mode' in self._data:
+                del self._data['ustreamer_h264_sink_mode']
+            if 'ustreamer_h264_sink_rm' in self._data:
+                del self._data['ustreamer_h264_sink_rm']
+
+    def is_h264_enabled(self):
+        return (self._data.get('ustreamer_h264_sink',
+                               None) == 'tinypilot::ustreamer::h264' and
+                self._data.get('ustreamer_h264_sink_mode', None) == 777 and
+                self._data.get('ustreamer_h264_sink_rm', None) is True)
+
 
 def load():
     """Retrieves the current TinyPilot update settings

--- a/app/views.py
+++ b/app/views.py
@@ -1,6 +1,7 @@
 import flask
 
 import hostname
+import update.settings
 from find_files import find as find_files
 
 views_blueprint = flask.Blueprint('views', __name__, url_prefix='')
@@ -11,10 +12,10 @@ _DEFAULT_HOSTNAME = 'tinypilot'
 
 @views_blueprint.route('/', methods=['GET'])
 def index_get():
+    settings = update.settings.load()
     return flask.render_template(
         'index.html',
-        use_webrtc_remote_screen=flask.current_app.config.get(
-            'USE_WEBRTC_REMOTE_SCREEN', False),
+        use_webrtc_remote_screen=settings.is_h264_enabled(),
         page_title_prefix=_page_title_prefix(),
         custom_elements_files=find_files.custom_elements_files())
 

--- a/dev_app_settings.cfg
+++ b/dev_app_settings.cfg
@@ -3,5 +3,3 @@
 
 KEYBOARD_PATH = '/dev/null'
 MOUSE_PATH = '/dev/null'
-
-USE_WEBRTC_REMOTE_SCREEN = True


### PR DESCRIPTION
I’ve started to look into https://github.com/tiny-pilot/tinypilot/issues/1113 to dive a bit deeper into potential solutions for turning H264 / WebRTC on and off via the backend.

As described in the ticket, it’s probably not an option for us to continue using the current mechanism, because that would require us to run `ansible-role-tinypilot` to effectuate, instead of just `ansible-role-ustreamer`, which would make it take a long time to apply the video settings.

Reminder: however we do it, [we are about to install Janus by default during the TinyPilot installation](https://github.com/tiny-pilot/ansible-role-tinypilot/issues/224).

## This PR

As demonstrated in this PR, we could derive whether H264 was activated via the presence of the H264-related parameters in `~/settings.yml`. (Turning H264 on or off would add or remove these three parameters.)

The benefit I’d see is that this solution is relatively simple for us to implement at the current stage.

I see the following downsides, though:

- It’s not perfectly safe to assume that only because the H264-related settings are present in `~/settings.yml`, that an H264 stream is in fact up and running. In theory, it could be that the parameters had been written, but the configuration had not been applied, or applying the settings had failed for some reason.
- The 3 `ustreamer_...` parameters actually have static values, so technically speaking it probably doesn’t really make sense to set and unset them at runtime in the same way we currently do. The Janus service/server is ready and running anyway, so from a control flow perspective it might make more sense to have all the configs correctly wired up from the start.

## Alternative Approach

An alternative that I would see is to install and pre-configure H264, Janus and the Janus-uStreamer plugin at install time, and then only toggle the FE remote screen between MJPEG and H264 based on a setting, e.g. as stored in the database. The major hindrance with this would be that we don’t have a database in Community right now, so we’d have to back-port it from Pro. I’m not sure how much work that is, though, mainly in regards to our automated schema migrations and the differing database layouts.

Contrary to what [I worried about in the ticket](https://github.com/tiny-pilot/tinypilot/issues/1113#issuecomment-1262533161), I think it should be safe to have the memory sink configured all the time, because [the uStreamer plugin is only attached after someone requests WebRTC](https://github.com/tiny-pilot/tinypilot/blob/fa87c256ecc87cc0239ee75367ff1b37c3c8c07f/app/static/js/webrtc-video.js#L62-L65). Janus itself would be running (idling) in the background anyway, so that part wouldn’t change.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1130"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>