### PR TITLE
Added step to check if overlay filesystem is enabled

### DIFF
--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -85,10 +85,11 @@ echo "TinyPilot state" >> "${LOG_FILE}"
 
 print_info "Checking if filesystem is read-only..."
 {
-  READ_ONLY_FILESYSTEM=off
+  READ_ONLY_FILESYSTEM="off"
   if grep -q "boot=overlay" /proc/cmdline ; then
-    READ_ONLY_FILESYSTEM=on
+    READ_ONLY_FILESYSTEM="on"
   fi
+  readonly READ_ONLY_FILESYSTEM
   echo "Read-only filesystem: ${READ_ONLY_FILESYSTEM}"
 } >> "${LOG_FILE}"
 

--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -83,6 +83,15 @@ print_info "Checking OS version..."
 
 echo "TinyPilot state" >> "${LOG_FILE}"
 
+print_info "Checking if filesystem is read-only..."
+{
+  READ_ONLY_FILESYSTEM=off
+  if grep -q "boot=overlay" /proc/cmdline ; then
+    READ_ONLY_FILESYSTEM=on
+  fi
+  echo "Read-only filesystem: ${READ_ONLY_FILESYSTEM}"
+} >> "${LOG_FILE}"
+
 print_info "Checking temperature..."
 printf "%s\n" "$(vcgencmd measure_temp)" >> "${LOG_FILE}"
 


### PR DESCRIPTION
Resolves #1205 by adding a step to the log collection script to check if the overlay / read-only filesystem is enabled.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1218"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>