### PR TITLE
Add a step to capture the board revision in the debug logs

### DIFF
--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -84,7 +84,7 @@ print_info "Checking OS version..."
 print_info "Checking hardware information..."
 {
   echo "Hardware information"
-  grep -E "Hardware|Revision|Model" /proc/cpuinfo | sed -r "s/\s+//1"
+  grep "^Hardware\|^Revision\|^Model" /proc/cpuinfo | sed "s/\s*:\s*/: /g"
   printf "\n"
 } >> "${LOG_FILE}"
 

--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -81,6 +81,13 @@ print_info "Checking OS version..."
   printf "\n"
 } >> "${LOG_FILE}"
 
+print_info "Checking hardware information..."
+{
+  echo "Hardware information"
+  grep -E "Hardware|Revision|Model" /proc/cpuinfo | sed -r "s/\s+//1"
+  printf "\n"
+} >> "${LOG_FILE}"
+
 echo "TinyPilot state" >> "${LOG_FILE}"
 
 print_info "Checking if filesystem is read-only..."


### PR DESCRIPTION
Resolves #1220 by capturing the board hardware, revision and model in the debug log.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1227"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>