### PR TITLE
Accept multiple WebRTC media stream tracks (i.e., video & audio)

### DIFF
--- a/app/static/js/webrtc-video.js
+++ b/app/static/js/webrtc-video.js
@@ -179,13 +179,7 @@ function attachToJanusPlugin() {
         return;
       }
 
-      // According to the examples/tests in the Janus repository, the track
-      // object is supposed to be cloned:
-      // https://github.com/meetecho/janus-gateway/blob/4110eea4568926dc18642a544718c87118629253/html/streamingtest.js#L249-L250
-      // That way, the track is assigned a new and globally unique id. This
-      // helps to avoid potential interferences with other JS code that might
-      // also deal with media tracks.
-      remoteScreen.enableWebrtc(track.clone());
+      remoteScreen.enableWebrtc(track);
     },
   });
 }

--- a/app/static/js/webrtc-video.js
+++ b/app/static/js/webrtc-video.js
@@ -98,7 +98,9 @@ function attachToJanusPlugin() {
       // Note, that the plugin will automatically start streaming when it
       // receives this request, so it’s technically not required to issue
       // another `start` request afterwards. (See below.)
-      janusPluginHandle.send({ message: { request: "watch" } });
+      janusPluginHandle.send({
+        message: { request: "watch", params: { audio: true } },
+      });
     },
 
     /**
@@ -123,7 +125,9 @@ function attachToJanusPlugin() {
         msg.error_code === 503 &&
         watchRequestRetryExpiryTimestamp > Date.now()
       ) {
-        janusPluginHandle.send({ message: { request: "watch" } });
+        janusPluginHandle.send({
+          message: { request: "watch", params: { audio: true } },
+        });
         return;
       }
       if (!jsep) {

--- a/app/static/js/webrtc-video.js
+++ b/app/static/js/webrtc-video.js
@@ -166,7 +166,9 @@ function attachToJanusPlugin() {
      * @param {boolean} added Whether the track was added or removed.
      */
     onremotetrack: function (track, mid, added) {
-      console.debug(`Remote track changed. mid:"${mid}" added:"${added}"`);
+      console.debug(
+        `Remote ${track.kind} track ${mid} ${added ? "added" : "removed"}.`
+      );
 
       if (!added) {
         remoteScreen.enableMjpeg();
@@ -179,9 +181,7 @@ function attachToJanusPlugin() {
       // That way, the track is assigned a new and globally unique id. This
       // helps to avoid potential interferences with other JS code that might
       // also deal with media tracks.
-      const stream = new MediaStream();
-      stream.addTrack(track.clone());
-      remoteScreen.enableWebrtc(stream);
+      remoteScreen.enableWebrtc(track.clone());
     },
   });
 }

--- a/app/static/js/webrtc-video.js
+++ b/app/static/js/webrtc-video.js
@@ -171,7 +171,7 @@ function attachToJanusPlugin() {
      */
     onremotetrack: function (track, mid, added) {
       console.debug(
-        `Remote ${track.kind} track ${mid} ${added ? "added" : "removed"}.`
+        `Remote ${track.kind} track "${mid}" ${added ? "added" : "removed"}.`
       );
 
       if (!added) {

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -324,13 +324,26 @@
          */
         enableWebrtc(mediaStreamTrack) {
           const modeChanged = this.elements.video.srcObject === null;
-          if (modeChanged) {
-            this.elements.video.srcObject = new MediaStream();
+          const stream = modeChanged
+            ? new MediaStream()
+            : this.elements.video.srcObject;
+          // Ensure that the stream doesn't contain multiple tracks of the same
+          // kind (i.e., multiple audio or video tracks).
+          // For example, if an additional new video track is being added, first
+          // remove the old video track.
+          for (const track of stream.getTracks()) {
+            if (
+              track.kind === mediaStreamTrack.kind &&
+              track.id !== mediaStreamTrack.id
+            ) {
+              stream.removeTrack(track);
+            }
           }
           // Note: If the specified track is already in the stream's track set,
           // the addTrack method has no effect.
           // https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/addTrack
-          this.elements.video.srcObject.addTrack(mediaStreamTrack);
+          stream.addTrack(mediaStreamTrack);
+          this.elements.video.srcObject = stream;
           this.webrtcEnabled = true;
           this.elements.image.removeAttribute("src");
           if (modeChanged) {

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -320,13 +320,22 @@
 
         /**
          * Enable the WebRTC stream while disabling the MJPEG stream.
-         * @param {MediaStream} mediaStream https://developer.mozilla.org/en-US/docs/Web/API/MediaStream
+         * @param {MediaStreamTrack} mediaStreamTrack https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack
          */
-        enableWebrtc(mediaStream) {
-          this.elements.video.srcObject = mediaStream;
+        enableWebrtc(mediaStreamTrack) {
+          let modeChanged = this.elements.video.srcObject === null;
+          if (modeChanged) {
+            this.elements.video.srcObject = new MediaStream();
+          }
+          // Note: If the specified track is already in the stream's track set,
+          // the addTrack method has no effect.
+          // https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/addTrack
+          this.elements.video.srcObject.addTrack(mediaStreamTrack);
           this.webrtcEnabled = true;
           this.elements.image.removeAttribute("src");
-          this.dispatchEvent(new VideoStreamingModeChangedEvent("H264"));
+          if (modeChanged) {
+            this.dispatchEvent(new VideoStreamingModeChangedEvent("H264"));
+          }
         }
 
         /**

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -323,7 +323,7 @@
          * @param {MediaStreamTrack} mediaStreamTrack https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack
          */
         enableWebrtc(mediaStreamTrack) {
-          let modeChanged = this.elements.video.srcObject === null;
+          const modeChanged = this.elements.video.srcObject === null;
           if (modeChanged) {
             this.elements.video.srcObject = new MediaStream();
           }


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1191

This PR alters our WebRTC client to accept multiple media stream tracks (i.e., video & audio) and adds them to a single media stream played by our `<video>` element.

### Notes

1. When it comes to switching between MJPEG and WebRTC, I tried to keep the `remote-screen` API more or less the same:
https://github.com/tiny-pilot/tinypilot/blob/465be33957912f5e1fb5e1445d9f148aaf2ce61b/app/templates/custom-elements/remote-screen.html#L321-L325
3. I've altered a [debug log](https://github.com/tiny-pilot/tinypilot/blob/465be33957912f5e1fb5e1445d9f148aaf2ce61b/app/static/js/webrtc-video.js#L174) to give more information about the type of media that has been changed.
    Before:
    > Remote track changed. mid:"0" added:"false"
    > Remote track changed. mid:"0" added:"true"
    > Remote track changed. mid:"1" added:"true"
    
    After:
    > Remote video track 0 removed.
    > Remote video track 0 added.
    > Remote audio track 1 added.
4. I've preemptively set the Janus plugin to enabled audio streaming, even though [optional audio streaming is only available from uStreamer `5.32`](https://github.com/pikvm/ustreamer/commit/9b4f3229f2115714aba7fc590f348a08905b8cef#diff-13064c1fd700eaf3cab601f029e6d1cf1d867a660ebee0b18a7fbf01916cb379R192). For now, it seems like the extra `params` as just ignored:
https://github.com/tiny-pilot/tinypilot/blob/465be33957912f5e1fb5e1445d9f148aaf2ce61b/app/static/js/webrtc-video.js#L101-L103


<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1231"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>