### PR TITLE
Verify working directory in create-bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
           command: sudo apt-get update && sudo apt-get install -y git
       - run:
           name: Create the bundle
-          command: cd bundler && ./create-bundle
+          command: ./create-bundle
       - store_artifacts:
           path: bundler/dist/
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
           command: sudo apt-get update && sudo apt-get install -y git
       - run:
           name: Create the bundle
-          command: ./create-bundle
+          command: ./bundler/create-bundle
       - store_artifacts:
           path: bundler/dist/
       - persist_to_workspace:

--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -19,10 +19,10 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 readonly SCRIPT_DIR
 cd "${SCRIPT_DIR}/.."
 
+cd ./bundler
+
 readonly ANSIBLE_ROLE_TINYPILOT_REPO='https://github.com/tiny-pilot/ansible-role-tinypilot'
 readonly ANSIBLE_ROLE_TINYPILOT_VERSION='master'
-
-cd ./bundler
 
 readonly BUNDLE_DIR='bundle'
 readonly OUTPUT_DIR='dist'

--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -14,8 +14,15 @@ set -u
 # Echo commands to stdout.
 set -x
 
+# Change directory to repository root.
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+readonly SCRIPT_DIR
+cd "${SCRIPT_DIR}/.."
+
 readonly ANSIBLE_ROLE_TINYPILOT_REPO='https://github.com/tiny-pilot/ansible-role-tinypilot'
 readonly ANSIBLE_ROLE_TINYPILOT_VERSION='master'
+
+cd ./bundler
 
 readonly BUNDLE_DIR='bundle'
 readonly OUTPUT_DIR='dist'


### PR DESCRIPTION
create-bundle implicitly assumes that the current working directory is the ./bundler directory. This is error-prone, as our other TinyPilot scripts that depend on working directories set the directory themselves.

This change makes create-bundle take responsibility for setting the working directory properly so that callers can execute the script regardless of external working directory.

Our directory traversal is a little odd because we effectively find the script's parent directory, then go up a directory, then go back to the same directory, but I think it's easier to do it that way so that our bash snippet for finding the repo root is the same across scripts.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1247"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>