### PR TITLE
Use docker build --progress=plain on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,10 @@ workflows:
       - check_style
       - build_python
       - build_javascript
-      - build_debian_package
+      - build_debian_package:
+          filters:
+            branches:
+              only: master
       - lint_debian_package:
           requires:
             - build_debian_package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,10 +209,7 @@ workflows:
       - check_style
       - build_python
       - build_javascript
-      - build_debian_package:
-          filters:
-            branches:
-              only: master
+      - build_debian_package
       - lint_debian_package:
           requires:
             - build_debian_package

--- a/dev-scripts/build-debian-pkg
+++ b/dev-scripts/build-debian-pkg
@@ -22,7 +22,6 @@ readonly TINYPILOT_VERSION
 PKG_VERSION="$(date '+%Y%m%d%H%M%S')"
 readonly PKG_VERSION
 
-
 DOCKER_BUILDKIT=1 docker build \
   --file debian-pkg/Dockerfile \
   --build-arg TINYPILOT_VERSION="${TINYPILOT_VERSION}" \

--- a/dev-scripts/build-debian-pkg
+++ b/dev-scripts/build-debian-pkg
@@ -15,10 +15,19 @@ readonly TINYPILOT_VERSION
 PKG_VERSION="$(date '+%Y%m%d%H%M%S')"
 readonly PKG_VERSION
 
+# Default to plain build progress output unless the user is running an
+# interactive terminal.
+DOCKER_PROGRESS="plain"
+if [[ -t 1 ]]; then
+  DOCKER_PROGRESS="auto"
+fi
+readonly DOCKER_PROGRESS
+
 DOCKER_BUILDKIT=1 docker build \
   --file debian-pkg/Dockerfile \
   --build-arg TINYPILOT_VERSION="${TINYPILOT_VERSION}" \
   --build-arg PKG_VERSION="${PKG_VERSION}" \
   --target=artifact \
+  --progress="${DOCKER_PROGRESS}" \
   --output "type=local,dest=$(pwd)/debian-pkg/releases/" \
   .

--- a/dev-scripts/build-debian-pkg
+++ b/dev-scripts/build-debian-pkg
@@ -6,13 +6,6 @@ set -e
 # Echo commands to stdout.
 set -x
 
-# Use plain Docker build progress output when we're running in CI.
-DOCKER_PROGRESS="auto"
-if [[ -n "${CI}" ]]; then
-  DOCKER_PROGRESS="plain"
-fi
-readonly DOCKER_PROGRESS
-
 # Exit on unset variable.
 set -u
 
@@ -21,6 +14,13 @@ readonly TINYPILOT_VERSION
 
 PKG_VERSION="$(date '+%Y%m%d%H%M%S')"
 readonly PKG_VERSION
+
+# Use plain Docker build progress output when we're running in CI.
+DOCKER_PROGRESS='auto'
+if [[ -n "${CI:-}" ]]; then
+  DOCKER_PROGRESS='plain'
+fi
+readonly DOCKER_PROGRESS
 
 DOCKER_BUILDKIT=1 docker build \
   --file debian-pkg/Dockerfile \

--- a/dev-scripts/build-debian-pkg
+++ b/dev-scripts/build-debian-pkg
@@ -6,6 +6,13 @@ set -e
 # Echo commands to stdout.
 set -x
 
+# Use plain Docker build progress output when we're running in CI.
+DOCKER_PROGRESS="auto"
+if [[ -n "${CI}" ]]; then
+  DOCKER_PROGRESS="plain"
+fi
+readonly DOCKER_PROGRESS
+
 # Exit on unset variable.
 set -u
 
@@ -15,13 +22,6 @@ readonly TINYPILOT_VERSION
 PKG_VERSION="$(date '+%Y%m%d%H%M%S')"
 readonly PKG_VERSION
 
-# Default to plain build progress output unless the user is running an
-# interactive terminal.
-DOCKER_PROGRESS="plain"
-if [[ -t 1 ]]; then
-  DOCKER_PROGRESS="auto"
-fi
-readonly DOCKER_PROGRESS
 
 DOCKER_BUILDKIT=1 docker build \
   --file debian-pkg/Dockerfile \


### PR DESCRIPTION
Similar to https://github.com/tiny-pilot/janus-debian/pull/12 we should use --progress=plain to produce less noisy output when running a Docker build on CircleCI.

This change detects whether we're running in CI based on whether the `CI` variables is set (which CircleCI and a few others set) and downgrades the progress output to plain if it is set.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1201"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>