### PR TITLE
Check that /opt/tinypilot exists before cleanup in prerm script

### DIFF
--- a/debian-pkg/debian/tinypilot.prerm
+++ b/debian-pkg/debian/tinypilot.prerm
@@ -3,15 +3,17 @@
 # Exit script on first failure.
 set -e
 
-cd /opt/tinypilot
-rm -rf venv
-find . \
-  -type f \
-  -name "*.pyc" \
-  -delete \
-  -or \
-  -type d \
-  -name __pycache__ \
-  -delete
+if [[ -d /opt/tinypilot ]] ; then
+  cd /opt/tinypilot
+  rm -rf venv
+  find . \
+    -type f \
+    -name "*.pyc" \
+    -delete \
+    -or \
+    -type d \
+    -name __pycache__ \
+    -delete
+fi
 
 #DEBHELPER#


### PR DESCRIPTION
Resolves #1264 by checking if `/opt/tinypilot` exists before proceeding with cleanup in `prerm` script.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1272"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>