### PR TITLE
Move tinypilot-updater service into core repo

### DIFF
--- a/.lintianignore
+++ b/.lintianignore
@@ -14,3 +14,9 @@ recursive-privilege-change
 # Our copyright notice isn't in the correct format.
 # https://lintian.debian.org/tags/copyright-without-copyright-notice
 copyright-without-copyright-notice
+
+# Apparently the Target and WantedBy fields we specify are atypical, so suppress
+# warnings until we can find the right field values.
+# https://github.com/tiny-pilot/tinypilot/issues/1207
+systemd-service-file-refers-to-obsolete-target
+systemd-service-file-refers-to-unusual-wantedby-target

--- a/debian-pkg/debian/rules
+++ b/debian-pkg/debian/rules
@@ -2,3 +2,6 @@
 
 %:
 	dh $@
+
+override_dh_installsystemd:
+	dh_installsystemd --name=tinypilot-updater

--- a/debian-pkg/debian/rules
+++ b/debian-pkg/debian/rules
@@ -4,4 +4,4 @@
 	dh $@
 
 override_dh_installsystemd:
-	dh_installsystemd --name=tinypilot-updater
+	dh_installsystemd --name=tinypilot-updater --no-start --no-enable

--- a/debian-pkg/debian/tinypilot.tinypilot-updater.service
+++ b/debian-pkg/debian/tinypilot.tinypilot-updater.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=TinyPilot updater
+After=syslog.target network.target
+
+[Service]
+Type=oneshot
+User=tinypilot
+WorkingDirectory=/opt/tinypilot
+ExecStart=/opt/tinypilot/venv/bin/python scripts/update-service
+Environment=PYTHONPATH=/opt/tinypilot/app
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=tinypilot-update-svc
+TimeoutSec=900
+KillSignal=SIGKILL
+
+[Install]
+WantedBy=local-fs.target

--- a/debian-pkg/debian/tinypilot.tinypilot-updater.service
+++ b/debian-pkg/debian/tinypilot.tinypilot-updater.service
@@ -8,8 +8,8 @@ User=tinypilot
 WorkingDirectory=/opt/tinypilot
 ExecStart=/opt/tinypilot/venv/bin/python scripts/update-service
 Environment=PYTHONPATH=/opt/tinypilot/app
-StandardOutput=syslog
-StandardError=syslog
+StandardOutput=journal
+StandardError=journal
 SyslogIdentifier=tinypilot-update-svc
 TimeoutSec=900
 KillSignal=SIGKILL


### PR DESCRIPTION
We previously implemented the tinypilot-updater service in ansible-role-tinypilot, but now that we have a Debian package, it's easier to install the service via the Debian package.

The systemd service definition is verbatim what existed in ansible-role-tinypilot except I've replaced `StandardOutput=syslog` with `StandardOutput=journal` (same with `StandardError`) due to [this lintian warning](https://lintian.debian.org/tags/systemd-service-file-uses-deprecated-syslog-facility).

This change corresponds to the removal of the service from ansible-role-tinypilot: https://github.com/tiny-pilot/ansible-role-tinypilot/pull/241

I tested this manually [on TinyPilot Pro](https://github.com/tiny-pilot/tinypilot-pro/compare/no-updater-scratch?expand=1), and it worked as expected.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1225"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>