### PR TITLE
Only display the WebRTC stream when is has a video track.

### DIFF
--- a/app/static/js/webrtc-video.js
+++ b/app/static/js/webrtc-video.js
@@ -175,9 +175,9 @@ function attachToJanusPlugin() {
       );
 
       if (added) {
-        remoteScreen.addWebrtcStreamTrack(track);
+        remoteScreen.enableWebrtcStreamTrack(track);
       } else {
-        remoteScreen.removeWebrtcStreamTrack(track);
+        remoteScreen.disableWebrtcStreamTrack(track);
       }
     },
   });

--- a/app/static/js/webrtc-video.js
+++ b/app/static/js/webrtc-video.js
@@ -174,12 +174,11 @@ function attachToJanusPlugin() {
         `Remote ${track.kind} track "${mid}" ${added ? "added" : "removed"}.`
       );
 
-      if (!added) {
-        remoteScreen.enableMjpeg();
-        return;
+      if (added) {
+        remoteScreen.addWebrtcStreamTrack(track);
+      } else {
+        remoteScreen.removeWebrtcStreamTrack(track);
       }
-
-      remoteScreen.enableWebrtc(track);
     },
   });
 }

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -137,6 +137,19 @@
             image: this.shadowRoot.getElementById("mjpeg-output"),
           };
 
+          // Initialize the WebRTC media stream.
+          this.elements.video.srcObject = new MediaStream();
+
+          // Display the WebRTC stream when the WebRTC media starts playing.
+          this.elements.video.addEventListener("playing", (event) => {
+            this.enableWebrtc();
+          });
+
+          // Display the MJPEG stream when the WebRTC media is paused.
+          this.elements.video.addEventListener("pause", (event) => {
+            this.enableMjpeg();
+          });
+
           this._addScreenEventListeners(this.elements.video);
           this._addScreenEventListeners(this.elements.image);
 
@@ -319,14 +332,12 @@
         }
 
         /**
-         * Enable the WebRTC stream while disabling the MJPEG stream.
+         * Adds a track to the WebRTC media stream.
          * @param {MediaStreamTrack} mediaStreamTrack https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack
          */
-        enableWebrtc(mediaStreamTrack) {
-          const modeChanged = this.elements.video.srcObject === null;
-          const stream = modeChanged
-            ? new MediaStream()
-            : this.elements.video.srcObject;
+        addWebrtcStreamTrack(mediaStreamTrack) {
+          const video = this.elements.video;
+          const stream = video.srcObject;
           // Ensure that the stream doesn't contain multiple tracks of the same
           // kind (i.e., multiple audio or video tracks).
           // For example, if an additional new video track is being added, first
@@ -343,21 +354,39 @@
           // the addTrack method has no effect.
           // https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/addTrack
           stream.addTrack(mediaStreamTrack);
-          this.elements.video.srcObject = stream;
-          this.webrtcEnabled = true;
-          this.elements.image.removeAttribute("src");
-          if (modeChanged) {
-            this.dispatchEvent(new VideoStreamingModeChangedEvent("H264"));
+          if (video.paused) {
+            video.play();
           }
         }
 
         /**
-         * Enable the MJPEG stream while disabling the WebRTC stream.
+         * Removes a track from the WebRTC media stream.
+         * @param {MediaStreamTrack} mediaStreamTrack https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack
+         */
+        removeWebrtcStreamTrack(mediaStreamTrack) {
+          const video = this.elements.video;
+          const stream = video.srcObject;
+          stream.removeTrack(mediaStreamTrack);
+          if (stream.getTracks().length === 0) {
+            video.pause();
+          }
+        }
+
+        /**
+         * Displays the WebRTC stream while hiding the MJPEG stream.
+         */
+        enableWebrtc() {
+          this.webrtcEnabled = true;
+          this.elements.image.removeAttribute("src");
+          this.dispatchEvent(new VideoStreamingModeChangedEvent("H264"));
+        }
+
+        /**
+         * Displays the MJPEG stream while hiding the WebRTC stream.
          */
         enableMjpeg() {
           this.elements.image.src = "/stream?advance_headers=1";
           this.webrtcEnabled = false;
-          this.elements.video.srcObject = null;
           this.dispatchEvent(new VideoStreamingModeChangedEvent("MJPEG"));
         }
 

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -385,6 +385,9 @@
          * Displays the MJPEG stream while hiding the WebRTC stream.
          */
         enableMjpeg() {
+          if (this.elements.image.hasAttribute("src")) {
+            return;
+          }
           this.elements.image.src = "/stream?advance_headers=1";
           this.webrtcEnabled = false;
           this.dispatchEvent(new VideoStreamingModeChangedEvent("MJPEG"));

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -374,9 +374,11 @@
           const video = this.elements.video;
           const stream = video.srcObject;
           stream.removeTrack(mediaStreamTrack);
-          if (stream.getTracks().length === 0) {
-            // Once there are no more tracks left in the stream, we pause the
-            // WebRTC media and display the MJPEG stream.
+          if (stream.getVideoTracks().length === 0) {
+            // Once there are no more video tracks left in the stream, we pause
+            // the WebRTC media and display the MJPEG stream. However, if there
+            // are no more audio tracks left in the stream, we stay in H.264
+            // mode because it's still better than MJPEG mode.
             video.pause();
             this.enableMjpeg();
           }

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -68,7 +68,7 @@
     <input id="mobile-keyboard-input" autocapitalize="off" type="text" />
 
     <img class="screen" id="mjpeg-output" />
-    <video class="screen" id="webrtc-output" autoplay playsinline muted></video>
+    <video class="screen" id="webrtc-output" playsinline muted></video>
   </div>
 </template>
 
@@ -139,19 +139,6 @@
 
           // Initialize the WebRTC media stream.
           this.elements.video.srcObject = new MediaStream();
-
-          // Display the WebRTC stream when the WebRTC media starts playing.
-          // Note: the media can either start playing automatically via the
-          // video element's `autoplay` attribute or explicitly when we call the
-          // `play` method.
-          this.elements.video.addEventListener("playing", (event) => {
-            this._enableWebrtc();
-          });
-
-          // Display the MJPEG stream when the WebRTC media is paused.
-          this.elements.video.addEventListener("pause", (event) => {
-            this.enableMjpeg();
-          });
 
           this._addScreenEventListeners(this.elements.video);
           this._addScreenEventListeners(this.elements.image);
@@ -363,14 +350,17 @@
           // the addTrack method has no effect.
           // https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/addTrack
           stream.addTrack(mediaStreamTrack);
-          if (video.paused) {
-            // We always attempt to play the media because only when the media
-            // starts playing do we know that the WebRTC stream is ready to be
-            // displayed.
-            video.play().catch((error) => {
+          // We always attempt to play the media because only when the media
+          // starts playing do we know that the WebRTC stream is ready to be
+          // displayed.
+          video
+            .play()
+            .then(() => {
+              this._enableWebrtc();
+            })
+            .catch((error) => {
               console.error("Failed to play WebRTC media: " + error);
             });
-          }
         }
 
         /**
@@ -386,8 +376,9 @@
           stream.removeTrack(mediaStreamTrack);
           if (stream.getTracks().length === 0) {
             // Once there are no more tracks left in the stream, we pause the
-            // media to indicate that the WebRTC stream should be hidden.
+            // WebRTC media and display the MJPEG stream.
             video.pause();
+            this.enableMjpeg();
           }
         }
 

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -335,10 +335,16 @@
         }
 
         /**
-         * Adds a track to the WebRTC media stream.
+         * Adds a track to the WebRTC media stream and attempts to display the
+         * WebRTC stream, while hiding the MJPEG stream.
+         *
+         * The WebRTC stream may silently fail to display if the browser hasn't
+         * been granted permission to play media. If so, the MJPEG stream will
+         * continue to be displayed.
+         *
          * @param {MediaStreamTrack} mediaStreamTrack https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack
          */
-        addWebrtcStreamTrack(mediaStreamTrack) {
+        enableWebrtcStreamTrack(mediaStreamTrack) {
           const video = this.elements.video;
           const stream = video.srcObject;
           // Ensure that the stream doesn't contain multiple tracks of the same
@@ -368,14 +374,19 @@
         }
 
         /**
-         * Removes a track from the WebRTC media stream.
+         * Removes a track from the WebRTC media stream. If there are no more
+         * tracks in the stream, the MJPEG stream is displayed and the WebRTC
+         * stream is hidden.
+         *
          * @param {MediaStreamTrack} mediaStreamTrack https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack
          */
-        removeWebrtcStreamTrack(mediaStreamTrack) {
+        disableWebrtcStreamTrack(mediaStreamTrack) {
           const video = this.elements.video;
           const stream = video.srcObject;
           stream.removeTrack(mediaStreamTrack);
           if (stream.getTracks().length === 0) {
+            // Once there are no more tracks left in the stream, we pause the
+            // media to indicate that the WebRTC stream should be hidden.
             video.pause();
           }
         }

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -141,6 +141,9 @@
           this.elements.video.srcObject = new MediaStream();
 
           // Display the WebRTC stream when the WebRTC media starts playing.
+          // Note: the media can either start playing automatically via the
+          // video element's `autoplay` attribute or explicitly when we call the
+          // `play` method.
           this.elements.video.addEventListener("playing", (event) => {
             this.enableWebrtc();
           });
@@ -355,6 +358,9 @@
           // https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/addTrack
           stream.addTrack(mediaStreamTrack);
           if (video.paused) {
+            // We always attempt to play the media because only when the media
+            // starts playing do we know that the WebRTC stream is ready to be
+            // displayed.
             video.play().catch((error) => {
               console.error("Failed play WebRTC media: " + error);
             });

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -368,7 +368,7 @@
             // starts playing do we know that the WebRTC stream is ready to be
             // displayed.
             video.play().catch((error) => {
-              console.error("Failed play WebRTC media: " + error);
+              console.error("Failed to play WebRTC media: " + error);
             });
           }
         }

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -322,8 +322,10 @@
         }
 
         /**
-         * Adds a track to the WebRTC media stream and attempts to display the
-         * WebRTC stream, while hiding the MJPEG stream.
+         * Adds a track to the WebRTC media stream. If there any video tracks in
+         * the stream, the WebRTC stream is displayed and the MJPEG stream is
+         * hidden. However, if there are only audio tracks in the stream, the
+         * MJPEG stream will continue to be displayed.
          *
          * The WebRTC stream may silently fail to display if the browser hasn't
          * been granted permission to play media. If so, the MJPEG stream will
@@ -351,8 +353,6 @@
           // https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/addTrack
           stream.addTrack(mediaStreamTrack);
           if (stream.getVideoTracks().length === 0) {
-            // Don't display the WebRTC stream if there are no video tracks.
-            // https://github.com/tiny-pilot/tinypilot/issues/1271
             return;
           }
           // We always attempt to play the media because only when the media
@@ -370,8 +370,10 @@
 
         /**
          * Removes a track from the WebRTC media stream. If there are no more
-         * tracks in the stream, the MJPEG stream is displayed and the WebRTC
-         * stream is hidden.
+         * video tracks in the stream, the MJPEG stream is displayed and the
+         * WebRTC stream is hidden. However, if there are no more audio tracks
+         * in the stream, the WebRTC stream will continue to be displayed
+         * because it's still better than the MJPEG stream.
          *
          * @param {MediaStreamTrack} mediaStreamTrack https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack
          */
@@ -380,11 +382,6 @@
           const stream = video.srcObject;
           stream.removeTrack(mediaStreamTrack);
           if (stream.getVideoTracks().length === 0) {
-            // Once there are no more video tracks left in the stream, we pause
-            // the WebRTC media and display the MJPEG stream. However, if there
-            // are no more audio tracks left in the stream, we stay in H.264
-            // mode because it's still better than MJPEG mode.
-            // https://github.com/tiny-pilot/tinypilot/issues/1271
             video.pause();
             this.enableMjpeg();
           }

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -350,6 +350,11 @@
           // the addTrack method has no effect.
           // https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/addTrack
           stream.addTrack(mediaStreamTrack);
+          if (stream.getVideoTracks().length === 0) {
+            // Don't display the WebRTC stream if there are no video tracks.
+            // https://github.com/tiny-pilot/tinypilot/issues/1271
+            return;
+          }
           // We always attempt to play the media because only when the media
           // starts playing do we know that the WebRTC stream is ready to be
           // displayed.
@@ -379,6 +384,7 @@
             // the WebRTC media and display the MJPEG stream. However, if there
             // are no more audio tracks left in the stream, we stay in H.264
             // mode because it's still better than MJPEG mode.
+            // https://github.com/tiny-pilot/tinypilot/issues/1271
             video.pause();
             this.enableMjpeg();
           }

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -355,7 +355,9 @@
           // https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/addTrack
           stream.addTrack(mediaStreamTrack);
           if (video.paused) {
-            video.play();
+            video.play().catch((error) => {
+              console.error("Failed play WebRTC media: " + error);
+            });
           }
         }
 

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -145,7 +145,7 @@
           // video element's `autoplay` attribute or explicitly when we call the
           // `play` method.
           this.elements.video.addEventListener("playing", (event) => {
-            this.enableWebrtc();
+            this._enableWebrtc();
           });
 
           // Display the MJPEG stream when the WebRTC media is paused.
@@ -394,7 +394,7 @@
         /**
          * Displays the WebRTC stream while hiding the MJPEG stream.
          */
-        enableWebrtc() {
+        _enableWebrtc() {
           this.webrtcEnabled = true;
           this.elements.image.removeAttribute("src");
           this.dispatchEvent(new VideoStreamingModeChangedEvent("H264"));


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1271

When adding/removing a track from the media stream, only display the WebRTC stream when it has at least one video track. 

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1275"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>