### PR TITLE
Refactor how we place files in Debian package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,19 +204,19 @@ workflows:
       - build_debian_package:
           filters:
             branches:
-              only: master
+              only: /.*/ # DEBUG
       - build_bundle:
           requires:
             - build_debian_package
           filters:
             branches:
-              only: master
+              only: /.*/ # DEBUG
       - verify_bundle:
           requires:
             - build_bundle
           filters:
             branches:
-              only: master
+              only: /.*/ # DEBUG
       - upload_bundle:
           requires:
             - verify_bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,19 +205,19 @@ workflows:
       - build_debian_package:
           filters:
             branches:
-              only: master
+              only: /.*/ # DEBUG
       - build_bundle:
           requires:
             - build_debian_package
           filters:
             branches:
-              only: master
+              only: /.*/ # DEBUG
       - verify_bundle:
           requires:
             - build_bundle
           filters:
             branches:
-              only: master
+              only: /.*/ # DEBUG
       - upload_bundle:
           requires:
             - verify_bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,12 +94,13 @@ jobs:
             export TINYPILOT_VERSION="$(git rev-parse --short HEAD)"
             export PKG_VERSION="$(date '+%Y%m%d%H%M%S')"
             docker buildx build \
+              --file debian-pkg/Dockerfile \
               --platform linux/arm/v7 \
               --build-arg TINYPILOT_VERSION \
               --build-arg PKG_VERSION \
               --target=artifact \
               --output type=local,dest=$(pwd)/releases/ \
-              ./debian-pkg
+              .
       - persist_to_workspace:
           root: ./releases
           paths:
@@ -204,19 +205,19 @@ workflows:
       - build_debian_package:
           filters:
             branches:
-              only: /.*/ # DEBUG
+              only: master
       - build_bundle:
           requires:
             - build_debian_package
           filters:
             branches:
-              only: /.*/ # DEBUG
+              only: master
       - verify_bundle:
           requires:
             - build_bundle
           filters:
             branches:
-              only: /.*/ # DEBUG
+              only: master
       - upload_bundle:
           requires:
             - verify_bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,19 +205,19 @@ workflows:
       - build_debian_package:
           filters:
             branches:
-              only: /.*/ # DEBUG
+              only: master
       - build_bundle:
           requires:
             - build_debian_package
           filters:
             branches:
-              only: /.*/ # DEBUG
+              only: master
       - verify_bundle:
           requires:
             - build_bundle
           filters:
             branches:
-              only: /.*/ # DEBUG
+              only: master
       - upload_bundle:
           requires:
             - verify_bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,19 +204,19 @@ workflows:
       - build_debian_package:
           filters:
             branches:
-              only: /.*/ # DEBUG
+              only: master
       - build_bundle:
           requires:
             - build_debian_package
           filters:
             branches:
-              only: /.*/ # DEBUG
+              only: master
       - verify_bundle:
           requires:
             - build_bundle
           filters:
             branches:
-              only: /.*/ # DEBUG
+              only: master
       - upload_bundle:
           requires:
             - verify_bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
               --build-arg PKG_VERSION \
               --target=artifact \
               --output type=local,dest=$(pwd)/releases/ \
-              .
+              ./debian-pkg
       - persist_to_workspace:
           root: ./releases
           paths:

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,35 +2,5 @@
 **/__pycache__
 **/*.py[cod]
 
-# Dev-only files and documentation.
+# Test files.
 **/*_test.py
-/.circleci
-/.coverage
-/.dependabot
-/.dockerignore
-/.git
-/.github
-/.gitignore
-/.prettierignore
-/.pylintrc
-/.shellcheckrc
-/.style.yapf
-/.vscode
-/.yapfignore
-/ARCHITECTURE.md
-/CONTRIBUTING.md
-/Dockerfile
-/MANIFEST.in
-/bundler
-/dev-scripts
-/dev_app_settings.cfg
-/dev_requirements.txt
-/e2e
-/get-tinypilot.sh
-/hooks
-/node_modules
-/package.json
-/package-lock.json
-/quick-install
-/readme-assets
-/venv

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,4 @@
 # Test files.
 **/*_test.py
 
-Dockerfile
+/debian-pkg/Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@
 
 # Test files.
 **/*_test.py
+
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,15 @@ RUN mkdir -p "/releases/${PKG_ID}"
 WORKDIR "/releases/${PKG_ID}"
 
 RUN mkdir -p opt/tinypilot
-COPY . ./opt/tinypilot/
+COPY ./COPYRIGHT opt/tinypilot/
+COPY ./LICENSE opt/tinypilot/
+COPY ./README.md opt/tinypilot/
+COPY ./requirements.txt opt/tinypilot/
+COPY ./app opt/tinypilot/app
+COPY ./scripts opt/tinypilot/scripts
+COPY ./debian-pkg .
 
 RUN echo "${TINYPILOT_VERSION}" > opt/tinypilot/VERSION
-
-RUN mkdir -p DEBIAN
 
 WORKDIR "/releases/${PKG_ID}/DEBIAN"
 
@@ -45,40 +49,6 @@ RUN echo "Package: ${PKG_NAME}" >> control && \
     echo "Architecture: all" >> control && \
     echo "Homepage: https://tinypilotkvm.com" >> control && \
     echo "Description: Simple, easy-to-use KVM over IP" >> control
-
-RUN cat > preinst <<EOF
-#!/bin/bash
-
-# If a .git directory exists, the previous version was installed with the legacy
-# installer, so wipe the install location.
-if [[ -d /opt/tinypilot/.git ]]; then
-  rm -rf /opt/tinypilot
-fi
-EOF
-RUN chmod 0555 preinst
-
-RUN echo "#!/bin/bash" > postinst && \
-    echo "chown -R tinypilot:tinypilot /opt/tinypilot" >> postinst && \
-    chmod 0555 postinst
-
-RUN cat > prerm <<EOF
-#!/bin/bash
-
-# Exit script on first failure.
-set -e
-
-cd /opt/tinypilot
-rm -rf venv
-find . \
-  -type f \
-  -name *.pyc \
-  -delete \
-  -or \
-  -type d \
-  -name __pycache__ \
-  -delete
-EOF
-RUN chmod 0555 prerm
 
 RUN dpkg --build "/releases/${PKG_ID}"
 

--- a/debian-pkg/DEBIAN/postinst
+++ b/debian-pkg/DEBIAN/postinst
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+chown -R tinypilot:tinypilot /opt/tinypilot

--- a/debian-pkg/DEBIAN/preinst
+++ b/debian-pkg/DEBIAN/preinst
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# If a .git directory exists, the previous version was installed with the legacy
+# installer, so wipe the install location.
+if [[ -d /opt/tinypilot/.git ]]; then
+  rm -rf /opt/tinypilot
+fi

--- a/debian-pkg/DEBIAN/prerm
+++ b/debian-pkg/DEBIAN/prerm
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 # Exit script on first failure.
@@ -8,7 +7,7 @@ cd /opt/tinypilot
 rm -rf venv
 find . \
   -type f \
-  -name *.pyc \
+  -name "*.pyc" \
   -delete \
   -or \
   -type d \

--- a/debian-pkg/DEBIAN/prerm
+++ b/debian-pkg/DEBIAN/prerm
@@ -1,0 +1,16 @@
+
+#!/bin/bash
+
+# Exit script on first failure.
+set -e
+
+cd /opt/tinypilot
+rm -rf venv
+find . \
+  -type f \
+  -name *.pyc \
+  -delete \
+  -or \
+  -type d \
+  -name __pycache__ \
+  -delete

--- a/debian-pkg/Dockerfile
+++ b/debian-pkg/Dockerfile
@@ -30,13 +30,13 @@ RUN mkdir -p "/releases/${PKG_ID}"
 WORKDIR "/releases/${PKG_ID}"
 
 RUN mkdir -p opt/tinypilot
-COPY ./COPYRIGHT opt/tinypilot/
-COPY ./LICENSE opt/tinypilot/
-COPY ./README.md opt/tinypilot/
-COPY ./requirements.txt opt/tinypilot/
-COPY ./app opt/tinypilot/app
-COPY ./scripts opt/tinypilot/scripts
-COPY ./debian-pkg .
+COPY ../COPYRIGHT opt/tinypilot/
+COPY ../LICENSE opt/tinypilot/
+COPY ../README.md opt/tinypilot/
+COPY ../requirements.txt opt/tinypilot/
+COPY ../app opt/tinypilot/app
+COPY ../scripts opt/tinypilot/scripts
+COPY . .
 
 RUN echo "${TINYPILOT_VERSION}" > opt/tinypilot/VERSION
 

--- a/debian-pkg/Dockerfile
+++ b/debian-pkg/Dockerfile
@@ -30,13 +30,13 @@ RUN mkdir -p "/releases/${PKG_ID}"
 WORKDIR "/releases/${PKG_ID}"
 
 RUN mkdir -p opt/tinypilot
-COPY ../COPYRIGHT opt/tinypilot/
-COPY ../LICENSE opt/tinypilot/
-COPY ../README.md opt/tinypilot/
-COPY ../requirements.txt opt/tinypilot/
-COPY ../app opt/tinypilot/app
-COPY ../scripts opt/tinypilot/scripts
-COPY . .
+COPY ./COPYRIGHT opt/tinypilot/
+COPY ./LICENSE opt/tinypilot/
+COPY ./README.md opt/tinypilot/
+COPY ./requirements.txt opt/tinypilot/
+COPY ./app opt/tinypilot/app
+COPY ./scripts opt/tinypilot/scripts
+COPY ./debian-pkg .
 
 RUN echo "${TINYPILOT_VERSION}" > opt/tinypilot/VERSION
 


### PR DESCRIPTION
This change adjusts how we package files in the Debian package so that we include less by default.

When we originally discussed whether to err on the side of including too much or too little, we didn't consider that including everything makes it more difficult to express where to place files in the Debian package.

This change adds a debian-pkg folder to the root of the repo, and everything within that folder gets placed into the Debian package root. Right now, this allows us to extract the special Debian preinst, postinst, prerm scripts to actual files, which allows shellcheck to flag issues that it can't flag when they're embedded in a Dockerfile.

The other benefit is that it allows us to embed other files that we want to place on the device within this repo. I've created a rough proof-of-concept of how we can continue this pattern to include all of /opt/tinypilot-privileged's scripts in the tinypilot core repo instead of keeping them separated in the Ansible role: https://github.com/tiny-pilot/tinypilot-pro/pull/618

Even though this is mostly a non-functional refactoring, there are two functional changes:

* We're excluding `./__init__.py` and `./setup.py` from the Debian package, as they have no function
  * We maybe could delete these files entirely, as I don't think they have any purpose.
* We're quoting the "*.pyc" string in `./debian-pkg/DEBIAN/prerm` per shellcheck's recommendation.

### Diff

* Package contents before: https://gist.github.com/mtlynch/17e736cfcb1e61724ccae144bc369d74#file-tinypilot-20221014191656-1-armhf-deb-txt
* Package contents after: https://gist.github.com/mtlynch/17e736cfcb1e61724ccae144bc369d74#file-tinypilot-20221017215728-1-armhf-deb-txt
* Diff (with dates excluded): https://gist.github.com/mtlynch/17e736cfcb1e61724ccae144bc369d74#file-change-diff