### PR TITLE
Use “H.264” as label, rather than “H264”

### DIFF
--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -37,6 +37,16 @@
       display: flex;
     }
 
+    .streaming-mode-value-mjpeg,
+    .streaming-mode-value-h264 {
+      display: none;
+    }
+
+    :host([streaming-mode="MJPEG"]) .streaming-mode-value-mjpeg,
+    :host([streaming-mode="H264"]) .streaming-mode-value-h264 {
+      display: inline;
+    }
+
     .setting label {
       display: block;
       text-align: right;
@@ -81,7 +91,8 @@
       Streaming Mode:
       <dropdown-button style="--dropdown-width: 9rem;">
         <button slot="button" class="btn-action">
-          <span id="streaming-mode-value">MJPEG</span>
+          <span class="streaming-mode-value-mjpeg">MJPEG</span>
+          <span class="streaming-mode-value-h264">H.264</span>
           <span class="icon-arrow"></span>
         </button>
         <li slot="item" id="streaming-mode-mjpeg-button">
@@ -89,7 +100,7 @@
           <div class="streaming-mode-hint">Best Compatibility</div>
         </li>
         <li slot="item" id="streaming-mode-h264-button">
-          <div>H264</div>
+          <div>H.264</div>
           <div class="streaming-mode-hint">
             Higher Quality,<br />Lower Bandwidth
           </div>
@@ -191,9 +202,6 @@
             ),
             streamingModeH264Button: this.shadowRoot.querySelector(
               "#streaming-mode-h264-button"
-            ),
-            streamingModeValue: this.shadowRoot.querySelector(
-              "#streaming-mode-value"
             ),
             fpsSlider: this.shadowRoot.querySelector("#fps-slider"),
             fpsValue: this.shadowRoot.querySelector("#fps-value"),
@@ -328,7 +336,6 @@
          * @param streamingMode {string}
          */
         _setStreamingMode(streamingMode) {
-          this.elements.streamingModeValue.textContent = streamingMode;
           this.elements.streamingModeMjpegButton.classList.toggle(
             "disabled",
             streamingMode === "MJPEG"


### PR DESCRIPTION
I think, the [canonical name is `H.264` (with dot)](https://en.wikipedia.org/wiki/Advanced_Video_Coding), rather than `H264`, so it would make sense to me to use that spelling for display values in our UI.

In order to differentiate more easily between the code symbol and the display value, I’d slightly refactor the implementation.

<img width="314" alt="Screenshot 2022-11-02 at 15 35 55" src="https://user-images.githubusercontent.com/83721279/199518878-2c7040ac-df00-4764-8bb2-cad0a6fca487.png">

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1176"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>