### PR TITLE
Tweak width of `<connection-indicator>` for space efficiency

### DIFF
--- a/app/templates/custom-elements/connection-indicator.html
+++ b/app/templates/custom-elements/connection-indicator.html
@@ -6,6 +6,12 @@
       position: relative;
     }
 
+    .status-bar-tooltip {
+      /* Slightly tweak the tooltip width, so that the “disconnected” text will
+         break in an optimal way, without creating extra space on the right. */
+      max-width: 23em;
+    }
+
     :host(:hover) .status-bar-tooltip {
       display: block;
     }


### PR DESCRIPTION
Similar to what we discussed in https://github.com/tiny-pilot/tinypilot/pull/1181 about the tooltip width, we could also tweak the width of the `<connection-indicator>` tooltip to optimise for the “disconnected” text.

Although the width currently happens to be `23em` both here and in the other PR, I think we shouldn’t just adjust [the default value of `25em`](https://github.com/tiny-pilot/tinypilot/blob/423f4a14443d2178a974cd7da75ba86d6e1344b6/app/static/css/style.css#L151) to `23em`. It’s only by accident that the values are the same for the current copy, and by having the override in the respective files, it’s more obvious that the value needs to be adjusted if we were to make changes to the text that would then require a different optimisation.

## Before

<img width="456" alt="Screenshot 2022-11-07 at 19 51 12" src="https://user-images.githubusercontent.com/83721279/200391000-82a0f201-82a4-4599-bf0e-e35b331bcc29.png">

## After

<img width="408" alt="Screenshot 2022-11-07 at 19 46 10" src="https://user-images.githubusercontent.com/83721279/200390826-5a56786c-80df-4bfc-af2d-6e790029fd1f.png">

Note, for the “connected” status we don’t have that problem, because it’s shorter, so we don’t hit the max-width constraint:

![Screenshot 2022-11-07 at 19 52 54](https://user-images.githubusercontent.com/83721279/200391927-6c198436-f1f3-4920-abea-85aa18970333.png)

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1184"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>