### PR TITLE
Backport `video_service` module from TinyPilot-Pro.

### DIFF
--- a/app/video_service.py
+++ b/app/video_service.py
@@ -1,0 +1,53 @@
+import logging
+import subprocess
+
+import flask
+
+logger = logging.getLogger(__name__)
+
+
+def restart():
+    """Restarts the video streaming services for the remote screen.
+
+    It only triggers the restart, but it doesn’t actually wait for it to
+    complete.
+    """
+    _restart_ustreamer()
+    if flask.current_app.config.get('USE_WEBRTC_REMOTE_SCREEN', False):
+        _restart_janus()
+
+
+def _restart_ustreamer():
+    """Restarts uStreamer in a best-effort manner.
+
+    In case the restart invocation failed, it ignores (but logs) the error.
+    """
+    logger.info('Triggering ustreamer restart...')
+    try:
+        subprocess.check_output(
+            ['sudo', '/usr/sbin/service', 'ustreamer', 'restart'],
+            stderr=subprocess.STDOUT,
+            universal_newlines=True)
+    except subprocess.CalledProcessError as e:
+        logger.error('Failed to restart ustreamer: %s', e)
+        return
+
+    logger.info('Successfully restarted ustreamer')
+
+
+def _restart_janus():
+    """Restarts Janus in a best-effort manner.
+
+    In case the restart invocation failed, it ignores (but logs) the error.
+    """
+    logger.info('Triggering janus restart...')
+    try:
+        subprocess.check_output(
+            ['sudo', '/usr/sbin/service', 'janus', 'restart'],
+            stderr=subprocess.STDOUT,
+            universal_newlines=True)
+    except subprocess.CalledProcessError as e:
+        logger.error('Failed to restart janus: %s', e)
+        return
+
+    logger.info('Successfully restarted janus')


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot/issues/1249

This PR contains an exact copy of https://github.com/tiny-pilot/tinypilot-pro/blob/bc0707716f01fc3c5291ec2c320eb44daa97bb41/app/video_service.py

Thanks to our [uStreamer launcher script](https://github.com/tiny-pilot/ansible-role-ustreamer/pull/89), we now dynamically determine the correct uStreamer command-line options each time the systemd `ustreamer` service is started. That means we no longer need to run an ansible playbook to apply the video settings sitting in `/home/tinypilot/settings.yml`. Instead, we can just restart `ustreamer.service` to redetermine the correct video options.

Seeing as we already have a `video_service` module in TinyPilot Pro that restarts uStreamer & Janus, I thought it would be a good idea to backport `video_service.py` to TinyPilot Community.

### Notes

1. I noticed that we're still referencing a [legacy environment variable: `USE_WEBRTC_REMOTE_SCREEN`](https://github.com/tiny-pilot/tinypilot-pro/blob/bc0707716f01fc3c5291ec2c320eb44daa97bb41/app/video_service.py#L16). I've fixed it in a [follow-up PR](https://github.com/tiny-pilot/tinypilot/pull/1255).

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1251"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>