### PR TITLE
Build Debian package with simple Docker rather than Docker+QEMU

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,9 +71,9 @@ jobs:
           command: ./dev-scripts/build-debian-pkg
       - run:
           name: Print Debian package contents
-          command: dpkg --contents releases/tinypilot*.deb
+          command: dpkg --contents debian-pkg/releases/tinypilot*.deb
       - persist_to_workspace:
-          root: ./releases
+          root: ./debian-pkg/releases
           paths:
             - "*.deb"
   build_bundle:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           version: 20.10.11
       - run:
           name: Build Debian package
-          command: ./deb-scripts/build-debian-pkg
+          command: ./dev-scripts/build-debian-pkg
       - run:
           name: Print Debian package contents
           command: dpkg --contents releases/tinypilot*.deb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,40 +67,11 @@ jobs:
       - setup_remote_docker:
           version: 20.10.11
       - run:
-          name: Enable multiarch builds with QEMU
-          command: |
-            docker run \
-              --rm \
-              --privileged \
-              multiarch/qemu-user-static \
-              --reset \
-              -p yes
-      - run:
-          name: Create multiarch build context
-          command: docker context create builder
-      - run:
-          name: Create multiplatform builder
-          command: |
-            docker buildx create builder \
-              --name builder \
-              --driver docker-container \
-              --use
-      - run:
-          name: Ensure builder has booted
-          command: docker buildx inspect --bootstrap
-      - run:
           name: Build Debian package
-          command: |
-            export TINYPILOT_VERSION="$(git rev-parse --short HEAD)"
-            export PKG_VERSION="$(date '+%Y%m%d%H%M%S')"
-            docker buildx build \
-              --file debian-pkg/Dockerfile \
-              --platform linux/arm/v7 \
-              --build-arg TINYPILOT_VERSION \
-              --build-arg PKG_VERSION \
-              --target=artifact \
-              --output type=local,dest=$(pwd)/releases/ \
-              .
+          command: ./deb-scripts/build-debian-pkg
+      - run:
+          name: Print Debian package contents
+          command: dpkg --contents releases/tinypilot*.deb
       - persist_to_workspace:
           root: ./releases
           paths:

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 **/*_test.py
 
 /debian-pkg/Dockerfile
+/debian-pkg/releases/

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ package-lock.json
 # Mac OS
 *.DS_Store
 *.xcworkspace
+
+# Debian package builds
+releases/

--- a/.gitignore
+++ b/.gitignore
@@ -75,4 +75,4 @@ package-lock.json
 *.xcworkspace
 
 # Debian package builds
-releases/
+debian-pkg/releases/

--- a/dev-scripts/build-debian-pkg
+++ b/dev-scripts/build-debian-pkg
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Exit build script on first failure.
+set -e
+
+# Echo commands to stdout.
+set -x
+
+# Exit on unset variable.
+set -u
+
+TINYPILOT_VERSION="$(git rev-parse --short HEAD)"
+export readonly TINYPILOT_VERSION
+
+PKG_VERSION="$(date '+%Y%m%d%H%M%S')"
+export readonly PKG_VERSION
+
+DOCKER_BUILDKIT=1 docker build \
+  --file debian-pkg/Dockerfile \
+  --build-arg TINYPILOT_VERSION \
+  --build-arg PKG_VERSION \
+  --target=artifact \
+  --output "type=local,dest=$(pwd)/releases/" \
+  .

--- a/dev-scripts/build-debian-pkg
+++ b/dev-scripts/build-debian-pkg
@@ -10,15 +10,15 @@ set -x
 set -u
 
 TINYPILOT_VERSION="$(git rev-parse --short HEAD)"
-export readonly TINYPILOT_VERSION
+readonly TINYPILOT_VERSION
 
 PKG_VERSION="$(date '+%Y%m%d%H%M%S')"
-export readonly PKG_VERSION
+readonly PKG_VERSION
 
 DOCKER_BUILDKIT=1 docker build \
   --file debian-pkg/Dockerfile \
-  --build-arg TINYPILOT_VERSION \
-  --build-arg PKG_VERSION \
+  --build-arg TINYPILOT_VERSION="${TINYPILOT_VERSION}" \
+  --build-arg PKG_VERSION="${PKG_VERSION}" \
   --target=artifact \
   --output "type=local,dest=$(pwd)/releases/" \
   .

--- a/dev-scripts/build-debian-pkg
+++ b/dev-scripts/build-debian-pkg
@@ -20,5 +20,5 @@ DOCKER_BUILDKIT=1 docker build \
   --build-arg TINYPILOT_VERSION="${TINYPILOT_VERSION}" \
   --build-arg PKG_VERSION="${PKG_VERSION}" \
   --target=artifact \
-  --output "type=local,dest=$(pwd)/releases/" \
+  --output "type=local,dest=$(pwd)/debian-pkg/releases/" \
   .


### PR DESCRIPTION
I'm not sure why I thought we needed to use QEMU to build the Debian package, as there are no architecture-specific files in the package. It might have just been that we copy/pasted from Janus without thinking about it too much.

This simplifies the Debian package build to just use standard Docker so that it runs faster and can build on more systems (e.g., those that don't support QEMU). The non-QEMU build runs in about 40s instead of 2m30s.

I tested a full Pro image with this change, and everything works fine: https://app.circleci.com/pipelines/github/tiny-pilot/tinypilot-pro/1900/workflows/96bafbbd-32c8-4910-b918-83a8238dda19

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1149"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>