### PR TITLE
Clarify name of Debian package build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
           name: Ensure builder has booted
           command: docker buildx inspect --bootstrap
       - run:
-          name: Build docker image with .deb package
+          name: Build Debian package
           command: |
             export TINYPILOT_VERSION="$(git rev-parse --short HEAD)"
             export PKG_VERSION="$(date '+%Y%m%d%H%M%S')"


### PR DESCRIPTION
We're actually building a Debian package, but the name made it sound like the Debian package already exists and we're building a Docker image.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1147"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>