### PR TITLE
Remove unused WebRTC dev env variable.

### DIFF
--- a/dev_app_settings.cfg
+++ b/dev_app_settings.cfg
@@ -3,5 +3,3 @@
 
 KEYBOARD_PATH = '/dev/null'
 MOUSE_PATH = '/dev/null'
-
-USE_WEBRTC_REMOTE_SCREEN = True


### PR DESCRIPTION
We no longer need the `USE_WEBRTC_REMOTE_SCREEN` dev env variable because the video streaming mode is now saved in the database.

I didn't catch this when reviewing https://github.com/tiny-pilot/tinypilot/pull/1166