### PR TITLE
Ensure `lsb-release` is installed.

### DIFF
--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -98,7 +98,8 @@ apt-get install -y \
   libffi-dev \
   libssl-dev \
   python3-dev \
-  python3-venv
+  python3-venv \
+  lsb-release
 
 python3 -m venv venv
 # shellcheck disable=SC1091 # Don’t follow sourced script.


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/ansible-role-ustreamer/issues/77

As mention in https://github.com/tiny-pilot/ansible-role-ustreamer/pull/78#issue-1466714471:
> To accurately distinguish between Raspberry Pi OS and Debian, we need to use the `ansible_lsb.id` fact because `ansible_distribution=='Debian'` for both OSs. This fact is [only defined if the `lsb-release` apt packages has been installed](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_conditionals.html#conditionals-based-on-ansible-facts) prior to ansible gathering facts.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1215"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>