### PR TITLE
Remove reference to legacy `USE_WEBRTC_REMOTE_SCREEN` variable.

### DIFF
--- a/app/video_service.py
+++ b/app/video_service.py
@@ -1,0 +1,53 @@
+import logging
+import subprocess
+
+import flask
+
+logger = logging.getLogger(__name__)
+
+
+def restart():
+    """Restarts the video streaming services for the remote screen.
+
+    It only triggers the restart, but it doesn’t actually wait for it to
+    complete.
+    """
+    _restart_ustreamer()
+    if flask.current_app.config.get('USE_WEBRTC_REMOTE_SCREEN', False):
+        _restart_janus()
+
+
+def _restart_ustreamer():
+    """Restarts uStreamer in a best-effort manner.
+
+    In case the restart invocation failed, it ignores (but logs) the error.
+    """
+    logger.info('Triggering ustreamer restart...')
+    try:
+        subprocess.check_output(
+            ['sudo', '/usr/sbin/service', 'ustreamer', 'restart'],
+            stderr=subprocess.STDOUT,
+            universal_newlines=True)
+    except subprocess.CalledProcessError as e:
+        logger.error('Failed to restart ustreamer: %s', e)
+        return
+
+    logger.info('Successfully restarted ustreamer')
+
+
+def _restart_janus():
+    """Restarts Janus in a best-effort manner.
+
+    In case the restart invocation failed, it ignores (but logs) the error.
+    """
+    logger.info('Triggering janus restart...')
+    try:
+        subprocess.check_output(
+            ['sudo', '/usr/sbin/service', 'janus', 'restart'],
+            stderr=subprocess.STDOUT,
+            universal_newlines=True)
+    except subprocess.CalledProcessError as e:
+        logger.error('Failed to restart janus: %s', e)
+        return
+
+    logger.info('Successfully restarted janus')

--- a/app/video_service.py
+++ b/app/video_service.py
@@ -1,7 +1,7 @@
 import logging
 import subprocess
 
-import flask
+import db.settings
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +13,9 @@ def restart():
     complete.
     """
     _restart_ustreamer()
-    if flask.current_app.config.get('USE_WEBRTC_REMOTE_SCREEN', False):
+    use_webrtc = db.settings.Settings().get_streaming_mode(
+    ) == db.settings.StreamingMode.H264
+    if use_webrtc:
         _restart_janus()
 
 


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot/issues/1249
Depends on https://github.com/tiny-pilot/tinypilot/pull/1251

We no longer use the `USE_WEBRTC_REMOTE_SCREEN` environment variable and instead we [save the current streaming mode to our local database](https://github.com/tiny-pilot/tinypilot/blob/24cb3f91cb8bfba3a71d5e407032e0073a768300/app/db/settings.py#L44-L63).

This PR removes the use of `USE_WEBRTC_REMOTE_SCREEN`.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1255"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>