### PR TITLE
Upgrade to greenlet 1.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pyyaml==5.4.1
 bidict==0.21.2
 click==7.1.2
 dnspython==1.16.0
-greenlet==1.0.0
+greenlet==1.1.2
 itsdangerous==1.1.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pyyaml==5.4.1
 bidict==0.21.2
 click==7.1.2
 dnspython==1.16.0
-greenlet==1.1.2
+greenlet==1.1.3
 itsdangerous==1.1.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1


### PR DESCRIPTION
1.1.3 adds compatibility for Python 3.11. We're not using 3.11 yet, but we may in the future, and users on Ubuntu systems are reporting issues trying to install TinyPilot due to the old version of greenlet.

Fixes #1128 
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1132"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>