### PR TITLE
Use lintian version from stable apt repo suite.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           command: sudo apt-get update
       - run:
           name: Install lintian
-          command: sudo apt-get install --target-release jammy-updates -y lintian=2.114.0ubuntu1.1
+          command: sudo apt-get install -y lintian=2.114.0ubuntu1
       - run:
           name: Print lintian version
           command: lintian --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           command: sudo apt-get update
       - run:
           name: Install lintian
-          command: sudo apt-get install -y lintian=2.114.0ubuntu1.1
+          command: sudo apt-get install --target-release jammy-updates -y lintian=2.114.0ubuntu1.1
       - run:
           name: Print lintian version
           command: lintian --version


### PR DESCRIPTION
Use lintian version`2.114.0ubuntu1` instead of `2.114.0ubuntu1.1`.

The lintian version we were using came from the [`jammy-updates` apt repo suite](https://packages.ubuntu.com/jammy-updates/lintian). It suddenly [vanished and broke our build](https://app.circleci.com/pipelines/github/tiny-pilot/tinypilot/2802/workflows/7b1addfb-c4ff-4aff-a7d6-50baa12c292b/jobs/12132?invite=true#step-103-10).

This PR uses the lintian version from the main [`jammy` suite](https://packages.ubuntu.com/jammy-updates/lintian).
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1219"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>