### PR TITLE
Use f-strings in places pylint recommends

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -23,8 +23,6 @@ unsafe-load-any-extension=no
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=
-  # Remove when we fix https://github.com/tiny-pilot/tinypilot/issues/995
-  consider-using-f-string,
   fixme,
   useless-suppression,
   suppressed-message,

--- a/app/api.py
+++ b/app/api.py
@@ -26,7 +26,7 @@ def debug_logs_get():
     try:
         return flask.Response(debug_logs.collect(), mimetype='text/plain')
     except debug_logs.Error as e:
-        return flask.Response('Failed to retrieve debug logs: %s' % str(e),
+        return flask.Response(f'Failed to retrieve debug logs: {e}',
                               status=500)
 
 

--- a/app/api.py
+++ b/app/api.py
@@ -26,8 +26,7 @@ def debug_logs_get():
     try:
         return flask.Response(debug_logs.collect(), mimetype='text/plain')
     except debug_logs.Error as e:
-        return flask.Response(f'Failed to retrieve debug logs: {e}',
-                              status=500)
+        return flask.Response(f'Failed to retrieve debug logs: {e}', status=500)
 
 
 @api_blueprint.route('/shutdown', methods=['POST'])

--- a/app/hid/write.py
+++ b/app/hid/write.py
@@ -74,7 +74,7 @@ def write_to_hid_interface(hid_path, buffer):
     # latency.
     if logger.getEffectiveLevel() == logging.DEBUG:
         logger.debug_sensitive('writing to HID interface %s: %s', hid_path,
-                               ' '.join(['0x%02x' % x for x in buffer]))
+                               ' '.join([f'{x:#04x}' for x in buffer]))
     # Writes can hang, for example, when TinyPilot is attempting to write to the
     # mouse interface, but the target system has no GUI. To avoid locking up the
     # main server process, perform the HID interface I/O in a separate process.
@@ -91,8 +91,9 @@ def write_to_hid_interface(hid_path, buffer):
     # If the result is None, it means the write failed to complete in time.
     if result is None or not result.was_successful():
         raise WriteError(
-            'Failed to write to HID interface: %s. Is USB cable connected?' %
-            hid_path)
+            f'Failed to write to HID interface: {hid_path}. '
+            'Is USB cable connected?'
+        )
 
 
 def _wait_for_process_exit(target_process):

--- a/app/hid/write.py
+++ b/app/hid/write.py
@@ -90,10 +90,8 @@ def write_to_hid_interface(hid_path, buffer):
     result = write_process.result()
     # If the result is None, it means the write failed to complete in time.
     if result is None or not result.was_successful():
-        raise WriteError(
-            f'Failed to write to HID interface: {hid_path}. '
-            'Is USB cable connected?'
-        )
+        raise WriteError(f'Failed to write to HID interface: {hid_path}. '
+                         'Is USB cable connected?')
 
 
 def _wait_for_process_exit(target_process):

--- a/app/js_to_hid.py
+++ b/app/js_to_hid.py
@@ -186,8 +186,8 @@ def _map_keycode(keystroke):
     try:
         return _MAPPING[keystroke.code]
     except KeyError as e:
-        raise UnrecognizedKeyCodeError('Unrecognized key code %s (%s)' %
-                                       (keystroke.key, keystroke.code)) from e
+        raise UnrecognizedKeyCodeError(
+            f'Unrecognized key code {keystroke.key} {keystroke.code}') from e
 
 
 def _count_modifiers(keystroke):

--- a/app/license_notice.py
+++ b/app/license_notice.py
@@ -270,7 +270,7 @@ def all_licensing_get():
     for license_data in _LICENSE_METADATA:
         response.append({
             'name': license_data.name,
-            'licenseUrl': '/licensing/%s/license' % license_data.name,
+            'licenseUrl': f'/licensing/{license_data.name}/license',
             'homepageUrl': license_data.homepage_url,
         })
 

--- a/app/request_parsers/json.py
+++ b/app/request_parsers/json.py
@@ -22,7 +22,7 @@ def parse_json_body(request, required_fields):
     result = []
     for field in required_fields:
         if field not in json:
-            raise errors.MissingFieldError('Missing required field: %s' % field)
+            raise errors.MissingFieldError(f'Missing required field: {field}')
         result.append(json[field])
 
     return tuple(result)

--- a/app/request_parsers/keystroke.py
+++ b/app/request_parsers/keystroke.py
@@ -77,15 +77,15 @@ def _merge_message_with_defaults(message):
 def _parse_modifier_key(modifier_key):
     if not isinstance(modifier_key, bool):
         raise InvalidModifierKeyError(
-            'Modifier keys must be boolean values: %s' % modifier_key)
+            f'Modifier keys must be boolean values: {modifier_key}')
     return modifier_key
 
 
 def _parse_code(code):
     if not isinstance(code, str):
-        raise InvalidKeyCodeError('Key code must be a string: %s' % code)
+        raise InvalidKeyCodeError(f'Key code must be a string: {code}')
 
     # Arbitrary limit, but just to prevent anything crazy.
     if len(code) > 30:
-        raise InvalidKeyCodeError('Key code is too long: %s' % code)
+        raise InvalidKeyCodeError(f'Key code is too long: {code}')
     return code

--- a/app/request_parsers/keystroke_test.py
+++ b/app/request_parsers/keystroke_test.py
@@ -10,7 +10,7 @@ class KeystrokeTest(unittest.TestCase):
     # pylint: disable=invalid-name
     def assertKeystrokesEqual(self, expected, actual):
         if expected != actual:
-            raise AssertionError('%s != %s' % (expected, actual))
+            raise AssertionError(f'{expected} != {actual}')
 
     def test_parses_valid_keystroke_message(self):
         self.assertKeystrokesEqual(

--- a/app/request_parsers/mouse_event.py
+++ b/app/request_parsers/mouse_event.py
@@ -81,13 +81,11 @@ def _parse_relative_position(relative_position):
             relative_position, int):
         raise InvalidRelativePositionError(
             'Relative position must be a float between 0.0 and 1.0: '
-            f'{relative_position}'
-        )
+            f'{relative_position}')
     if not (0.0 <= relative_position <= 1.0):
         raise InvalidRelativePositionError(
             'Relative position must be a float between 0.0 and 1.0: '
-            f'{relative_position}'
-        )
+            f'{relative_position}')
     return relative_position
 
 

--- a/app/request_parsers/mouse_event.py
+++ b/app/request_parsers/mouse_event.py
@@ -55,7 +55,7 @@ def parse_mouse_event(message):
     for field in required_fields:
         if field not in message:
             raise MissingFieldErrorError(
-                'Mouse event request is missing required field: %s' % field)
+                f'Mouse event request is missing required field: {field}')
     return MouseEvent(
         buttons=_parse_button_state(message['buttons']),
         relative_x=_parse_relative_position(message['relativeX']),
@@ -69,10 +69,10 @@ def parse_mouse_event(message):
 def _parse_button_state(buttons):
     if not isinstance(buttons, int):
         raise InvalidButtonStateError(
-            'Button state must be an integer value: %s' % buttons)
+            f'Button state must be an integer value: {buttons}')
     if not (0 <= buttons <= _MAX_BUTTON_STATE):
-        raise InvalidButtonStateError('Button state must be <= 0x%x: %s' %
-                                      (_MAX_BUTTON_STATE, buttons))
+        raise InvalidButtonStateError(
+            f'Button state must be <= {_MAX_BUTTON_STATE:#x}: {buttons}')
     return buttons
 
 
@@ -80,20 +80,22 @@ def _parse_relative_position(relative_position):
     if not isinstance(relative_position, float) and not isinstance(
             relative_position, int):
         raise InvalidRelativePositionError(
-            'Relative position must be a float between 0.0 and 1.0: %s' %
-            relative_position)
+            'Relative position must be a float between 0.0 and 1.0: '
+            f'{relative_position}'
+        )
     if not (0.0 <= relative_position <= 1.0):
         raise InvalidRelativePositionError(
-            'Relative position must be a float between 0.0 and 1.0: %s' %
-            relative_position)
+            'Relative position must be a float between 0.0 and 1.0: '
+            f'{relative_position}'
+        )
     return relative_position
 
 
 def _parse_wheel_value(wheel_value):
     if not isinstance(wheel_value, int):
-        raise InvalidWheelValueError('Wheel value must be a int: %s' %
-                                     wheel_value)
+        raise InvalidWheelValueError(
+            f'Wheel value must be a int: {wheel_value}')
     if wheel_value not in (-1, 0, 1):
-        raise InvalidWheelValueError('Wheel value must be -1, 0, or 1: %s' %
-                                     wheel_value)
+        raise InvalidWheelValueError(
+            f'Wheel value must be -1, 0, or 1: {wheel_value}')
     return wheel_value

--- a/app/version.py
+++ b/app/version.py
@@ -45,8 +45,7 @@ def local_version():
         raise VersionFileError(
             'The local version file must only contain UTF-8 characters.') from e
     except IOError as e:
-        raise VersionFileError('Failed to check local version: %s' %
-                               str(e)) from e
+        raise VersionFileError(f'Failed to check local version: {e}') from e
     if version == '':
         raise VersionFileError('The local version file cannot be empty.')
     return version
@@ -69,7 +68,7 @@ def latest_version():
             response_bytes = response.read()
     except urllib.error.URLError as e:
         raise VersionRequestError(
-            'Failed to request latest available version: %s' % str(e)) from e
+            f'Failed to request latest available version: {e}') from e
 
     try:
         response_text = response_bytes.decode('utf-8')

--- a/app/views.py
+++ b/app/views.py
@@ -42,5 +42,5 @@ def stream_get():
 
 def _page_title_prefix():
     if hostname.determine().lower() != _DEFAULT_HOSTNAME.lower():
-        return '%s - ' % hostname.determine()
+        return f'{hostname.determine()} - '
     return ''

--- a/scripts/update-service
+++ b/scripts/update-service
@@ -43,7 +43,7 @@ def run_update_script():
     except subprocess.CalledProcessError as e:
         logger.error('Update process terminated with failing exit code: %s',
                      str(e))
-        return make_update_result(update_error='The update failed: %s' % str(e))
+        return make_update_result(update_error=f'The update failed: {e}')
 
     logger.info('Update completed successfully')
     return make_update_result(update_error=None)


### PR DESCRIPTION
Fixes #995

# Background

tinypilot currently uses old c-style formatting. In order to avoid any complaints from pylint, the `consider-using-f-string` check was disabled. This PR attempts to fix that by updating potentially problematic lines to use f-strings and then removing this check from the list of disabled rules.

# Changes

* Change c-style formatting by f-strings.
* Remove `consider-using-f-string` from the disabled rules in `.pylintrc`.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1143"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>