### PR TITLE
Remove check for 64-bit OS

### DIFF
--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -40,14 +40,6 @@ clean_up() {
 # Always clean up before exiting.
 trap 'clean_up' EXIT
 
-# Prevent installation on the 64-bit version of Raspberry Pi OS.
-# https://github.com/tiny-pilot/tinypilot/issues/929
-if [[ "$(uname -m)" == 'aarch64' && "$(lsb_release --id --short)" == 'Debian' ]]; then
-  echo '64-bit Raspberry Pi OS is not yet supported.' >&2
-  echo 'Please use the 32-bit version of Raspberry Pi OS.' >&2
-  exit 1
-fi
-
 # Check if there's already a settings file with extra installation settings.
 if [[ -f "${TINYPILOT_SETTINGS_FILE}" ]]; then
   echo "Using settings file at: ${TINYPILOT_SETTINGS_FILE}"


### PR DESCRIPTION
A user reported successful installation on 64-bit Raspbian Bullseye, so we no longer need to block install on aarch64 systems.

Reference: https://github.com/tiny-pilot/tinypilot/issues/929#issuecomment-1358011310
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1238"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>