### PR TITLE
Log whether SSH access is enabled in debug logs

### DIFF
--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -100,6 +100,16 @@ print_info "Checking if filesystem is read-only..."
   echo "Read-only filesystem: ${READ_ONLY_FILESYSTEM}"
 } >> "${LOG_FILE}"
 
+print_info "Checking if SSH is enabled..."
+{
+  SSH_STATUS="disabled"
+  if systemctl is-active --quiet ssh ; then
+    SSH_STATUS="enabled"
+  fi
+  readonly SSH_STATUS
+  echo "SSH access: ${SSH_STATUS}"
+} >> "${LOG_FILE}"
+
 print_info "Checking temperature..."
 printf "%s\n" "$(vcgencmd measure_temp)" >> "${LOG_FILE}"
 

--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -103,7 +103,7 @@ print_info "Checking if filesystem is read-only..."
 print_info "Checking if SSH is enabled..."
 {
   SSH_STATUS="disabled"
-  if systemctl is-active --quiet ssh ; then
+  if /opt/tinypilot/scripts/is-ssh-enabled ; then
     SSH_STATUS="enabled"
   fi
   readonly SSH_STATUS

--- a/scripts/is-ssh-enabled
+++ b/scripts/is-ssh-enabled
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Test if SSH is enabled.
+
+# Exit on unset variable.
+set -u
+
+# Exit on first error.
+set -e
+
+print_help() {
+  cat << EOF
+Usage: ${0##*/} [-h]
+Returns an exit code of 0 if SSH is enabled and 255 if SSH is disabled.
+  -h Display this help and exit.
+EOF
+}
+
+# Parse command-line arguments.
+while getopts 'h' opt; do
+  case "${opt}" in
+    h)
+      print_help
+      exit
+      ;;
+    *)
+      print_help >&2
+      exit 1
+  esac
+done
+
+if systemctl is-active --quiet ssh ; then
+  exit 0
+fi
+
+exit 255


### PR DESCRIPTION
Resolves #1273 by adding a step that checks if SSH is enabled.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1274"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>