### PR TITLE
Add a convenience script for installing TinyPilot bundles

### DIFF
--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -71,8 +71,7 @@ fi
 
 readonly INSTALLER_DIR='/opt/tinypilot-updater'
 
-# Extract tarball to installer directory. The installer directory and all its
-# content must have root ownership.
+# Extract tarball to installer directory.
 rm -rf "${INSTALLER_DIR}"
 mkdir -p "${INSTALLER_DIR}"
 tar \

--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -22,7 +22,7 @@ set -e
 if [[ "${EUID}" -ne 0 ]]; then
   echo "This script requires root privileges." >&2
   echo "Please re-run with sudo:" >&2
-  echo "  sudo $0 $@" >&2
+  echo "  sudo $0 $*" >&2
   exit 1
 fi
 

--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -48,8 +48,8 @@ while getopts 'h' opt; do
   esac
 done
 
-# Ensure 'new_hostname' is given.
-shift $((OPTIND - 1))
+# Ensure 'bundle_path' is given.
+shift "$((OPTIND - 1))"
 if (( $# == 0 )); then
   echo 'Input parameter missing: bundle_path' >&2
   exit 1
@@ -60,7 +60,7 @@ set -x
 
 readonly BUNDLE_PATH="$1"
 
-if [[ $BUNDLE_PATH == http* ]]; then
+if [[ "${BUNDLE_PATH}" == http* ]]; then
   cd "$(mktemp --directory)"
   wget "${BUNDLE_PATH}"
   BUNDLE_FILE_PATH="${PWD}/$(find . -name '*.tgz')"

--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -51,7 +51,7 @@ done
 # Ensure 'new_hostname' is given.
 shift $((OPTIND - 1))
 if (( $# == 0 )); then
-  echo 'Input parameter missing: new_hostname' >&2
+  echo 'Input parameter missing: bundle_path' >&2
   exit 1
 fi
 

--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# Install TinyPilot from a TinyPilot bundle tarball.
+#
+# Examples:
+#  sudo install-bundle /tmp/tinypilot-community-20230103T1619Z-1.8.0-74+7623988.tgz
+#  sudo install-bundle https://example.com/tinypilot-community-20230103T1619Z-1.8.0-74+7623988.tgz
+#
+# This script is only for development, though unlike other dev scripts, it
+# installs on the device. Regular users should use the get-tinypilot.sh or
+# get-tinypilot-pro.sh scripts.
+#
+# get-tinypilot.sh and get-tinypilot-pro.sh do not use this script because they
+# can't rely on it being available locally at install time.
+
+# Exit on unset variable.
+set -u
+
+# Exit on first error.
+set -e
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "This script requires root privileges." >&2
+  echo "Please re-run with sudo:" >&2
+  echo "  sudo $0 $@" >&2
+  exit 1
+fi
+
+print_help() {
+  cat << EOF
+Usage: ${0##*/} [-h] bundle_path
+Install the specified TinyPilot bundle on the system.
+  bundle_path: Local filesystem path or URL to TinyPilot bundle.
+  -h Display this help and exit.
+EOF
+}
+
+# Parse command-line arguments.
+while getopts 'h' opt; do
+  case "${opt}" in
+    h)
+      print_help
+      exit
+      ;;
+    *)
+      print_help >&2
+      exit 1
+  esac
+done
+
+# Ensure 'new_hostname' is given.
+shift $((OPTIND - 1))
+if (( $# == 0 )); then
+  echo 'Input parameter missing: new_hostname' >&2
+  exit 1
+fi
+
+# Echo commands to stdout.
+set -x
+
+readonly BUNDLE_PATH="$1"
+
+if [[ $BUNDLE_PATH == http* ]]; then
+  cd "$(mktemp --directory)"
+  wget "${BUNDLE_PATH}"
+  BUNDLE_FILE_PATH="${PWD}/$(find . -name '*.tgz')"
+  readonly BUNDLE_FILE_PATH
+else
+  readonly BUNDLE_FILE_PATH="${BUNDLE_PATH}"
+fi
+
+readonly INSTALLER_DIR='/opt/tinypilot-updater'
+
+# Extract tarball to installer directory. The installer directory and all its
+# content must have root ownership.
+rm -rf "${INSTALLER_DIR}"
+mkdir -p "${INSTALLER_DIR}"
+tar \
+  --gunzip \
+  --extract \
+  --file "${BUNDLE_FILE_PATH}" \
+  --directory "${INSTALLER_DIR}"
+
+# Run install.
+pushd "${INSTALLER_DIR}"
+./install


### PR DESCRIPTION
Now that we're storing the TinyPilot bundle as a CI artifact (3c4193bb41748d58ce43cd6535bd52b11d1fccd9), I've found that a convenient way to test changes on a real device is to make a git branch, make changes, push to Github, grab the bundle from CI, and then install the bundle on the device.

This change adds a convenience script to make the process of installing a pre-release bundle easier.

There are a few ugly spots in this change:

The first is that we're shipping a dev-only script as part of normal device install. We can't keep this script in dev-scripts because that's excluded from a TinyPilot install. If we really wanted to keep things tidy, we could keep this in dev-scripts and require the developer to git clone the repo to get this script onto the device, but I think the benefits of having the script available outweight the drawbacks of installing a dev-only script.

The second drawback is that it duplicates code from get-tinypilot.sh/get-tinypilot-pro.sh. Those scripts can't call install-bundle because they can't make any assumptions about what's present on the system at install time. Again, I think this is worth the tradeoff.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1246"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>