### PR TITLE
Build TinyPilot Debian package and install bundle outside the main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,13 +210,21 @@ workflows:
       - build_python
       - build_javascript
       - build_debian_package
-      - lint_debian_package
+      - lint_debian_package:
+          requires:
+            - build_debian_package
       - build_bundle:
           requires:
             - build_debian_package
+          filters:
+            branches:
+              only: master
       - verify_bundle:
           requires:
             - build_bundle
+          filters:
+            branches:
+              only: master
       - upload_bundle:
           requires:
             - verify_bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,15 +216,9 @@ workflows:
       - build_bundle:
           requires:
             - build_debian_package
-          filters:
-            branches:
-              only: master
       - verify_bundle:
           requires:
             - build_bundle
-          filters:
-            branches:
-              only: master
       - upload_bundle:
           requires:
             - verify_bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,8 @@ workflows:
       - upload_bundle:
           requires:
             - verify_bundle
+          # Uploading a new bundle affects Gatekeeper's view of the latest
+          # bundle available, so we should only do this on master.
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,25 +209,14 @@ workflows:
       - check_style
       - build_python
       - build_javascript
-      - build_debian_package:
-          filters:
-            branches:
-              only: master
-      - lint_debian_package:
-          requires:
-            - build_debian_package
+      - build_debian_package
+      - lint_debian_package
       - build_bundle:
           requires:
             - build_debian_package
-          filters:
-            branches:
-              only: master
       - verify_bundle:
           requires:
             - build_bundle
-          filters:
-            branches:
-              only: master
       - upload_bundle:
           requires:
             - verify_bundle


### PR DESCRIPTION
This change adjusts filtering in CircleCI so that we build the TinyPilot Debian package and install bundle even in non-main repo branches.

Uploading a bundle changes state on our update server, so we should only do that in our main branch. But all the other steps are fine to run in branches because it doesn't affect state outside of CI. It's often useful to build packages or bundles in the branches if we want to test something end-to-end.