### PR TITLE
Override dark-mode in style guide

### DIFF
--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -11,6 +11,12 @@
     @import "css/icons.css";
     @import "css/toggle.css";
 
+    body {
+      /* Override to prevent dark-mode, otherwise we would need to make several
+         color adjustments in the styleguide to account for the dark background.
+         That’s not worth the effort, since the styleguide is internal. */
+      background: var(--brand-creme-light) !important;
+    }
     main {
       margin: 1rem auto;
       width: 40rem;


### PR DESCRIPTION
With dark-mode turned on, the style guide is not really useable. The easiest is to override (and thus ignore) dark-mode in the style guide and force it to be light-mode. Otherwise, we would have to adjust the default text color, plus several background and border colors, to make all elements work with the dark background.

<img width="939" alt="Screenshot 2023-01-11 at 17 34 16" src="https://user-images.githubusercontent.com/83721279/211863551-f94c6ae6-6270-4065-81fd-715af99b4c1a.png">
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1257"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>