### PR TITLE
Specify requirement for 32-bit Raspbian

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See ["TinyPilot: Build a KVM Over IP for Under \$100"](https://mtlynch.io/tinypi
 
 ## Pre-requisites
 
-- Raspberry Pi OS Stretch or later
+- Raspberry Pi OS Buster or later (32-bit)
 - python3-venv
 
 ## Simple installation


### PR DESCRIPTION
Update the documentation to clarify that we only support 32-bit Raspbian on Buster or later. Previously, it said we support Raspbian Stretch, but that OS is no longer maintained or available, and we haven't tested on Stretch in a long time.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1239"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>