### PR TITLE
Remove Cell as a pointer option

### DIFF
--- a/app/static/css/cursors.css
+++ b/app/static/css/cursors.css
@@ -23,7 +23,3 @@
 *[cursor="pointer"] > * {
   cursor: pointer !important;
 }
-
-*[cursor="cell"] > * {
-  cursor: cell !important;
-}

--- a/app/templates/custom-elements/menu-bar.html
+++ b/app/templates/custom-elements/menu-bar.html
@@ -282,7 +282,6 @@
             "crosshair",
             "dot",
             "pointer",
-            "cell",
           ];
           const cursorList = this.shadowRoot.getElementById("cursor-list");
           for (const cursorOption of screenCursorOptions.splice(1)) {


### PR DESCRIPTION
We added Cell as an option because it was part of an external user contribution in the early days of TinyPilot to add different pointer options, but I don't think it fits anymore. I can't imagine anyone choosing this as their cursor.

There's a slight bug to this fix in that if the user has already chosen Cell as their cursor, the menu bar will show no cursor selected and the cursor will revert to the browser default. I don't think it's worth the effort to fix this bug since the issue will go away once the user selects a new cursor and nothing negative happens except that the remote screen falls back to the default cursor.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1138"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>