### PR TITLE
Simplify manipulating CSS class list via `classList.toggle`

### DIFF
--- a/app/templates/custom-elements/menu-bar.html
+++ b/app/templates/custom-elements/menu-bar.html
@@ -302,22 +302,14 @@
 
         set isKeyboardVisible(isVisible) {
           const menuItem = this.shadowRoot.getElementById("keyboard-menu-item");
-          if (isVisible) {
-            menuItem.classList.add("nav-selected");
-          } else {
-            menuItem.classList.remove("nav-selected");
-          }
+          menuItem.classList.toggle("nav-selected", isVisible);
         }
 
         set isInputIndicatorEnabled(isEnabled) {
           const menuItem = this.shadowRoot.getElementById(
             "keystroke-history-menu-item"
           );
-          if (isEnabled) {
-            menuItem.classList.add("nav-selected");
-          } else {
-            menuItem.classList.remove("nav-selected");
-          }
+          menuItem.classList.toggle("nav-selected", isEnabled);
         }
 
         emitCustomEvent(eventId, detail) {
@@ -334,11 +326,10 @@
           for (const cursorListItem of this.shadowRoot.querySelectorAll(
             "#cursor-list li"
           )) {
-            if (newCursor === cursorListItem.getAttribute("cursor")) {
-              cursorListItem.classList.add("nav-selected");
-            } else {
-              cursorListItem.classList.remove("nav-selected");
-            }
+            cursorListItem.classList.toggle(
+              "nav-selected",
+              newCursor === cursorListItem.getAttribute("cursor")
+            );
           }
         }
       }

--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -269,11 +269,10 @@
               this.elements.jpegQualityRestoreButton,
             ],
           ].forEach(([actualValue, defaultValue, resetButton]) => {
-            if (actualValue === defaultValue) {
-              resetButton.classList.add("reset-button-hidden");
-            } else {
-              resetButton.classList.remove("reset-button-hidden");
-            }
+            resetButton.classList.toggle(
+              "reset-button-hidden",
+              actualValue === defaultValue
+            );
           });
         }
 


### PR DESCRIPTION
I stumbled across a handy method that allows us to simplify manipulating an element’s CSS class list via JavaScript: [`classList.toggle()`](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/toggle).

I’m planning to use this method in the [H264-related code of the video settings dialog](https://github.com/tiny-pilot/tinypilot/issues/1114), so I pulled out this refactoring to make the code consistent throughout.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1164"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>