### PR TITLE
Copy contents of `ansible-role-tinypilot` repo into `ansible-role` directory.

### DIFF
--- a/ansible-role/.circleci/config.yml
+++ b/ansible-role/.circleci/config.yml
@@ -1,0 +1,80 @@
+version: 2.1
+jobs:
+  check_whitespace:
+    docker:
+      - image: cimg/base:2020.01
+    steps:
+      - checkout
+      - run:
+          name: Check for trailing whitespace
+          command: tests/check-trailing-whitespace
+      - run:
+          name: Check that all text files end in a trailing newline
+          command: tests/check-trailing-newline
+  check_bash:
+    docker:
+      - image: koalaman/shellcheck-alpine:v0.7.1
+    steps:
+      - run:
+          name: Install dependencies
+          command: apk add bash git grep openssh
+      - checkout
+      - run:
+          name: Run static analysis on bash scripts
+          command: ./tests/check-bash
+  build_debian_package:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: Clone TinyPilot core repo
+          command: git clone https://github.com/tiny-pilot/tinypilot.git .
+      - setup_remote_docker:
+          version: 20.10.11
+      - run:
+          name: Build Debian package
+          command: ./dev-scripts/build-debian-pkg
+      - persist_to_workspace:
+          root: ./debian-pkg/releases
+          paths:
+            - "*.deb"
+  build:
+    machine:
+      image: ubuntu-2004:202010-01
+    resource_class: large
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./debian-pkgs
+      - run:
+          name: Give TinyPilot Debian package a predictable filename
+          command: mv debian-pkgs/tinypilot*.deb debian-pkgs/tinypilot_latest_all.deb
+      - run:
+          name: Create symlink to role
+          command: |
+            mkdir -p "${HOME}/.ansible/roles" && \
+            ln -s "${HOME}/project" "${HOME}/.ansible/roles/ansible-role-tinypilot"
+      - run:
+          name: Create Python3 virtual environment
+          command: python3 -m venv venv
+      - run:
+          name: Test role with molecule
+          command: |
+            . venv/bin/activate && \
+            pip install --upgrade pip && \
+            pip install wheel==0.34.2 && \
+            pip install -r molecule/requirements.txt && \
+            ansible --version && \
+            molecule --version && \
+            ansible-galaxy install --role-file meta/requirements.yml && \
+            molecule test
+workflows:
+  version: 2
+  all-tests:
+    jobs:
+      - check_whitespace
+      - check_bash
+      - build_debian_package
+      - build:
+          requires:
+            - build_debian_package

--- a/ansible-role/.github/workflows/merge-pro.yml
+++ b/ansible-role/.github/workflows/merge-pro.yml
@@ -1,0 +1,35 @@
+name: Merge community changes into pro repo
+on:
+  push:
+    branches:
+      - master
+jobs:
+  updateFork:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: tiny-pilot/ansible-role-tinypilot-pro
+          token: ${{ secrets.PR_BOT_PAT }}
+      - name: Reset the default branch with upstream changes
+        run: |
+          git remote add upstream https://github.com/tiny-pilot/ansible-role-tinypilot.git
+          git fetch upstream master:upstream-master
+          git reset --hard upstream-master
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.PR_BOT_PAT }}
+          branch: community-changes-${{ github.sha }}
+          delete-branch: true
+          # If the committer to the community repo (github.actor) has no access
+          # to the pro repo, the PR will be unassigned.
+          assignees: ${{ github.actor }}
+          title: Merge changes from community repository
+          body: |
+            Merge the last changes from community repository :
+
+            https://github.com/tiny-pilot/ansible-role-tinypilot/commit/${{ github.sha }}
+
+            **Do not use "Squash and merge" !**
+            Merge this PR with a merge commit, keeping the commit history.

--- a/ansible-role/.gitignore
+++ b/ansible-role/.gitignore
@@ -1,0 +1,2 @@
+debian-pkgs
+venv

--- a/ansible-role/.shellcheckrc
+++ b/ansible-role/.shellcheckrc
@@ -1,0 +1,3 @@
+# Stop shellcheck from complaining about references to files that don't
+# exist. They'll exist in a production environment, so these flags are noise.
+disable=SC1091

--- a/ansible-role/.yamllint
+++ b/ansible-role/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/ansible-role/LICENSE
+++ b/ansible-role/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Michael Lynch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ansible-role/README.md
+++ b/ansible-role/README.md
@@ -10,7 +10,7 @@ Ansible role for [TinyPilot KVM](https://github.com/tiny-pilot/tinypilot).
 Available variables are listed below, along with default values (see [defaults/main.yml](defaults/main.yml)):
 
 ```yaml
-tinypilot_interface: '127.0.0.1'
+tinypilot_interface: "127.0.0.1"
 tinypilot_port: 8000
 tinypilot_keyboard_interface: /dev/hidg0
 # The client is responsible for specifying the path/URL to the TinyPilot Debian
@@ -20,8 +20,8 @@ tinypilot_debian_package_path: null
 
 ## Dependencies
 
-* [tiny-pilot.ustreamer](https://github.com/tiny-pilot/ansible-role-ustreamer)
-* [tiny-pilot.nginx](https://github.com/tiny-pilot/ansible-role-nginx)
+- [tiny-pilot.ustreamer](https://github.com/tiny-pilot/ansible-role-ustreamer)
+- [tiny-pilot.nginx](https://github.com/tiny-pilot/ansible-role-nginx)
 
 ## Example Playbook
 

--- a/ansible-role/README.md
+++ b/ansible-role/README.md
@@ -1,0 +1,69 @@
+# Ansible Role: TinyPilot
+
+[![CircleCI](https://circleci.com/gh/tiny-pilot/ansible-role-tinypilot.svg?style=svg)](https://circleci.com/gh/tiny-pilot/ansible-role-tinypilot)
+[![License](http://img.shields.io/:license-mit-blue.svg?style=flat-square)](LICENSE)
+
+Ansible role for [TinyPilot KVM](https://github.com/tiny-pilot/tinypilot).
+
+## Role Variables
+
+Available variables are listed below, along with default values (see [defaults/main.yml](defaults/main.yml)):
+
+```yaml
+tinypilot_interface: '127.0.0.1'
+tinypilot_port: 8000
+tinypilot_keyboard_interface: /dev/hidg0
+# The client is responsible for specifying the path/URL to the TinyPilot Debian
+# package
+tinypilot_debian_package_path: null
+```
+
+## Dependencies
+
+* [tiny-pilot.ustreamer](https://github.com/tiny-pilot/ansible-role-ustreamer)
+* [tiny-pilot.nginx](https://github.com/tiny-pilot/ansible-role-nginx)
+
+## Example Playbook
+
+## Building a TinyPilot Debian package
+
+To install TinyPilot using the Ansible role, you need to provide the role with a path or URL to a TinyPilot Debian package.
+
+To build a TinyPilot Debian package, run the following snippet:
+
+```bash
+cd $(mktemp -d) && \
+  git clone https://github.com/tiny-pilot/tinypilot.git . && \
+  ./dev-scripts/build-debian-pkg
+```
+
+This will produce a TinyPilot Debian package under `./debian-pkg/releases`.
+
+### `example.yml`
+
+```yaml
+- hosts: all
+  roles:
+    - role: ansible-role-tinypilot
+      vars:
+        tinypilot_debian_package_path: /path/to/tinypilot.deb
+```
+
+### Running Example Playbook
+
+```bash
+ansible-galaxy install git+https://github.com/tiny-pilot/ansible-role-tinypilot.git
+ansible-playbook example.yml
+```
+
+## Documentation
+
+- [Introduction to the USB gadget driver](docs/usb-gadget-driver.md)
+
+## License
+
+MIT
+
+## Author Information
+
+This role was created in 2020 by [Michael Lynch](http://mtlynch.io).

--- a/ansible-role/defaults/main.yml
+++ b/ansible-role/defaults/main.yml
@@ -5,7 +5,7 @@ tinypilot_debian_package_path: null
 # Port on which TinyPilot frontend listens (accessible from other hosts on the
 # network).
 tinypilot_external_port: 80
-tinypilot_interface: '127.0.0.1'
+tinypilot_interface: "127.0.0.1"
 # Port on which TinyPilot's backend listens (accessible only from
 # tinypilot_interface).
 tinypilot_port: 8000

--- a/ansible-role/defaults/main.yml
+++ b/ansible-role/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+# Specifies the filesystem path or URL of a Debian package that installs
+# TinyPilot.
+tinypilot_debian_package_path: null
+# Port on which TinyPilot frontend listens (accessible from other hosts on the
+# network).
+tinypilot_external_port: 80
+tinypilot_interface: '127.0.0.1'
+# Port on which TinyPilot's backend listens (accessible only from
+# tinypilot_interface).
+tinypilot_port: 8000
+tinypilot_keyboard_interface: /dev/hidg0
+tinypilot_mouse_interface: /dev/hidg1
+tinypilot_enable_debug_logging: no
+tinypilot_pip_args: ""
+tinypilot_app_settings_file: "/home/{{ tinypilot_user }}/app_settings.cfg"
+
+# uStreamer version to use on systems prior to Raspbian Bullseye (Debian 11).
+ustreamer_repo_version_legacy: v4.13
+# uStreamer version to use on Raspbian Bullseye (Debian 11) or later systems.
+ustreamer_repo_version_modern: v5.34

--- a/ansible-role/docs/usb-gadget-driver.md
+++ b/ansible-role/docs/usb-gadget-driver.md
@@ -1,0 +1,56 @@
+# USB Gadget Driver and `configfs`
+
+We use `configfs` for configuring the USB gadget driver. Since `configfs` can feel unintuitive to work with, here is a quick overview of how it works, and what some of its quirks are.
+
+See also the Linux kernel documentation:
+
+- [General `configfs` overview](https://www.kernel.org/doc/Documentation/filesystems/configfs/configfs.txt)
+- [USB gadget driver](https://www.kernel.org/doc/Documentation/usb/gadget_configfs.txt)
+- [Reference of available parameters and possible values](https://www.kernel.org/doc/Documentation/ABI/testing/)
+
+## Introduction
+
+`configfs` is a virtual file system provided by the Linux kernel. It is mounted underneath `/sys/kernel/config/`. The file system does not map to a persistent disk, though, but the entire structure is held in memory.
+
+The basic idea behind `configfs` is to interact with kernel functionality via file system APIs. So the file and directory entries in `configfs` are like a facade that’s directly wrapped around regular operating system APIs. Making changes to `configfs` files or folders is equivalent to making function calls (to system APIs), rather than merely persisting values on disk.
+
+Examples for possible operations:
+
+```bash
+# Set up config for a USB mouse.
+mkdir -p functions/hid.mouse
+
+# Make mass storage behave like a CD-ROM drive.
+echo 1 > functions/mass_storage.0/lun.0/cdrom
+```
+
+## Internal folder structure
+
+The `configfs` files and folders must be in line with a specific, predefined structure.
+
+- `/sys/kernel/config/usb_gadget/`: Contains a sub-folder per gadget configuration.
+  - `g1/`: We have a single gadget registered right now, which is identified by `g1`. Among other items, this folder contains:
+    - `UDC`: While the gadget is activated, this contains the name of the USB device controller (hence the acronym). If the gadget is deactivated, this file is empty. That means, the active-state of the gadget can be controlled through the value in this file.
+    - `functions/`: Contains the actual configurations for the USB interface features. Creating a sub-folder (e.g. `hid.mouse` for the USB mouse) will automatically set up the internal file structure of that new folder. These functions need to be symlinked from the `configs/c.1` folder, otherwise they won’t have any effect. Example items:
+      - `hid.mouse/`: USB mouse config
+      - `hid.keyboard/`: USB keyboard config
+      - `mass_storage.0`: USB mass storage config
+    - `configs/`: This folder contains the complete and authoritative configurations for the USB gadget. There could be multiple ones, but we only use one right now, which is identified by `c.1`.
+      - `c.1/`: Among others:
+        - `strings/`: Device info, like the serial number or the manufacturer name.
+        - `hid.mouse/`: Example of a symlink to the `functions/hid.mouse` folder. It only allows a symlink here, you can’t create the configuration in place.
+
+## Behaviour
+
+The `configfs` virtual file system does **not** behave like a regular disk file system in many ways. Some examples:
+
+- You cannot create arbitrary files or folders, or rename them, but you can only create items at predefined places with predefined names.
+- When writing parameters into files, it might require the values to be in a certain format (i.e., the parameters are essentially validated at write-time).
+- Changes are effectuated immediately and synchronously, just as if you had made calls to the respective system API directly, e.g. via C functions. Unlike with other file-based configurations, you don’t have to restart any service or such.
+- Sometimes, operations must be carried out in a specific order that depends on internal logic rather than on conventional file system rules. E.g., when writing parameters into existing files, it might only work if that’s done in a specific order.
+- When creating a new `functions/` sub-folder, the kernel automatically and immediately sets up a content structure of files and sub-folders. As mentioned above, that structure is fixed and can’t be changed.
+- Folders can only be deleted via `rmdir`, not via `rm -rf`. That’s even true if the folder isn’t empty, in which case `rmdir` would usually fail.
+- `functions/` folders can only be deleted when they are **not** referenced by a symlink from the `configs/c.1/` folder, otherwise the deletion attempt fails.
+- Symlinks have special meaning, and creating or deleting them might have side-effects. Also, `configfs` items cannot be symlinked from outside the virtual file system.
+- Some operations can only be carried out while the gadget is deactivated, or they only take effect after re-activating the gadget.
+- Configuration changes that are made while the gadget is active might silently fail, i.e. they could leave the entire gadget in an inconsistent or broken state, despite the command itself returning exit code `0`. Therefore, it’s important to be mindful of potential failure cases.

--- a/ansible-role/files/init-usb-gadget
+++ b/ansible-role/files/init-usb-gadget
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+# Configures USB gadgets, see: docs/usb-gadget-driver.md
+
+# Exit on first error.
+set -e
+
+# Echo commands to stdout.
+set -x
+
+# Treat undefined environment variables as errors.
+set -u
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+# shellcheck source=lib/usb-gadget.sh
+source "${SCRIPT_DIR}/lib/usb-gadget.sh"
+
+print_help() {
+  cat << EOF
+Usage: ${0##*/} [-h]
+Init USB gadget.
+  -h Display this help and exit.
+EOF
+}
+
+# Parse command-line arguments.
+while getopts "h" opt; do
+  case "${opt}" in
+    h)
+      print_help
+      exit
+      ;;
+    *)
+      print_help >&2
+      exit 1
+  esac
+done
+
+modprobe libcomposite
+
+# Adapted from https://github.com/girst/hardpass-sendHID/blob/master/README.md
+
+cd "${USB_GADGET_PATH}"
+mkdir -p "${USB_DEVICE_DIR}"
+cd "${USB_DEVICE_DIR}"
+
+echo 0x1d6b > idVendor  # Linux Foundation
+echo 0x0104 > idProduct # Multifunction Composite Gadget
+echo 0x0100 > bcdDevice # v1.0.0
+echo 0x0200 > bcdUSB    # USB2
+
+mkdir -p "$USB_STRINGS_DIR"
+echo "6b65796d696d6570690" > "${USB_STRINGS_DIR}/serialnumber"
+echo "tinypilot" > "${USB_STRINGS_DIR}/manufacturer"
+echo "Multifunction USB Device" > "${USB_STRINGS_DIR}/product"
+
+# Keyboard
+mkdir -p "$USB_KEYBOARD_FUNCTIONS_DIR"
+echo 1 > "${USB_KEYBOARD_FUNCTIONS_DIR}/protocol" # Keyboard
+echo 1 > "${USB_KEYBOARD_FUNCTIONS_DIR}/subclass" # Boot interface subclass
+echo 8 > "${USB_KEYBOARD_FUNCTIONS_DIR}/report_length"
+# Write the report descriptor
+D=$(mktemp)
+
+{
+  echo -ne \\x05\\x01       # Usage Page (Generic Desktop Ctrls)
+  echo -ne \\x09\\x06       # Usage (Keyboard)
+  echo -ne \\xA1\\x01       # Collection (Application)
+  echo -ne \\x05\\x08       #   Usage Page (LEDs)
+  echo -ne \\x19\\x01       #   Usage Minimum (Num Lock)
+  echo -ne \\x29\\x03       #   Usage Maximum (Scroll Lock)
+  echo -ne \\x15\\x00       #   Logical Minimum (0)
+  echo -ne \\x25\\x01       #   Logical Maximum (1)
+  echo -ne \\x75\\x01       #   Report Size (1)
+  echo -ne \\x95\\x03       #   Report Count (3)
+  echo -ne \\x91\\x02       #   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+  echo -ne \\x09\\x4B       #   Usage (Generic Indicator)
+  echo -ne \\x95\\x01       #   Report Count (1)
+  echo -ne \\x91\\x02       #   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+  echo -ne \\x95\\x04       #   Report Count (4)
+  echo -ne \\x91\\x01       #   Output (Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+  echo -ne \\x05\\x07       #   Usage Page (Kbrd/Keypad)
+  echo -ne \\x19\\xE0       #   Usage Minimum (0xE0)
+  echo -ne \\x29\\xE7       #   Usage Maximum (0xE7)
+  echo -ne \\x95\\x08       #   Report Count (8)
+  echo -ne \\x81\\x02       #   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+  echo -ne \\x75\\x08       #   Report Size (8)
+  echo -ne \\x95\\x01       #   Report Count (1)
+  echo -ne \\x81\\x01       #   Input (Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
+  echo -ne \\x19\\x00       #   Usage Minimum (0x00)
+  echo -ne \\x29\\x91       #   Usage Maximum (0x91)
+  echo -ne \\x26\\xFF\\x00  #   Logical Maximum (255)
+  echo -ne \\x95\\x06       #   Report Count (6)
+  echo -ne \\x81\\x00       #   Input (Data,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
+  echo -ne \\xC0            # End Collection
+} >> "$D"
+cp "$D" "${USB_KEYBOARD_FUNCTIONS_DIR}/report_desc"
+# Enable pre-boot events (if the gadget driver supports it).
+if [[ -f "${USB_KEYBOARD_FUNCTIONS_DIR}/no_out_endpoint" ]]; then
+  echo 1 > "${USB_KEYBOARD_FUNCTIONS_DIR}/no_out_endpoint"
+fi
+
+# Mouse
+mkdir -p "$USB_MOUSE_FUNCTIONS_DIR"
+echo 0 > "${USB_MOUSE_FUNCTIONS_DIR}/protocol"
+echo 0 > "${USB_MOUSE_FUNCTIONS_DIR}/subclass"
+echo 7 > "${USB_MOUSE_FUNCTIONS_DIR}/report_length"
+# Write the report descriptor
+D=$(mktemp)
+{
+echo -ne \\x05\\x01      # USAGE_PAGE (Generic Desktop)
+echo -ne \\x09\\x02      # USAGE (Mouse)
+echo -ne \\xA1\\x01      # COLLECTION (Application)
+                         #   8-buttons
+echo -ne \\x05\\x09      #   USAGE_PAGE (Button)
+echo -ne \\x19\\x01      #   USAGE_MINIMUM (Button 1)
+echo -ne \\x29\\x08      #   USAGE_MAXIMUM (Button 8)
+echo -ne \\x15\\x00      #   LOGICAL_MINIMUM (0)
+echo -ne \\x25\\x01      #   LOGICAL_MAXIMUM (1)
+echo -ne \\x95\\x08      #   REPORT_COUNT (8)
+echo -ne \\x75\\x01      #   REPORT_SIZE (1)
+echo -ne \\x81\\x02      #   INPUT (Data,Var,Abs)
+                         #   x,y absolute coordinates
+echo -ne \\x05\\x01      #   USAGE_PAGE (Generic Desktop)
+echo -ne \\x09\\x30      #   USAGE (X)
+echo -ne \\x09\\x31      #   USAGE (Y)
+echo -ne \\x16\\x00\\x00 #   LOGICAL_MINIMUM (0)
+echo -ne \\x26\\xFF\\x7F #   LOGICAL_MAXIMUM (32767)
+echo -ne \\x75\\x10      #   REPORT_SIZE (16)
+echo -ne \\x95\\x02      #   REPORT_COUNT (2)
+echo -ne \\x81\\x02      #   INPUT (Data,Var,Abs)
+                         #   vertical wheel
+echo -ne \\x09\\x38      #   USAGE (wheel)
+echo -ne \\x15\\x81      #   LOGICAL_MINIMUM (-127)
+echo -ne \\x25\\x7F      #   LOGICAL_MAXIMUM (127)
+echo -ne \\x75\\x08      #   REPORT_SIZE (8)
+echo -ne \\x95\\x01      #   REPORT_COUNT (1)
+echo -ne \\x81\\x06      #   INPUT (Data,Var,Rel)
+                         #   horizontal wheel
+echo -ne \\x05\\x0C      #   USAGE_PAGE (Consumer Devices)
+echo -ne \\x0A\\x38\\x02 #   USAGE (AC Pan)
+echo -ne \\x15\\x81      #   LOGICAL_MINIMUM (-127)
+echo -ne \\x25\\x7F      #   LOGICAL_MAXIMUM (127)
+echo -ne \\x75\\x08      #   REPORT_SIZE (8)
+echo -ne \\x95\\x01      #   REPORT_COUNT (1)
+echo -ne \\x81\\x06      #   INPUT (Data,Var,Rel)
+echo -ne \\xC0           # END_COLLECTION
+} >> "$D"
+cp "$D" "${USB_MOUSE_FUNCTIONS_DIR}/report_desc"
+
+mkdir -p "${USB_CONFIG_DIR}"
+echo 250 > "${USB_CONFIG_DIR}/MaxPower"
+
+CONFIGS_STRINGS_DIR="${USB_CONFIG_DIR}/${USB_STRINGS_DIR}"
+mkdir -p "${CONFIGS_STRINGS_DIR}"
+echo "Config ${USB_CONFIG_INDEX}: ECM network" > "${CONFIGS_STRINGS_DIR}/configuration"
+
+ln -s "${USB_KEYBOARD_FUNCTIONS_DIR}" "${USB_CONFIG_DIR}/"
+ln -s "${USB_MOUSE_FUNCTIONS_DIR}" "${USB_CONFIG_DIR}/"
+
+usb_gadget_activate

--- a/ansible-role/files/lib/usb-gadget.sh
+++ b/ansible-role/files/lib/usb-gadget.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Shared parameters and functionality for the usb gadget.
+# See: docs/usb-gadget-driver.md
+
+export readonly USB_DEVICE_DIR="g1"
+export readonly USB_GADGET_PATH="/sys/kernel/config/usb_gadget"
+export readonly USB_DEVICE_PATH="${USB_GADGET_PATH}/${USB_DEVICE_DIR}"
+
+export readonly USB_STRINGS_DIR="strings/0x409"
+export readonly USB_KEYBOARD_FUNCTIONS_DIR="functions/hid.keyboard"
+export readonly USB_MOUSE_FUNCTIONS_DIR="functions/hid.mouse"
+export readonly USB_MASS_STORAGE_NAME="mass_storage.0"
+export readonly USB_MASS_STORAGE_FUNCTIONS_DIR="functions/${USB_MASS_STORAGE_NAME}"
+
+export readonly USB_CONFIG_INDEX=1
+export readonly USB_CONFIG_DIR="configs/c.${USB_CONFIG_INDEX}"
+export readonly USB_ALL_CONFIGS_DIR="configs/*"
+export readonly USB_ALL_FUNCTIONS_DIR="functions/*"
+
+function usb_gadget_activate {
+  ls /sys/class/udc > "${USB_DEVICE_PATH}/UDC"
+  chmod 777 /dev/hidg0
+  chmod 777 /dev/hidg1
+}
+export -f usb_gadget_activate
+
+function usb_gadget_deactivate {
+  echo '' > "${USB_DEVICE_PATH}/UDC"
+}
+export -f usb_gadget_deactivate

--- a/ansible-role/files/remove-usb-gadget
+++ b/ansible-role/files/remove-usb-gadget
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Tears down USB gadgets, see: docs/usb-gadget-driver.md
+
+# Exit on first error.
+set -e
+
+# Echo commands to stdout.
+set -x
+
+# Treat undefined environment variables as errors.
+set -u
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+# shellcheck source=lib/usb-gadget.sh
+source "${SCRIPT_DIR}/lib/usb-gadget.sh"
+
+cd "${USB_GADGET_PATH}"
+
+if [ ! -d "${USB_DEVICE_DIR}" ]; then
+    echo "Gadget does not exist, quitting."
+    exit 0
+fi
+
+pushd "${USB_DEVICE_DIR}"
+
+# Disable all gadgets
+if [ -n "$(cat UDC)" ]; then
+  echo "" > UDC
+fi
+
+# Walk items in `configs`
+for config in ${USB_ALL_CONFIGS_DIR} ; do
+    # Exit early if there are no entries
+    [ "${config}" == "${USB_ALL_CONFIGS_DIR}" ] && break
+
+    # Remove all functions from config
+    for function in ${USB_ALL_FUNCTIONS_DIR} ; do
+      file="${config}/$(basename "${function}")"
+      [ -e "${file}" ] && rm "${file}"
+    done
+
+    # Remove strings in config
+    [ -d "${config}/${USB_STRINGS_DIR}" ] && rmdir "${config}/${USB_STRINGS_DIR}"
+
+    rmdir "${config}"
+done
+
+# Remove functions
+for function in ${USB_ALL_FUNCTIONS_DIR} ; do
+    [ -d "${function}" ] && rmdir "${function}"
+done
+
+# Remove strings from device
+[ -d "${USB_STRINGS_DIR}" ] && rmdir "${USB_STRINGS_DIR}"
+
+popd
+
+rmdir "${USB_DEVICE_DIR}"

--- a/ansible-role/handlers/main.yml
+++ b/ansible-role/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+- name: reload TinyPilot systemd config
+  systemd:
+    name: tinypilot
+    daemon_reload: yes
+
+- name: restart TinyPilot service
+  service:
+    name: tinypilot
+    state: restarted
+
+- name: start usb-gadget service
+  service:
+    name: usb-gadget
+    state: started

--- a/ansible-role/meta/main.yml
+++ b/ansible-role/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  role_name: tinypilot
+  author: Michael Lynch
+  description: Use your Raspberry Pi as a virtual keyboard
+  license: MIT
+
+  min_ansible_version: 2.10
+
+  platforms:
+    - name: Debian
+      versions:
+        - buster
+    - name: Ubuntu
+      versions:
+        - bionic
+
+  galaxy_tags:
+    - raspberrypi
+    - kvm
+    - usb
+    - hid
+    - oss

--- a/ansible-role/meta/requirements.yml
+++ b/ansible-role/meta/requirements.yml
@@ -1,0 +1,3 @@
+---
+- src: https://github.com/tiny-pilot/ansible-role-ustreamer
+- src: https://github.com/tiny-pilot/ansible-role-nginx

--- a/ansible-role/molecule/default/converge.yml
+++ b/ansible-role/molecule/default/converge.yml
@@ -1,0 +1,22 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: no
+  tasks:
+    - name: Update apt cache and install system dependencies
+      apt:
+        name:
+          # To accurately detect the OS of the target machine, we need to
+          # install the lsb-release package before Ansible gathers facts. This
+          # ensures that the ansible_lsb fact is defined.
+          # https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_conditionals.html#conditionals-based-on-ansible-facts
+          - lsb-release
+        update_cache: true
+        cache_valid_time: 600
+    - name: Gather facts
+      setup:
+    - name: "Include ansible-role-tinypilot"
+      include_role:
+        name: "ansible-role-tinypilot"
+      vars:
+        tinypilot_debian_package_path: /opt/debian-pkgs/tinypilot_latest_all.deb

--- a/ansible-role/molecule/default/molecule.yml
+++ b/ansible-role/molecule/default/molecule.yml
@@ -1,0 +1,42 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: debian10
+    image: geerlingguy/docker-debian10-ansible
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - "${PWD}/debian-pkgs:/opt/debian-pkgs:ro"
+    privileged: true
+    pre_build_image: true
+  - name: debian11
+    image: geerlingguy/docker-debian11-ansible
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - "${PWD}/debian-pkgs:/opt/debian-pkgs:ro"
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  log: true
+  inventory:
+    hosts:
+      all:
+        vars:
+          ansible_user: root
+verifier:
+  name: ansible
+scenario:
+  name: default
+  test_sequence:
+    - lint
+    - destroy
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - destroy

--- a/ansible-role/molecule/requirements.txt
+++ b/ansible-role/molecule/requirements.txt
@@ -1,0 +1,59 @@
+# To update this file:
+#
+#   1. Delete the venv folder
+#   2. Create a fresh venv folder with python3 -m venv venv
+#   3. pip install the direct dependencies
+#   4. Run pip freeze and save any indirect dependencies below
+#   5. Remove dataclasses==0.8 and pkg_resources==0.0.0
+
+# Direct dependencies
+
+ansible==2.10.7
+molecule==3.2.3
+molecule-docker==0.2.4
+
+# Indirect dependencies
+
+ansible-base==2.10.17
+arrow==1.2.2
+bcrypt==3.2.2
+binaryornot==0.4.4
+Cerberus==1.3.4
+certifi==2022.12.7
+cffi==1.15.1
+chardet==5.0.0
+charset-normalizer==2.1.0
+click==7.1.2
+click-completion==0.5.2
+click-help-colors==0.9.1
+commonmark==0.9.1
+cookiecutter==2.1.1
+cryptography==38.0.3
+distro==1.7.0
+docker==5.0.3
+enrich==1.2.7
+idna==3.3
+Jinja2==3.1.2
+jinja2-time==0.2.0
+MarkupSafe==2.1.1
+packaging==21.3
+paramiko==2.11.0
+pathspec==0.9.0
+pluggy==0.13.1
+pycparser==2.21
+Pygments==2.12.0
+PyNaCl==1.5.0
+pyparsing==3.0.9
+python-dateutil==2.8.2
+python-slugify==6.1.2
+PyYAML==5.4.1
+requests==2.28.1
+rich==12.5.1
+selinux==0.2.1
+shellingham==1.5.0
+six==1.16.0
+subprocess-tee==0.3.5
+text-unidecode==1.3
+urllib3==1.26.11
+websocket-client==1.3.3
+yamllint==1.27.1

--- a/ansible-role/tasks/install_usb_gadget.yml
+++ b/ansible-role/tasks/install_usb_gadget.yml
@@ -1,0 +1,120 @@
+---
+- name: set the path to config.txt on non-Ubuntu systems
+  set_fact:
+    config_txt_path: /boot/config.txt
+  when: ansible_distribution != 'Ubuntu'
+
+- name: set the path to config.txt for Ubuntu
+  set_fact:
+    config_txt_path: /boot/firmware/config.txt
+  when: ansible_distribution == 'Ubuntu'
+
+- name: check for a boot config file
+  stat:
+    path: "{{ config_txt_path }}"
+  register: boot_config_stat
+
+- name: enable dwc2 driver in boot config
+  lineinfile:
+    path: "{{ config_txt_path }}"
+    create: no
+    line: dtoverlay=dwc2
+  register: boot_config_lineinfile
+  when: boot_config_stat.stat.exists
+
+- name: check for an /etc/modules file
+  stat:
+    path: /etc/modules
+  register: etc_modules_stat
+
+- name: enable dwc2 driver in modules
+  lineinfile:
+    path: /etc/modules
+    create: no
+    line: dwc2
+  register: modules_lineinfile
+  when: etc_modules_stat.stat.exists
+
+- name: determine if a reboot is required
+  set_fact:
+    reboot_required: >-
+      {{ boot_config_lineinfile.changed or modules_lineinfile.changed }}
+
+- name: create TinyPilot privileged folder
+  file:
+    path: "{{ tinypilot_privileged_dir }}"
+    state: directory
+    owner: "root"
+    group: "root"
+
+- name: copy usb-gadget initializer
+  copy:
+    src: init-usb-gadget
+    dest: "{{ tinypilot_privileged_dir }}/init-usb-gadget"
+    owner: root
+    group: root
+    mode: '0700'
+
+- name: copy usb-gadget de-initializer
+  copy:
+    src: remove-usb-gadget
+    dest: "{{ tinypilot_privileged_dir }}/remove-usb-gadget"
+    owner: root
+    group: root
+    mode: '0700'
+
+- name: install usb-gadget initializer as a service
+  template:
+    src: usb-gadget.systemd.j2
+    dest: /lib/systemd/system/usb-gadget.service
+    owner: root
+    group: root
+    mode: '0644'
+  register: usb_gadget_template
+
+- name: enable systemd usb-gadget initializer service file
+  systemd:
+    name: usb-gadget
+    enabled: yes
+    daemon_reload: "{{ usb_gadget_template.changed }}"
+
+# This custom USB HID kernel module fixes compatibility issues in pre-boot for
+# OS X systems. The patch already exists in kernal versions >= 5.15.
+# Issue: https://github.com/tiny-pilot/ansible-role-tinypilot/issues/151
+- name: check the HID module file
+  ansible.builtin.stat:
+    path: /lib/modules/{{ ansible_kernel }}/kernel/drivers/usb/gadget/function/usb_f_hid.ko
+    checksum_algorithm: sha256
+  register: hid_module_stat
+
+- name: save whether the HID module should be patched
+  set_fact:
+    patch_hid_module: >-
+      {{ ansible_kernel is version('5.15', '<')
+         and ansible_kernel is version('5.10', '>=')
+         and hid_module_stat.stat.checksum is defined
+         and hid_module_stat.stat.checksum != '45f9c885e8b0e1d2fdaf4aec2179a38ad9a1c76c71f44c997c99a865fdfe72d7' }}
+
+- name: ensure HID module is not in use
+  service:
+    name: usb-gadget
+    state: stopped
+  when: patch_hid_module and not reboot_required
+
+- name: unload HID module
+  command: modprobe --remove usb_f_hid
+  when: patch_hid_module and not reboot_required
+
+- name: patch HID module
+  get_url:
+    url: https://github.com/tiny-pilot/hid-backport/raw/master/bin/usb_f_hid.ko
+    dest: "{{ hid_module_stat.stat.path }}"
+    mode: '0644'
+    force: yes
+  when: patch_hid_module
+
+- name: load HID module
+  command: modprobe usb_f_hid
+  when: patch_hid_module and not reboot_required
+  notify:
+    - start usb-gadget service

--- a/ansible-role/tasks/install_usb_gadget.yml
+++ b/ansible-role/tasks/install_usb_gadget.yml
@@ -53,7 +53,7 @@
     dest: "{{ tinypilot_privileged_dir }}/init-usb-gadget"
     owner: root
     group: root
-    mode: '0700'
+    mode: "0700"
 
 - name: copy usb-gadget de-initializer
   copy:
@@ -61,7 +61,7 @@
     dest: "{{ tinypilot_privileged_dir }}/remove-usb-gadget"
     owner: root
     group: root
-    mode: '0700'
+    mode: "0700"
 
 - name: install usb-gadget initializer as a service
   template:
@@ -69,7 +69,7 @@
     dest: /lib/systemd/system/usb-gadget.service
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"
   register: usb_gadget_template
 
 - name: enable systemd usb-gadget initializer service file
@@ -109,7 +109,7 @@
   get_url:
     url: https://github.com/tiny-pilot/hid-backport/raw/master/bin/usb_f_hid.ko
     dest: "{{ hid_module_stat.stat.path }}"
-    mode: '0644'
+    mode: "0644"
     force: yes
   when: patch_hid_module
 

--- a/ansible-role/tasks/main.yml
+++ b/ansible-role/tasks/main.yml
@@ -1,0 +1,77 @@
+---
+- name: install uStreamer
+  import_tasks: ustreamer.yml
+  tags:
+    - ustreamer
+
+- name: install nginx
+  import_tasks: nginx.yml
+
+- name: create the `lib` directory if it does not exist
+  file:
+    path: "{{ tinypilot_privileged_dir }}/lib"
+    state: directory
+
+- name: copy `lib` scripts
+  copy:
+    src: "{{ item }}"
+    dest: "{{ tinypilot_privileged_dir }}/lib/{{ item | basename }}"
+    owner: root
+    group: root
+    mode: '0755'
+  with_fileglob:
+    - lib/*
+
+- name: install HID USB gadget
+  import_tasks: install_usb_gadget.yml
+
+- name: install TinyPilot Debian package
+  apt:
+    deb: "{{ tinypilot_debian_package_path }}"
+
+- name: find absolute path to python3
+  shell: realpath $(which python3)
+  register: realpath_python3
+  changed_when: false
+
+- name: save absolute path to python3
+  set_fact:
+    python3_abs_path: "{{ realpath_python3.stdout }}"
+
+- name: create TinyPilot virtualenv
+  pip:
+    virtualenv: "{{ tinypilot_dir }}/venv"
+    virtualenv_command: "{{ python3_abs_path }} -m venv venv"
+    requirements: "{{ tinypilot_dir }}/requirements.txt"
+    extra_args: "{{ tinypilot_pip_args }}"
+  notify:
+    - restart TinyPilot service
+
+- name: create TinyPilot app settings
+  template:
+    src: tinypilot-app-settings.cfg.j2
+    dest: "{{ tinypilot_app_settings_file }}"
+    owner: "{{ tinypilot_user }}"
+    group: "{{ tinypilot_group }}"
+  notify:
+    - restart TinyPilot service
+  tags:
+    - app-settings
+
+- name: install TinyPilot as a service
+  template:
+    src: tinypilot.systemd.j2
+    dest: /lib/systemd/system/tinypilot.service
+    owner: root
+    group: root
+    mode: '0644'
+  notify:
+    - reload TinyPilot systemd config
+    - restart TinyPilot service
+  tags:
+    - systemd-config
+
+- name: enable systemd TinyPilot service file
+  systemd:
+    name: tinypilot
+    enabled: yes

--- a/ansible-role/tasks/main.yml
+++ b/ansible-role/tasks/main.yml
@@ -18,7 +18,7 @@
     dest: "{{ tinypilot_privileged_dir }}/lib/{{ item | basename }}"
     owner: root
     group: root
-    mode: '0755'
+    mode: "0755"
   with_fileglob:
     - lib/*
 
@@ -64,7 +64,7 @@
     dest: /lib/systemd/system/tinypilot.service
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"
   notify:
     - reload TinyPilot systemd config
     - restart TinyPilot service

--- a/ansible-role/tasks/nginx.yml
+++ b/ansible-role/tasks/nginx.yml
@@ -1,0 +1,84 @@
+---
+- name: import nginx role
+  import_role:
+    name: ansible-role-nginx
+  vars:
+    nginx_upstreams:
+      - name: tinypilot
+        servers:
+          - "{{ tinypilot_interface }}:{{ tinypilot_port }} fail_timeout=1s max_fails=600"
+      - name: ustreamer
+        servers:
+          - "{{ ustreamer_interface }}:{{ ustreamer_port }} fail_timeout=1s max_fails=600"
+      - name: janus-ws
+        # The Janus port and interface are currently not configurable, but they
+        # are set to fixed values by the Janus Debian package.
+        # See: https://github.com/tiny-pilot/janus-debian/issues/5
+        servers:
+          - "127.0.0.1:8002 fail_timeout=1s max_fails=600"
+    nginx_vhosts:
+      - listen: "{{ tinypilot_external_port }} default_server"
+        server_name: "tinypilot"
+        root: "{{ tinypilot_dir }}"
+        index: "index.html"
+        extra_parameters: |
+          proxy_buffers 16 16k;
+          proxy_buffer_size 16k;
+          proxy_set_header Host $host;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_http_version 1.1;
+
+          location /socket.io {
+            proxy_pass http://tinypilot;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            # Since this is a connection upgrade, we don't inherit the settings from
+            # above. We need these so that nginx forwards requests properly to
+            # Flask-SocketIO.
+            # See: https://github.com/miguelgrinberg/Flask-SocketIO/issues/1501#issuecomment-802082048
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
+            proxy_set_header X-Forwarded-Proto $scheme;
+          }
+          location /state {
+            proxy_pass http://ustreamer;
+          }
+          location /stream {
+            postpone_output 0;
+            proxy_buffering off;
+            proxy_ignore_headers X-Accel-Buffering;
+            proxy_pass http://ustreamer;
+          }
+          location /snapshot {
+            proxy_pass http://ustreamer;
+          }
+          location /janus/ws {
+            proxy_pass http://janus-ws;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Scheme $scheme;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Port $server_port;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          }
+          location / {
+            proxy_pass http://tinypilot;
+          }
+          location ~* ^/.+\.(html|js|js.map|css|woff|woff2)$ {
+            root "{{ tinypilot_dir }}/app/static";
+
+            # We cache assets to prevent the browser from making redundant
+            # requests to the same files while loading the page. (Observed on
+            # Chrome 91.) We don’t want caching otherwise, though, in order to
+            # avoid stale files after users update their device. Note, that in
+            # addition to `max-age`, the browser’s caching behaviour is relative
+            # to the `Last-Modified` header, so we make that seem recent.
+            add_header Last-Modified $date_gmt;
+            add_header Cache-Control 'public, max-age=10s';
+          }
+          location ~* ^/.+\.(jpg|jpeg|png|ico)$ {
+            root "{{ tinypilot_dir }}/app/static";
+          }
+    nginx_remove_default_vhost: true

--- a/ansible-role/tasks/ustreamer.yml
+++ b/ansible-role/tasks/ustreamer.yml
@@ -12,7 +12,7 @@
   set_fact:
     ustreamer_repo_version: "{{ ustreamer_repo_version_legacy }}"
   when: (tinypilot_is_os_raspbian or tinypilot_is_os_debian) and
-          ((ansible_distribution_major_version | int) <= 10)
+    ((ansible_distribution_major_version | int) <= 10)
 
 - name: import uStreamer role
   import_role:

--- a/ansible-role/tasks/ustreamer.yml
+++ b/ansible-role/tasks/ustreamer.yml
@@ -1,0 +1,19 @@
+---
+- name: detect OS
+  set_fact:
+    tinypilot_is_os_raspbian: "{{ ansible_lsb.id is defined and ansible_lsb.id == 'Raspbian' }}"
+    tinypilot_is_os_debian: "{{ ansible_lsb.id is defined and ansible_lsb.id == 'Debian' }}"
+
+- name: choose the default version of uStreamer to install
+  set_fact:
+    ustreamer_repo_version: "{{ ustreamer_repo_version_modern }}"
+
+- name: override the target version of uStreamer with a legacy version for compatibility
+  set_fact:
+    ustreamer_repo_version: "{{ ustreamer_repo_version_legacy }}"
+  when: (tinypilot_is_os_raspbian or tinypilot_is_os_debian) and
+          ((ansible_distribution_major_version | int) <= 10)
+
+- name: import uStreamer role
+  import_role:
+    name: ansible-role-ustreamer

--- a/ansible-role/templates/tinypilot-app-settings.cfg.j2
+++ b/ansible-role/templates/tinypilot-app-settings.cfg.j2
@@ -1,0 +1,5 @@
+# This configuration file is an actual Python file. Only variables in uppercase
+# are recognized as config keys.
+
+KEYBOARD_PATH = '{{ tinypilot_keyboard_interface }}'
+MOUSE_PATH = '{{ tinypilot_mouse_interface }}'

--- a/ansible-role/templates/tinypilot.systemd.j2
+++ b/ansible-role/templates/tinypilot.systemd.j2
@@ -1,0 +1,20 @@
+[Unit]
+Description=TinyPilot - RPi-based virtual KVM
+After=syslog.target network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+User={{ tinypilot_user }}
+WorkingDirectory={{ tinypilot_dir }}
+ExecStart={{ tinypilot_dir }}/venv/bin/python app/main.py
+Environment=HOST={{ tinypilot_interface }}
+Environment=PORT={{ tinypilot_port }}
+Environment=APP_SETTINGS_FILE={{ tinypilot_app_settings_file }}
+{% if tinypilot_enable_debug_logging %}
+Environment=DEBUG=1
+{% endif %}
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible-role/templates/usb-gadget.systemd.j2
+++ b/ansible-role/templates/usb-gadget.systemd.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Initialize USB gadgets
+After=syslog.target
+
+[Service]
+Type=oneshot
+User=root
+ExecStart={{ tinypilot_privileged_dir }}/init-usb-gadget
+RemainAfterExit=true
+ExecStop={{ tinypilot_privileged_dir }}/remove-usb-gadget
+StandardOutput=journal
+
+[Install]
+WantedBy=local-fs.target

--- a/ansible-role/tests/check-bash
+++ b/ansible-role/tests/check-bash
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Run static analysis on bash scripts.
+
+# Exit on first failing command.
+set -e
+
+# Exit on unset variable.
+set -u
+
+BASH_SCRIPTS=()
+
+while read -r filepath; do
+  if head -n 1 "${filepath}" | grep --quiet \
+    --regexp '#!/bin/bash' \
+    --regexp '#!/usr/bin/env bash' \
+    --regexp '#!/usr/sh' \
+    --regexp '#!/usr/bin/env sh' \
+    ; then
+      BASH_SCRIPTS+=("${filepath}")
+  fi
+done < <(git ls-files)
+
+readonly BASH_SCRIPTS
+
+shellcheck "${BASH_SCRIPTS[@]}"

--- a/ansible-role/tests/check-trailing-newline
+++ b/ansible-role/tests/check-trailing-newline
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Verify that all text files end in a trailing newline.
+
+# Exit on first failing command.
+set -e
+# Exit on unset variable.
+set -u
+
+FILES=$(find . \
+  -type f \
+  -not -path "./.git/*" \
+  -exec grep \
+  --binary-files=without-match \
+  --quiet \
+  . {} \; -print)
+
+SUCCESS=0
+
+for F in ${FILES[*]}
+do
+  if ! [[ -s "$F" && -z "$(tail -c 1 "$F")" ]]; then
+    printf "File must end in a trailing newline: %s\n" "$F"
+    SUCCESS=-1
+  fi
+done
+
+exit "$SUCCESS"

--- a/ansible-role/tests/check-trailing-whitespace
+++ b/ansible-role/tests/check-trailing-whitespace
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Check for trailing whitespace
+
+# Echo commands to console.
+set -x
+# Exit on first failing command.
+set -e
+# Exit on unset variable.
+set -u
+
+if grep \
+  "\s$" \
+  --extended-regexp \
+  --line-number \
+  --binary-files=without-match \
+  --dereference-recursive \
+  --exclude-dir=.git \
+  ./ ; then
+  echo "ERROR: Found trailing whitespace";
+  exit 1;
+fi

--- a/ansible-role/vars/main.yml
+++ b/ansible-role/vars/main.yml
@@ -1,0 +1,21 @@
+---
+# TinyPilot's get-tinypilot.sh script (which it uses for installation and
+# updates) relies on the tinypilot user being named "tinypilot" so changing this
+# value will break updates.
+tinypilot_user: tinypilot
+tinypilot_group: tinypilot
+
+tinypilot_dir: /opt/tinypilot
+tinypilot_privileged_dir: /opt/tinypilot-privileged
+
+# uStreamer variables are placed here, instead of in `defaults/main.yml`,
+# in order to elevate their variable precedence. These variables will now
+# override the default variables in the uStreamer role.
+ustreamer_interface: '127.0.0.1'
+ustreamer_port: 8001
+ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git
+# Assigning `ustreamer_h264_sink` will make the uStreamer role install the Janus
+# server on the system, and thus enable H264 video streaming.
+ustreamer_h264_sink: tinypilot::ustreamer::h264
+ustreamer_h264_sink_mode: 777
+ustreamer_h264_sink_rm: yes

--- a/ansible-role/vars/main.yml
+++ b/ansible-role/vars/main.yml
@@ -11,7 +11,7 @@ tinypilot_privileged_dir: /opt/tinypilot-privileged
 # uStreamer variables are placed here, instead of in `defaults/main.yml`,
 # in order to elevate their variable precedence. These variables will now
 # override the default variables in the uStreamer role.
-ustreamer_interface: '127.0.0.1'
+ustreamer_interface: "127.0.0.1"
 ustreamer_port: 8001
 ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git
 # Assigning `ustreamer_h264_sink` will make the uStreamer role install the Janus


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot/issues/1174

We have decided consolidate the `ansible-role-tinypilot` repo into the `tinypilot` repo because there's no longer a strong reason to keep the repos separate. Using a single repo would also reduce the git admin that usually comes with developing features that touch both codebases (i.e., pinning repo versions).

This PR simply copies the contents of the [`ansible-role-tinypilot` repo](https://github.com/tiny-pilot/ansible-role-tinypilot/tree/70321141a8f90589962f1ae4069002afad355b7b) into the `ansible-role` directory, with no additional changes. This is a non-functional change.

### Notes

* I've kept the `ansible-role` directory on the top level of this repo to make the code more visible and accessible. An alternative might have been to store it under `bundler/bundle/roles/ansible-role-tinypilot` because [that's where we'll need it during the bundle process](https://github.com/tiny-pilot/tinypilot/blob/f09b26b2042ad97f2d6c699b0610f4d416207281/bundler/verify-bundle#L47-L58).
* The [failing build](https://app.circleci.com/pipelines/github/tiny-pilot/tinypilot/2956/workflows/18ee9efb-1545-45ce-8446-bb21caaa2213/jobs/13672) is fixed in a follow-up PR:
    https://github.com/tiny-pilot/tinypilot/pull/1283


<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1282"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>