### PR TITLE
Add incompatible hardware check to installation script

### DIFF
--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -40,6 +40,13 @@ clean_up() {
 # Always clean up before exiting.
 trap 'clean_up' EXIT
 
+# Prevent installation on the Raspberry Pi 3.
+if grep -q "^Model *: Raspberry Pi 3" /proc/cpuinfo ; then
+  echo 'You are trying to install on incompatible hardware.' >&2
+  echo 'Visit https://github.com/tiny-pilot/tinypilot/ for more details.' >&2
+  exit 1
+fi
+
 # Prevent installation on the 64-bit version of Raspberry Pi OS.
 # https://github.com/tiny-pilot/tinypilot/issues/929
 if [[ "$(uname -m)" == 'aarch64' && "$(lsb_release --id --short)" == 'Debian' ]]; then

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -54,21 +54,11 @@ if [[ "${HAS_PRO_INSTALLED}" = 1 ]]; then
   fi
 fi
 
-if ! grep -q "4 Model B\|Zero 2 W" /proc/cpuinfo ; then
-  set +u
-  if [[ "${FORCE_ALLOW_INCOMPATIBLE}" = 1 ]]; then
-    echo "Installing on potentially incompatible hardware"
-    set -u
-  else
-    set +x
-    printf "You are trying to install on potentially incompatible hardware.\n\n"
-    printf "Visit https://github.com/tiny-pilot/tinypilot/ for more details.\n"
-    printf "\n"
-    printf "If you want to install anyway type the following:\n\n"
-    printf "  export FORCE_ALLOW_INCOMPATIBLE=1\n\n"
-    printf "And then run your previous command again.\n"
-    exit 255
-  fi
+if grep -q "Raspberry Pi 3" /proc/cpuinfo ; then
+  set +x
+  printf "You are trying to install on incompatible hardware.\n\n"
+  printf "Visit https://github.com/tiny-pilot/tinypilot/ for more details.\n"
+  exit 255
 fi
 
 # HACK: If we let mktemp use the default /tmp directory, the system purges the

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -54,6 +54,23 @@ if [[ "${HAS_PRO_INSTALLED}" = 1 ]]; then
   fi
 fi
 
+if ! grep -q "4 Model B\|Zero 2 W" /proc/cpuinfo ; then
+  set +u
+  if [[ "${FORCE_ALLOW_INCOMPATIBLE}" = 1 ]]; then
+    echo "Installing on potentially incompatible hardware"
+    set -u
+  else
+    set +x
+    printf "You are trying to install on potentially incompatible hardware.\n\n"
+    printf "Visit https://github.com/tiny-pilot/tinypilot/ for more details.\n"
+    printf "\n"
+    printf "If you want to install anyway type the following:\n\n"
+    printf "  export FORCE_ALLOW_INCOMPATIBLE=1\n\n"
+    printf "And then run your previous command again.\n"
+    exit 255
+  fi
+fi
+
 # HACK: If we let mktemp use the default /tmp directory, the system purges the
 # file before the end of the script for some reason. We use /var/tmp as a
 # workaround.

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -54,13 +54,6 @@ if [[ "${HAS_PRO_INSTALLED}" = 1 ]]; then
   fi
 fi
 
-if grep -q "Raspberry Pi 3" /proc/cpuinfo ; then
-  set +x
-  printf "You are trying to install on incompatible hardware.\n\n"
-  printf "Visit https://github.com/tiny-pilot/tinypilot/ for more details.\n"
-  exit 255
-fi
-
 # HACK: If we let mktemp use the default /tmp directory, the system purges the
 # file before the end of the script for some reason. We use /var/tmp as a
 # workaround.


### PR DESCRIPTION
Resolves #1221 by adding a step to check for incompatible hardware to the installation script.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1230"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>