### PR TITLE
Video settings: drop `video` prefix from code symbols

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -240,23 +240,23 @@ def settings_video_get():
 
     Returns:
         On success, a JSON data structure with the following properties:
-        - videoStreamingMode: string
-        - videoFps: int
-        - videoDefaultFps: int
-        - videoJpegQuality: int
-        - videoDefaultJpegQuality: int
-        - videoH264Bitrate: int
-        - videoDefaultH264Bitrate: int
+        - streamingMode: string
+        - fps: int
+        - defaultFps: int
+        - jpegQuality: int
+        - defaultJpegQuality: int
+        - h264Bitrate: int
+        - defaultH264Bitrate: int
 
         Example of success:
         {
-            "videoStreamingMode": "MJPEG",
-            "videoFps": 12,
-            "videoDefaultFps": 30,
-            "videoJpegQuality": 80,
-            "videoDefaultJpegQuality": 80,
-            "videoH264Bitrate": 450,
-            "videoDefaultH264Bitrate": 5000
+            "streamingMode": "MJPEG",
+            "fps": 12,
+            "defaultFps": 30,
+            "jpegQuality": 80,
+            "defaultJpegQuality": 80,
+            "h264Bitrate": 450,
+            "defaultH264Bitrate": 5000
         }
 
         Returns an error object on failure.
@@ -266,16 +266,16 @@ def settings_video_get():
     except update.settings.LoadSettingsError as e:
         return json_response.error(e), 500
 
-    video_streaming_mode = db.settings.Settings().get_streaming_mode().value
+    streaming_mode = db.settings.Settings().get_streaming_mode().value
 
     return json_response.success({
-        'videoStreamingMode': video_streaming_mode,
-        'videoFps': update_settings.ustreamer_desired_fps,
-        'videoDefaultFps': video_settings.DEFAULT_FPS,
-        'videoJpegQuality': update_settings.ustreamer_quality,
-        'videoDefaultJpegQuality': video_settings.DEFAULT_JPEG_QUALITY,
-        'videoH264Bitrate': update_settings.ustreamer_h264_bitrate,
-        'videoDefaultH264Bitrate': video_settings.DEFAULT_H264_BITRATE
+        'streamingMode': streaming_mode,
+        'fps': update_settings.ustreamer_desired_fps,
+        'defaultFps': video_settings.DEFAULT_FPS,
+        'jpegQuality': update_settings.ustreamer_quality,
+        'defaultJpegQuality': video_settings.DEFAULT_JPEG_QUALITY,
+        'h264Bitrate': update_settings.ustreamer_h264_bitrate,
+        'defaultH264Bitrate': video_settings.DEFAULT_H264_BITRATE
     })
 
 
@@ -288,29 +288,29 @@ def settings_video_put():
 
     Expects a JSON data structure in the request body that contains the
     following parameters for the video settings:
-    - videoStreamingMode: string
-    - videoFps: int
-    - videoJpegQuality: int
-    - videoH264Bitrate: int
+    - streamingMode: string
+    - fps: int
+    - jpegQuality: int
+    - h264Bitrate: int
 
     Example of request body:
     {
-        "videoStreamingMode": "MJPEG",
-        "videoFps": 12,
-        "videoJpegQuality": 80,
-        "videoH264Bitrate": 450
+        "streamingMode": "MJPEG",
+        "fps": 12,
+        "jpegQuality": 80,
+        "h264Bitrate": 450
     }
 
     Returns:
         Empty response on success, error object otherwise.
     """
     try:
-        video_streaming_mode = \
+        streaming_mode = \
             request_parsers.video_settings.parse_streaming_mode(flask.request)
-        video_fps = request_parsers.video_settings.parse_fps(flask.request)
-        video_jpeg_quality = request_parsers.video_settings.parse_jpeg_quality(
+        fps = request_parsers.video_settings.parse_fps(flask.request)
+        jpeg_quality = request_parsers.video_settings.parse_jpeg_quality(
             flask.request)
-        video_h264_bitrate = request_parsers.video_settings.parse_h264_bitrate(
+        h264_bitrate = request_parsers.video_settings.parse_h264_bitrate(
             flask.request)
     except request_parsers.errors.InvalidVideoSettingError as e:
         return json_response.error(e), 400
@@ -320,13 +320,13 @@ def settings_video_put():
     except update.settings.LoadSettingsError as e:
         return json_response.error(e), 500
 
-    update_settings.ustreamer_desired_fps = video_fps
-    update_settings.ustreamer_quality = video_jpeg_quality
-    update_settings.ustreamer_h264_bitrate = video_h264_bitrate
+    update_settings.ustreamer_desired_fps = fps
+    update_settings.ustreamer_quality = jpeg_quality
+    update_settings.ustreamer_h264_bitrate = h264_bitrate
 
     # Store the new parameters. Note: we only actually persist anything if *all*
     # values have passed the validation.
-    db.settings.Settings().set_streaming_mode(video_streaming_mode)
+    db.settings.Settings().set_streaming_mode(streaming_mode)
     try:
         update.settings.save(update_settings)
     except update.settings.SaveSettingsError as e:

--- a/app/request_parsers/video_settings.py
+++ b/app/request_parsers/video_settings.py
@@ -5,53 +5,53 @@ from request_parsers import json
 
 def parse_fps(request):
     # pylint: disable=unbalanced-tuple-unpacking
-    (video_fps,) = json.parse_json_body(request, required_fields=['videoFps'])
+    (fps,) = json.parse_json_body(request, required_fields=['fps'])
     try:
-        video_fps = _as_int(video_fps)
-        if not 1 <= video_fps <= 30:
+        fps = _as_int(fps)
+        if not 1 <= fps <= 30:
             raise ValueError
     except ValueError as e:
         raise errors.InvalidVideoSettingError(
             'The video FPS must be a whole number between 1 and 30.') from e
-    return video_fps
+    return fps
 
 
 def parse_jpeg_quality(request):
     # pylint: disable=unbalanced-tuple-unpacking
-    (video_jpeg_quality,) = json.parse_json_body(
-        request, required_fields=['videoJpegQuality'])
+    (jpeg_quality,) = json.parse_json_body(request,
+                                           required_fields=['jpegQuality'])
     try:
-        video_jpeg_quality = _as_int(video_jpeg_quality)
-        if not 1 <= video_jpeg_quality <= 100:
+        jpeg_quality = _as_int(jpeg_quality)
+        if not 1 <= jpeg_quality <= 100:
             raise ValueError
     except ValueError as e:
         raise errors.InvalidVideoSettingError(
             'The video JPEG quality must be a whole number between 1 and 100.'
         ) from e
-    return video_jpeg_quality
+    return jpeg_quality
 
 
 def parse_h264_bitrate(request):
     # pylint: disable=unbalanced-tuple-unpacking
-    (video_h264_bitrate,) = json.parse_json_body(
-        request, required_fields=['videoH264Bitrate'])
+    (h264_bitrate,) = json.parse_json_body(request,
+                                           required_fields=['h264Bitrate'])
     try:
-        video_h264_bitrate = _as_int(video_h264_bitrate)
-        if not 25 <= video_h264_bitrate <= 20000:
+        h264_bitrate = _as_int(h264_bitrate)
+        if not 25 <= h264_bitrate <= 20000:
             raise ValueError
     except ValueError as e:
         raise errors.InvalidVideoSettingError(
             'The H264 bitrate must be a whole number between 25 and 20000.'
         ) from e
-    return video_h264_bitrate
+    return h264_bitrate
 
 
 def parse_streaming_mode(request):
     # pylint: disable=unbalanced-tuple-unpacking
-    (video_streaming_mode,) = json.parse_json_body(
-        request, required_fields=['videoStreamingMode'])
+    (streaming_mode,) = json.parse_json_body(request,
+                                             required_fields=['streamingMode'])
     try:
-        return db.settings.StreamingMode(video_streaming_mode)
+        return db.settings.StreamingMode(streaming_mode)
     except ValueError as e:
         raise errors.InvalidVideoSettingError(
             'The video streaming mode must be `MJPEG` or `H264`.') from e

--- a/app/request_parsers/video_settings_test.py
+++ b/app/request_parsers/video_settings_test.py
@@ -16,17 +16,17 @@ class VideoFpsParserTest(unittest.TestCase):
 
     def test_reject_integers_out_of_bounds(self):
         with self.assertRaises(errors.InvalidVideoSettingError):
-            video_settings.parse_fps(make_mock_request({'videoFps': 0}))
+            video_settings.parse_fps(make_mock_request({'fps': 0}))
         with self.assertRaises(errors.InvalidVideoSettingError):
-            video_settings.parse_fps(make_mock_request({'videoFps': 31}))
+            video_settings.parse_fps(make_mock_request({'fps': 31}))
 
     def test_accept_integers_within_bounds(self):
         self.assertEqual(
-            1, video_settings.parse_fps(make_mock_request({'videoFps': 1})))
+            1, video_settings.parse_fps(make_mock_request({'fps': 1})))
         self.assertEqual(
-            15, video_settings.parse_fps(make_mock_request({'videoFps': 15})))
+            15, video_settings.parse_fps(make_mock_request({'fps': 15})))
         self.assertEqual(
-            30, video_settings.parse_fps(make_mock_request({'videoFps': 30})))
+            30, video_settings.parse_fps(make_mock_request({'fps': 30})))
 
     def test_reject_non_integers(self):
         for value in [
@@ -34,12 +34,11 @@ class VideoFpsParserTest(unittest.TestCase):
         ]:
             with self.subTest(value):
                 with self.assertRaises(errors.InvalidVideoSettingError):
-                    video_settings.parse_fps(
-                        make_mock_request({'videoFps': value}))
+                    video_settings.parse_fps(make_mock_request({'fps': value}))
 
     def test_reject_incorrect_key(self):
         with self.assertRaises(errors.MissingFieldError):
-            video_settings.parse_fps(make_mock_request({'fps': 1}))
+            video_settings.parse_fps(make_mock_request({'something': 1}))
 
 
 class VideoJpegQualityParserTest(unittest.TestCase):
@@ -47,24 +46,24 @@ class VideoJpegQualityParserTest(unittest.TestCase):
     def test_reject_integers_out_of_bounds(self):
         with self.assertRaises(errors.InvalidVideoSettingError):
             video_settings.parse_jpeg_quality(
-                make_mock_request({'videoJpegQuality': 0}))
+                make_mock_request({'jpegQuality': 0}))
         with self.assertRaises(errors.InvalidVideoSettingError):
             video_settings.parse_jpeg_quality(
-                make_mock_request({'videoJpegQuality': 101}))
+                make_mock_request({'jpegQuality': 101}))
 
     def test_accept_integers_within_bounds(self):
         self.assertEqual(
             1,
             video_settings.parse_jpeg_quality(
-                make_mock_request({'videoJpegQuality': 1})))
+                make_mock_request({'jpegQuality': 1})))
         self.assertEqual(
             50,
             video_settings.parse_jpeg_quality(
-                make_mock_request({'videoJpegQuality': 50})))
+                make_mock_request({'jpegQuality': 50})))
         self.assertEqual(
             100,
             video_settings.parse_jpeg_quality(
-                make_mock_request({'videoJpegQuality': 100})))
+                make_mock_request({'jpegQuality': 100})))
 
     def test_reject_non_integers(self):
         for value in [
@@ -73,12 +72,12 @@ class VideoJpegQualityParserTest(unittest.TestCase):
             with self.subTest(value):
                 with self.assertRaises(errors.InvalidVideoSettingError):
                     video_settings.parse_jpeg_quality(
-                        make_mock_request({'videoJpegQuality': value}))
+                        make_mock_request({'jpegQuality': value}))
 
     def test_reject_incorrect_key(self):
         with self.assertRaises(errors.MissingFieldError):
             video_settings.parse_jpeg_quality(
-                make_mock_request({'jpegQuality': 1}))
+                make_mock_request({'something': 1}))
 
 
 class VideoH264BitrateParserTest(unittest.TestCase):
@@ -86,24 +85,24 @@ class VideoH264BitrateParserTest(unittest.TestCase):
     def test_reject_integers_out_of_bounds(self):
         with self.assertRaises(errors.InvalidVideoSettingError):
             video_settings.parse_h264_bitrate(
-                make_mock_request({'videoH264Bitrate': 24}))
+                make_mock_request({'h264Bitrate': 24}))
         with self.assertRaises(errors.InvalidVideoSettingError):
             video_settings.parse_h264_bitrate(
-                make_mock_request({'videoH264Bitrate': 20001}))
+                make_mock_request({'h264Bitrate': 20001}))
 
     def test_accept_integers_within_bounds(self):
         self.assertEqual(
             25,
             video_settings.parse_h264_bitrate(
-                make_mock_request({'videoH264Bitrate': 25})))
+                make_mock_request({'h264Bitrate': 25})))
         self.assertEqual(
             5000,
             video_settings.parse_h264_bitrate(
-                make_mock_request({'videoH264Bitrate': 5000})))
+                make_mock_request({'h264Bitrate': 5000})))
         self.assertEqual(
             20000,
             video_settings.parse_h264_bitrate(
-                make_mock_request({'videoH264Bitrate': 20000})))
+                make_mock_request({'h264Bitrate': 20000})))
 
     def test_reject_non_integers(self):
         for value in [
@@ -112,12 +111,12 @@ class VideoH264BitrateParserTest(unittest.TestCase):
             with self.subTest(value):
                 with self.assertRaises(errors.InvalidVideoSettingError):
                     video_settings.parse_h264_bitrate(
-                        make_mock_request({'videoH264Bitrate': value}))
+                        make_mock_request({'h264Bitrate': value}))
 
     def test_reject_incorrect_key(self):
         with self.assertRaises(errors.MissingFieldError):
             video_settings.parse_h264_bitrate(
-                make_mock_request({'h264Bitrate': 1}))
+                make_mock_request({'something': 1}))
 
 
 class VideoStreamingModeParserTest(unittest.TestCase):
@@ -126,28 +125,28 @@ class VideoStreamingModeParserTest(unittest.TestCase):
         self.assertEqual(
             db.settings.StreamingMode.MJPEG,
             video_settings.parse_streaming_mode(
-                make_mock_request({'videoStreamingMode': 'MJPEG'})))
+                make_mock_request({'streamingMode': 'MJPEG'})))
         self.assertEqual(
             db.settings.StreamingMode.H264,
             video_settings.parse_streaming_mode(
-                make_mock_request({'videoStreamingMode': 'H264'})))
+                make_mock_request({'streamingMode': 'H264'})))
 
     def test_reject_invalid_modes(self):
         with self.assertRaises(errors.InvalidVideoSettingError):
             video_settings.parse_streaming_mode(
-                make_mock_request({'videoStreamingMode': 'mjpeg'}))
+                make_mock_request({'streamingMode': 'mjpeg'}))
         with self.assertRaises(errors.InvalidVideoSettingError):
             video_settings.parse_streaming_mode(
-                make_mock_request({'videoStreamingMode': 'asdf'}))
+                make_mock_request({'streamingMode': 'asdf'}))
 
     def test_reject_invalid_types(self):
         for value in [None, True, 15.0, (), [], {}]:
             with self.subTest(value):
                 with self.assertRaises(errors.InvalidVideoSettingError):
                     video_settings.parse_streaming_mode(
-                        make_mock_request({'videoStreamingMode': value}))
+                        make_mock_request({'streamingMode': value}))
 
     def test_reject_incorrect_key(self):
         with self.assertRaises(errors.MissingFieldError):
             video_settings.parse_streaming_mode(
-                make_mock_request({'streamingMode': 'MJPEG'}))
+                make_mock_request({'something': 'MJPEG'}))

--- a/app/static/js/controllers.js
+++ b/app/static/js/controllers.js
@@ -250,13 +250,13 @@ export async function getVideoSettings() {
     .then(processJsonResponse)
     .then((data) => {
       [
-        "videoStreamingMode",
-        "videoFps",
-        "videoDefaultFps",
-        "videoJpegQuality",
-        "videoDefaultJpegQuality",
-        "videoH264Bitrate",
-        "videoDefaultH264Bitrate",
+        "streamingMode",
+        "fps",
+        "defaultFps",
+        "jpegQuality",
+        "defaultJpegQuality",
+        "h264Bitrate",
+        "defaultH264Bitrate",
       ].forEach((field) => {
         if (!data.hasOwnProperty(field)) {
           throw new ControllerError(`Missing expected ${field} field`);
@@ -267,10 +267,10 @@ export async function getVideoSettings() {
 }
 
 export async function saveVideoSettings({
-  videoStreamingMode,
-  videoFps,
-  videoJpegQuality,
-  videoH264Bitrate,
+  streamingMode,
+  fps,
+  jpegQuality,
+  h264Bitrate,
 }) {
   return fetch("/api/settings/video", {
     method: "PUT",
@@ -282,10 +282,10 @@ export async function saveVideoSettings({
       "X-CSRFToken": getCsrfToken(),
     },
     body: JSON.stringify({
-      videoStreamingMode,
-      videoFps,
-      videoJpegQuality,
-      videoH264Bitrate,
+      streamingMode,
+      fps,
+      jpegQuality,
+      h264Bitrate,
     }),
   }).then(processJsonResponse);
 }

--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -271,13 +271,13 @@
           getVideoSettings()
             .then(
               ({
-                videoStreamingMode: streamingMode,
-                videoFps: fps,
-                videoDefaultFps: defaultFps,
-                videoJpegQuality: jpegQuality,
-                videoDefaultJpegQuality: defaultJpegQuality,
-                videoH264Bitrate: bitrate,
-                videoDefaultH264Bitrate: defaultBitrate,
+                streamingMode,
+                fps,
+                defaultFps,
+                jpegQuality,
+                defaultJpegQuality,
+                h264Bitrate: bitrate,
+                defaultH264Bitrate: defaultBitrate,
               }) => {
                 this._setStreamingMode(streamingMode);
                 this._initialSettings.streamingMode = streamingMode;
@@ -423,10 +423,10 @@
         _saveSettings() {
           this.state = this.states.SAVING;
           return saveVideoSettings({
-            videoStreamingMode: this._getStreamingMode(),
-            videoFps: this._getFps(),
-            videoJpegQuality: this._getJpegQuality(),
-            videoH264Bitrate: this._getBitrate(),
+            streamingMode: this._getStreamingMode(),
+            fps: this._getFps(),
+            jpegQuality: this._getJpegQuality(),
+            h264Bitrate: this._getBitrate(),
           })
             .then(applyVideoSettings)
             .then(() => {


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot/issues/1156.

This PR drops the `video` prefix in all places, where it’s clear from the context what the names refer to. So e.g. inside `<video-settings-dialog>`, we don’t really need to prefix the variables, whereas for [`InvalidVideoSettingError` (in `request_parsers.errors`)](https://github.com/tiny-pilot/tinypilot/blob/159c7a93d6165afa6618cadc1bb514daaf47f040/app/request_parsers/errors.py#L17) the prefix/infix is useful as kind-of “namespace” / differentiator.

Note, in [`controllers.js`, there is still one naming mismatch](https://github.com/tiny-pilot/tinypilot/blob/4a46d82d206ef83ed76f81524acd1dccb0b00cb8/app/templates/custom-elements/video-settings-dialog.html#L279-L280) – that will be cleaned up in the next (and last) PR.