### PR TITLE
Add step to print settings.yml in debug logs

### DIFF
--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -113,6 +113,13 @@ print_info "Checking for voltage issues..."
   printf "\n"
 } >> "${LOG_FILE}"
 
+print_info "Checking TinyPilot settings..."
+{
+  printf "TinyPilot settings.yml\n"
+  cat /home/tinypilot/settings.yml
+  printf "\n"
+} >> "${LOG_FILE}"
+
 print_info "Checking TinyPilot configuration..."
 {
   printf "TinyPilot configuration\n"


### PR DESCRIPTION
Resolves #1280 by adding a step to the `collect-debug-logs` script that prints out the contents of `/home/tinypilot/settings.yml`.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1281"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>