### PR TITLE
Respect dark mode system preference for background color

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -18,6 +18,7 @@
 
   --brand-sand-light: hsl(var(--brand-hue-yellow), 59%, 92%);
   --brand-creme-light: hsl(var(--brand-hue-yellow), 60%, 97%);
+  --brand-background-dark: hsl(var(--brand-hue-yellow), 16%, 11%);
 
   --brand-orange-light: hsl(var(--brand-hue-orange), 100%, 80%);
   --brand-orange-dark: hsl(var(--brand-hue-orange), 50%, 50%);
@@ -52,6 +53,12 @@
 body {
   margin: 0;
   background: var(--brand-creme-light);
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: var(--brand-background-dark);
+  }
 }
 
 .container {


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1091, by automatically making the site’s background-color dark, if the user prefers a dark color scheme.

https://user-images.githubusercontent.com/83721279/203367442-cc8e3f68-8f18-4fe5-9edf-3482584e074d.mov

The dark background color is technically a very dark brown. I think it makes sense to not make it pitch black (like `#000`), so that the borders of the remote screen are still discernible even if it happens to render all black. (E.g., the “no signal” placeholder.)

Two notes:

- For [the onscreen keyboard](https://user-images.githubusercontent.com/83721279/203368683-e6db16b1-6c37-4e66-b865-5bc8caf6d8cf.png), it’s currently tricky to make it dark, because its color values [are mostly hard-coded](https://github.com/tiny-pilot/tinypilot/blob/master/app/templates/custom-elements/key.html#L22). We’d have to refactor that first, but I’m not sure how worthwhile that is. For now, I think it’s bearable.
- The [dialogs](https://user-images.githubusercontent.com/83721279/203368695-42410389-0a9b-4210-8fb6-2e074f119665.png) must stay bright, because otherwise they wouldn’t have enough contrast against the dark overlay background.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1208"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>