### PR TITLE
Store the TinyPilot bundle as a build artifact in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,13 +210,21 @@ workflows:
       - build_python
       - build_javascript
       - build_debian_package
-      - lint_debian_package
+      - lint_debian_package:
+          requires:
+            - build_debian_package
       - build_bundle:
           requires:
             - build_debian_package
+          filters:
+            branches:
+              only: master
       - verify_bundle:
           requires:
             - build_bundle
+          filters:
+            branches:
+              only: master
       - upload_bundle:
           requires:
             - verify_bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,15 +216,9 @@ workflows:
       - build_bundle:
           requires:
             - build_debian_package
-          filters:
-            branches:
-              only: master
       - verify_bundle:
           requires:
             - build_bundle
-          filters:
-            branches:
-              only: master
       - upload_bundle:
           requires:
             - verify_bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,8 @@ workflows:
       - upload_bundle:
           requires:
             - verify_bundle
+          # Uploading a new bundle affects Gatekeeper's view of the latest
+          # bundle available, so we should only do this on master.
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,25 +209,14 @@ workflows:
       - check_style
       - build_python
       - build_javascript
-      - build_debian_package:
-          filters:
-            branches:
-              only: master
-      - lint_debian_package:
-          requires:
-            - build_debian_package
+      - build_debian_package
+      - lint_debian_package
       - build_bundle:
           requires:
             - build_debian_package
-          filters:
-            branches:
-              only: master
       - verify_bundle:
           requires:
             - build_bundle
-          filters:
-            branches:
-              only: master
       - upload_bundle:
           requires:
             - verify_bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
           name: Create the bundle
           command: cd bundler && ./create-bundle
       - store_artifacts:
-          path: bundler/dist/files.txt
+          path: bundler/dist/
       - persist_to_workspace:
           root: ./bundler
           paths:


### PR DESCRIPTION
Now that we're building the bundle on non-master branches, it's helpful to store it as a CI artifact in case we want to test the bundle before merging changes into master.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1216"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>