### PR TITLE
Fix API status code when retrieving video-FPS fails

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -252,7 +252,7 @@ def settings_video_fps_get():
     try:
         video_fps = update.settings.load().ustreamer_desired_fps
     except update.settings.LoadSettingsError as e:
-        return json_response.error(e), 200
+        return json_response.error(e), 500
     # Note: Default values are not set in the settings file. So when the
     # values are unset, we must respond with the correct default value.
     if video_fps is None:


### PR DESCRIPTION
I’m currently working on https://github.com/tiny-pilot/tinypilot/issues/1156, and I stumbled across a glitch in the code, where we accidentally return status 200 on error.

It’s only for FPS, the other endpoints are correct (e.g. [for JPEG Quality](https://github.com/tiny-pilot/tinypilot/blob/344516c32b0a3a48e2f28cd6f5368ccc04146868/app/api.py#L326-L327)).

Although this change will likely vanish soon, due to the upcoming refactoring, I think it’s still better to quickly fix it, to avoid having an inconsistent basis.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1188"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>