### PR TITLE
Add endpoints + controllers for changing the streaming mode

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,5 +1,6 @@
 import flask
 
+import db.settings
 import debug_logs
 import hostname
 import json_response
@@ -377,6 +378,48 @@ def settings_video_jpeg_quality_default_get():
     """
     return json_response.success(
         {'videoJpegQuality': video_settings.DEFAULT_JPEG_QUALITY})
+
+
+@api_blueprint.route('/settings/video/streaming_mode', methods=['GET'])
+def settings_video_streaming_mode_get():
+    """Retrieves the current video streaming mode.
+
+    Returns:
+        On success, a JSON data structure with the following properties:
+        videoStreamingMode: string.
+
+        Example:
+        {
+            "videoStreamingMode": "MJPEG"
+        }
+    """
+    settings = db.settings.Settings()
+    return json_response.success(
+        {'videoStreamingMode': settings.get_streaming_mode().value})
+
+
+@api_blueprint.route('/settings/video/streaming_mode', methods=['PUT'])
+def settings_video_streaming_mode_put():
+    """Changes the video streaming mode.
+
+    Expects a JSON data structure in the request body that contains the
+    new videoStreamingMode as a string. Example:
+    {
+        "videoStreamingMode": "H264"
+    }
+
+    Returns:
+        Empty response on success, error object otherwise.
+    """
+    try:
+        video_streaming_mode = \
+            request_parsers.video_settings.parse_streaming_mode(flask.request)
+    except request_parsers.errors.InvalidVideoStreamingModeError as e:
+        return json_response.error(e), 400
+
+    settings = db.settings.Settings()
+    settings.set_streaming_mode(video_streaming_mode)
+    return json_response.success()
 
 
 @api_blueprint.route('/settings/video/apply', methods=['POST'])

--- a/app/request_parsers/errors.py
+++ b/app/request_parsers/errors.py
@@ -20,3 +20,7 @@ class InvalidVideoFpsError(Error):
 
 class InvalidVideoJpegQualityError(Error):
     pass
+
+
+class InvalidVideoStreamingModeError(Error):
+    pass

--- a/app/request_parsers/video_settings.py
+++ b/app/request_parsers/video_settings.py
@@ -1,3 +1,4 @@
+import db.settings
 from request_parsers import errors
 from request_parsers import json
 
@@ -36,3 +37,14 @@ def parse_jpeg_quality(request):
             'The video JPEG quality must be an whole number between 1 and 100.'
         ) from e
     return video_jpeg_quality
+
+
+def parse_streaming_mode(request):
+    # pylint: disable=unbalanced-tuple-unpacking
+    (video_streaming_mode,) = json.parse_json_body(
+        request, required_fields=['videoStreamingMode'])
+    try:
+        return db.settings.StreamingMode(video_streaming_mode)
+    except ValueError as e:
+        raise errors.InvalidVideoStreamingModeError(
+            'The video streaming mode must be `MJPEG` or `H264`.') from e

--- a/app/request_parsers/video_settings_test.py
+++ b/app/request_parsers/video_settings_test.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest import mock
 
+import db.settings
 from request_parsers import errors
 from request_parsers import video_settings
 
@@ -78,3 +79,36 @@ class VideoJpegQualityParserTest(unittest.TestCase):
         with self.assertRaises(errors.MissingFieldError):
             video_settings.parse_jpeg_quality(
                 make_mock_request({'jpegQuality': 1}))
+
+
+class VideoStreamingModeParserTest(unittest.TestCase):
+
+    def test_accept_valid_values(self):
+        self.assertEqual(
+            db.settings.StreamingMode.MJPEG,
+            video_settings.parse_streaming_mode(
+                make_mock_request({'videoStreamingMode': 'MJPEG'})))
+        self.assertEqual(
+            db.settings.StreamingMode.H264,
+            video_settings.parse_streaming_mode(
+                make_mock_request({'videoStreamingMode': 'H264'})))
+
+    def test_reject_invalid_modes(self):
+        with self.assertRaises(errors.InvalidVideoStreamingModeError):
+            video_settings.parse_streaming_mode(
+                make_mock_request({'videoStreamingMode': 'mjpeg'}))
+        with self.assertRaises(errors.InvalidVideoStreamingModeError):
+            video_settings.parse_streaming_mode(
+                make_mock_request({'videoStreamingMode': 'asdf'}))
+
+    def test_reject_invalid_types(self):
+        for value in [None, True, 15.0, (), [], {}]:
+            with self.subTest(value):
+                with self.assertRaises(errors.InvalidVideoStreamingModeError):
+                    video_settings.parse_streaming_mode(
+                        make_mock_request({'videoStreamingMode': value}))
+
+    def test_reject_incorrect_key(self):
+        with self.assertRaises(errors.MissingFieldError):
+            video_settings.parse_streaming_mode(
+                make_mock_request({'streamingMode': 'MJPEG'}))

--- a/app/static/js/controllers.js
+++ b/app/static/js/controllers.js
@@ -332,6 +332,36 @@ export async function getDefaultVideoJpegQuality() {
     });
 }
 
+export async function getVideoStreamingMode() {
+  return fetch("/api/settings/video/streaming_mode", {
+    method: "GET",
+    mode: "same-origin",
+    cache: "no-cache",
+    redirect: "error",
+  })
+    .then(processJsonResponse)
+    .then((data) => {
+      if (!data.hasOwnProperty("videoStreamingMode")) {
+        throw new ControllerError("Missing expected videoStreamingMode field");
+      }
+      return data.videoStreamingMode;
+    });
+}
+
+export async function setVideoStreamingMode(videoStreamingMode) {
+  return fetch("/api/settings/video/streaming_mode", {
+    method: "PUT",
+    mode: "same-origin",
+    cache: "no-cache",
+    redirect: "error",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRFToken": getCsrfToken(),
+    },
+    body: JSON.stringify({ videoStreamingMode }),
+  }).then(processJsonResponse);
+}
+
 export async function applyVideoSettings() {
   return fetch("/api/settings/video/apply", {
     method: "POST",


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1113.

This PR adds the backend endpoints and FE controllers for getting and setting the streaming mode.

- In contrast to the other video settings, we don’t have a need for an endpoint to get the default value, since we don’t need that functionality in the UI. (See [the UI wireframes](https://github.com/tiny-pilot/tinypilot-pro/pull/598).)
- The added code takes over some patterns from the existing code around video settings. See [this issue for potential refactoring ideas](https://github.com/tiny-pilot/tinypilot/issues/1156).
- The endpoints themselves are not wired up yet. That will be done via https://github.com/tiny-pilot/tinypilot/issues/1114.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1158"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>