### PR TITLE
Fix Debian package filename to use arch all instead of armhf

### DIFF
--- a/debian-pkg/Dockerfile
+++ b/debian-pkg/Dockerfile
@@ -22,7 +22,7 @@ ARG PKG_VERSION
 
 ARG PKG_NAME="tinypilot"
 ARG PKG_BUILD_NUMBER="1"
-ARG PKG_ARCH="armhf"
+ARG PKG_ARCH="all"
 ARG PKG_ID="${PKG_NAME}-${PKG_VERSION}-${PKG_BUILD_NUMBER}-${PKG_ARCH}"
 
 RUN mkdir -p "/releases/${PKG_ID}"
@@ -46,7 +46,7 @@ RUN echo "Package: ${PKG_NAME}" >> control && \
     echo "Version: ${PKG_VERSION}" >> control && \
     echo "Maintainer: TinyPilot Support <support@tinypilotkvm.com>" >> control && \
     echo "Depends: python3, python3-pip, python3-venv, sudo" >> control && \
-    echo "Architecture: all" >> control && \
+    echo "Architecture: ${PKG_ARCH}" >> control && \
     echo "Homepage: https://tinypilotkvm.com" >> control && \
     echo "Description: Simple, easy-to-use KVM over IP" >> control
 


### PR DESCRIPTION
We have a mismatch between the architecture we declare in the Debian package and the architecture we specify in the filename. The filename was specifying an architecture of armhf, while the Debian package was declaring all.

all is correct, so this change updates the filename to match and makes it harder for the two to go out of sync.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1197"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>