### PR TITLE
Create tinypilot user and group in Debian package

### DIFF
--- a/debian-pkg/Dockerfile
+++ b/debian-pkg/Dockerfile
@@ -50,7 +50,7 @@ Build-Depends: debhelper (>= 11)
 
 Package: ${PKG_NAME}
 Architecture: ${PKG_ARCH}
-Depends: python3, python3-pip, python3-venv, sudo
+Depends: adduser, python3, python3-pip, python3-venv, sudo
 Homepage: https://tinypilotkvm.com
 Description: Simple, easy-to-use KVM over IP
 XBS-Tinypilot-Version: ${TINYPILOT_VERSION}

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -19,13 +19,12 @@ getent group "${TINYPILOT_GROUP}" > /dev/null || \
     --system \
     "${TINYPILOT_GROUP}"
 
-# Create tinypilot  user if it doesn't already exist.
-getent passwd "${TINYPILOT_USER}" > /dev/null || \
-  adduser \
-    --system \
-    --group "${TINYPILOT_GROUP}" \
-    --home "${TINYPILOT_HOME_DIR}" \
-    "${TINYPILOT_USER}"
+# adduser is idempotent, so we don't need to check existence first.
+adduser \
+  --system \
+  --ingroup "${TINYPILOT_GROUP}" \
+  --home "${TINYPILOT_HOME_DIR}" \
+  "${TINYPILOT_USER}"
 
 chown -R "${TINYPILOT_USER}:${TINYPILOT_GROUP}" /opt/tinypilot
 

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -6,6 +6,9 @@ set -e
 # Exit on unset variable.
 set -u
 
+# Echo commands to stdout.
+set -x
+
 readonly TINYPILOT_USER="tinypilot"
 readonly TINYPILOT_GROUP="tinypilot"
 readonly TINYPILOT_HOME_DIR="/home/${TINYPILOT_USER}"

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -11,13 +11,13 @@ readonly TINYPILOT_GROUP="tinypilot"
 readonly TINYPILOT_HOME_DIR="/home/${TINYPILOT_USER}"
 
 # Create tinypilot group if it doesn't already exist.
-getent group "${TINYPILOT_GROUP}" || \
+getent group "${TINYPILOT_GROUP}" > /dev/null || \
   addgroup \
     --system \
     "${TINYPILOT_GROUP}"
 
 # Create tinypilot  user if it doesn't already exist.
-getent passwd "${TINYPILOT_USER}" || \
+getent passwd "${TINYPILOT_USER}" > /dev/null || \
   adduser \
     --system \
     --group "${TINYPILOT_GROUP}" \

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -3,6 +3,23 @@
 # Exit script on first failure.
 set -e
 
-chown -R tinypilot:tinypilot /opt/tinypilot
+# Exit on unset variable.
+set -u
+
+readonly TINYPILOT_USER="tinypilot"
+readonly TINYPILOT_GROUP="tinypilot"
+readonly TINYPILOT_HOME_DIR="/home/${TINYPILOT_USER}"
+
+addgroup \
+  --system \
+  "${TINYPILOT_GROUP}"
+
+adduser \
+  --system \
+  --group "${TINYPILOT_GROUP}" \
+  --home "${TINYPILOT_HOME_DIR}" \
+  "${TINYPILOT_USER}"
+
+chown -R "${TINYPILOT_USER}:${TINYPILOT_GROUP}" /opt/tinypilot
 
 #DEBHELPER#

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -10,16 +10,19 @@ readonly TINYPILOT_USER="tinypilot"
 readonly TINYPILOT_GROUP="tinypilot"
 readonly TINYPILOT_HOME_DIR="/home/${TINYPILOT_USER}"
 
-# Note that we can't use the --system flag. We've always installed the group
-# without applying the --system flag, so to start now will cause conflicts
-# during update for existing installations.
-addgroup "${TINYPILOT_GROUP}"
+# Create tinypilot group if it doesn't already exist.
+getent group "${TINYPILOT_GROUP}" || \
+  addgroup \
+    --system \
+    "${TINYPILOT_GROUP}"
 
-adduser \
-  --system \
-  --group "${TINYPILOT_GROUP}" \
-  --home "${TINYPILOT_HOME_DIR}" \
-  "${TINYPILOT_USER}"
+# Create tinypilot  user if it doesn't already exist.
+getent passwd "${TINYPILOT_USER}" || \
+  adduser \
+    --system \
+    --group "${TINYPILOT_GROUP}" \
+    --home "${TINYPILOT_HOME_DIR}" \
+    "${TINYPILOT_USER}"
 
 chown -R "${TINYPILOT_USER}:${TINYPILOT_GROUP}" /opt/tinypilot
 

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -6,9 +6,6 @@ set -e
 # Exit on unset variable.
 set -u
 
-# Echo commands to stdout.
-set -x
-
 readonly TINYPILOT_USER="tinypilot"
 readonly TINYPILOT_GROUP="tinypilot"
 readonly TINYPILOT_HOME_DIR="/home/${TINYPILOT_USER}"

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -10,9 +10,10 @@ readonly TINYPILOT_USER="tinypilot"
 readonly TINYPILOT_GROUP="tinypilot"
 readonly TINYPILOT_HOME_DIR="/home/${TINYPILOT_USER}"
 
-addgroup \
-  --system \
-  "${TINYPILOT_GROUP}"
+# Note that we can't use the --system flag. We've always installed the group
+# without applying the --system flag, so to start now will cause conflicts
+# during update for existing installations.
+addgroup "${TINYPILOT_GROUP}"
 
 adduser \
   --system \


### PR DESCRIPTION
We've been relying on the Ansible role to create the tinypilot user and group, but as we're chipping away Ansible logic, it seemed like a good opportunity to implement this logic in the Debian package instead.

I'm following the guidance here:

https://wiki.debian.org/AccountHandlingInMaintainerScripts

I considered adding the `--disabled-login` flag, but it [doesn't seem to be documented well](https://unix.stackexchange.com/a/96897/152974), and it's not something we had before, so I'm just leaving it out.

Corresponding change in Ansible: https://github.com/tiny-pilot/ansible-role-tinypilot/pull/252

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1240"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>