### PR TITLE
Fix style in `ansible-role` directory.

### DIFF
--- a/ansible-role/README.md
+++ b/ansible-role/README.md
@@ -10,7 +10,7 @@ Ansible role for [TinyPilot KVM](https://github.com/tiny-pilot/tinypilot).
 Available variables are listed below, along with default values (see [defaults/main.yml](defaults/main.yml)):
 
 ```yaml
-tinypilot_interface: '127.0.0.1'
+tinypilot_interface: "127.0.0.1"
 tinypilot_port: 8000
 tinypilot_keyboard_interface: /dev/hidg0
 # The client is responsible for specifying the path/URL to the TinyPilot Debian
@@ -20,8 +20,8 @@ tinypilot_debian_package_path: null
 
 ## Dependencies
 
-* [tiny-pilot.ustreamer](https://github.com/tiny-pilot/ansible-role-ustreamer)
-* [tiny-pilot.nginx](https://github.com/tiny-pilot/ansible-role-nginx)
+- [tiny-pilot.ustreamer](https://github.com/tiny-pilot/ansible-role-ustreamer)
+- [tiny-pilot.nginx](https://github.com/tiny-pilot/ansible-role-nginx)
 
 ## Example Playbook
 

--- a/ansible-role/defaults/main.yml
+++ b/ansible-role/defaults/main.yml
@@ -5,7 +5,7 @@ tinypilot_debian_package_path: null
 # Port on which TinyPilot frontend listens (accessible from other hosts on the
 # network).
 tinypilot_external_port: 80
-tinypilot_interface: '127.0.0.1'
+tinypilot_interface: "127.0.0.1"
 # Port on which TinyPilot's backend listens (accessible only from
 # tinypilot_interface).
 tinypilot_port: 8000

--- a/ansible-role/tasks/install_usb_gadget.yml
+++ b/ansible-role/tasks/install_usb_gadget.yml
@@ -53,7 +53,7 @@
     dest: "{{ tinypilot_privileged_dir }}/init-usb-gadget"
     owner: root
     group: root
-    mode: '0700'
+    mode: "0700"
 
 - name: copy usb-gadget de-initializer
   copy:
@@ -61,7 +61,7 @@
     dest: "{{ tinypilot_privileged_dir }}/remove-usb-gadget"
     owner: root
     group: root
-    mode: '0700'
+    mode: "0700"
 
 - name: install usb-gadget initializer as a service
   template:
@@ -69,7 +69,7 @@
     dest: /lib/systemd/system/usb-gadget.service
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"
   register: usb_gadget_template
 
 - name: enable systemd usb-gadget initializer service file
@@ -109,7 +109,7 @@
   get_url:
     url: https://github.com/tiny-pilot/hid-backport/raw/master/bin/usb_f_hid.ko
     dest: "{{ hid_module_stat.stat.path }}"
-    mode: '0644'
+    mode: "0644"
     force: yes
   when: patch_hid_module
 

--- a/ansible-role/tasks/main.yml
+++ b/ansible-role/tasks/main.yml
@@ -18,7 +18,7 @@
     dest: "{{ tinypilot_privileged_dir }}/lib/{{ item | basename }}"
     owner: root
     group: root
-    mode: '0755'
+    mode: "0755"
   with_fileglob:
     - lib/*
 
@@ -64,7 +64,7 @@
     dest: /lib/systemd/system/tinypilot.service
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"
   notify:
     - reload TinyPilot systemd config
     - restart TinyPilot service

--- a/ansible-role/tasks/ustreamer.yml
+++ b/ansible-role/tasks/ustreamer.yml
@@ -12,7 +12,7 @@
   set_fact:
     ustreamer_repo_version: "{{ ustreamer_repo_version_legacy }}"
   when: (tinypilot_is_os_raspbian or tinypilot_is_os_debian) and
-          ((ansible_distribution_major_version | int) <= 10)
+    ((ansible_distribution_major_version | int) <= 10)
 
 - name: import uStreamer role
   import_role:

--- a/ansible-role/vars/main.yml
+++ b/ansible-role/vars/main.yml
@@ -11,7 +11,7 @@ tinypilot_privileged_dir: /opt/tinypilot-privileged
 # uStreamer variables are placed here, instead of in `defaults/main.yml`,
 # in order to elevate their variable precedence. These variables will now
 # override the default variables in the uStreamer role.
-ustreamer_interface: '127.0.0.1'
+ustreamer_interface: "127.0.0.1"
 ustreamer_port: 8001
 ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git
 # Assigning `ustreamer_h264_sink` will make the uStreamer role install the Janus


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot/issues/1174

This PR adds the styles changes, created from running [`dev-scripts/fix-style`](https://github.com/tiny-pilot/tinypilot/blob/e13e4b48fa5705dd94d170a3079bfda1b1d4bd40/dev-scripts/fix-style), needed to fix the [previously failing build](https://app.circleci.com/pipelines/github/tiny-pilot/tinypilot/2956/workflows/18ee9efb-1545-45ce-8446-bb21caaa2213/jobs/13672). This is a non-functional change.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1283"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>