### PR TITLE
Modify install script to fail if the read-only filesystem is enabled

### DIFF
--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -47,6 +47,14 @@ if grep -q "^Model *: Raspberry Pi 3" /proc/cpuinfo ; then
   exit 1
 fi
 
+# Abort installation if the read-only filesystem is enabled
+if grep -q "boot=overlay" /proc/cmdline ; then
+  echo 'The read-only filesystem is enabled.' >&2
+  echo 'Disable the read-only filesystem before proceeding.' >&2
+  echo 'See https://tinypilotkvm.com/faq/read-only-filesystem for details.' >&2
+  exit 1
+fi
+
 # Check if there's already a settings file with extra installation settings.
 if [[ -f "${TINYPILOT_SETTINGS_FILE}" ]]; then
   echo "Using settings file at: ${TINYPILOT_SETTINGS_FILE}"


### PR DESCRIPTION
Resolves #1243 by modifying the install script to fail if the read-only filesystem is enabled.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1250"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>