### PR TITLE
Remove all `tc358743`-related defaults from bundle installer

### DIFF
--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -84,6 +84,8 @@ fi
 # If this system does not use a TC358743 capture chip, assume defaults for a
 # MacroSilicon MS2109-based HDMI-to-USB capture dongle. The TC358743 defaults
 # are provided in the uStreamer Ansible role.
+# TODO: we might be able to remove these defaults from here.
+# See https://github.com/tiny-pilot/tinypilot/issues/1267
 if ! "${USE_TC358743_DEFAULTS}"; then
   yaml_set_if_undefined "${INSTALL_SETTINGS_FILE}" "ustreamer_encoder" "hw"
   yaml_set_if_undefined "${INSTALL_SETTINGS_FILE}" "ustreamer_format" "jpeg"


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1110.

In order to establish Bullseye compatibility, we can’t write the encoder parameter into the `settings.yml` file anymore, because Bullseye needs `m2m-image` and not `omx`.

It’s safe for us to remove *all* TC358743-related parameters in one go, not just `ustreamer_encoder`. The only reason why we originally added these YAML settings to the install script (and to the `settings.yml` file) was for the now-retired `update-video-settings` privileged script, which ran a part of the uStreamer Ansible role under the hood. (See https://github.com/tiny-pilot/tinypilot/pull/657, and https://github.com/tiny-pilot/tinypilot/issues/1267 for more context.) The uStreamer role already has [all the defaults for TC358743 on it’s own](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/490b8b46c06b1fb613c07e2d6e8bf5a315cf619c/tasks/provision_tc358743.yml#L61L74).

I still left the non TC358743-related settings in place and created (and referenced) [a follow-up refactoring ticket](https://github.com/tiny-pilot/tinypilot/issues/1267). That let’s us move forward with the Bullseye migration, and we can dedicate time at a later point for a full clean-up and also the necessary testing on Community-hardware.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1268"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>