### PR TITLE
Specify /bin/bash as the tinypilot user's shell

### DIFF
--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -8,9 +8,6 @@ set -u
 
 readonly TINYPILOT_USER="tinypilot"
 readonly TINYPILOT_GROUP="tinypilot"
-# We have to specify a shell so that we can still execute commands as tinypilot
-# with "sudo su".
-readonly TINYPILOT_SHELL="/bin/bash"
 readonly TINYPILOT_HOME_DIR="/home/${TINYPILOT_USER}"
 readonly TINYPILOT_SETTINGS_FILE="${TINYPILOT_HOME_DIR}/settings.yml"
 readonly USTREAMER_CONFIG_FILE="/opt/ustreamer-launcher/configs.d/100-tinypilot.yml"
@@ -24,7 +21,9 @@ getent group "${TINYPILOT_GROUP}" > /dev/null || \
 # adduser is idempotent, so we don't need to check existence first.
 adduser \
   --system \
-  --shell "${TINYPILOT_SHELL}" \
+  `# We have to specify a shell to override the default /usr/sbin/nologin, ` \
+  `# which prevents us from executing commands through "sudo su".` \
+  --shell /bin/bash \
   --ingroup "${TINYPILOT_GROUP}" \
   --home "${TINYPILOT_HOME_DIR}" \
   "${TINYPILOT_USER}"

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -8,6 +8,9 @@ set -u
 
 readonly TINYPILOT_USER="tinypilot"
 readonly TINYPILOT_GROUP="tinypilot"
+# We have to specify a shell so that we can still execute commands as tinypilot
+# with "sudo su".
+readonly TINYPILOT_SHELL="/bin/bash"
 readonly TINYPILOT_HOME_DIR="/home/${TINYPILOT_USER}"
 readonly TINYPILOT_SETTINGS_FILE="${TINYPILOT_HOME_DIR}/settings.yml"
 readonly USTREAMER_CONFIG_FILE="/opt/ustreamer-launcher/configs.d/100-tinypilot.yml"
@@ -21,6 +24,7 @@ getent group "${TINYPILOT_GROUP}" > /dev/null || \
 # adduser is idempotent, so we don't need to check existence first.
 adduser \
   --system \
+  --shell "${TINYPILOT_SHELL}" \
   --ingroup "${TINYPILOT_GROUP}" \
   --home "${TINYPILOT_HOME_DIR}" \
   "${TINYPILOT_USER}"


### PR DESCRIPTION
Without a shell specified, the user defaults to /usr/sbin/nologin, which prevents us from executing commands as the tinypilot user through sudo su.

I tested this on a clean install of Raspbian Buster Lite, and it fixes the `sudo su` issue.

Fixes #1260

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1261"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>