### PR TITLE
H.264 audio: Unmute video stream automatically

### DIFF
--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -367,13 +367,13 @@
           // https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/addTrack
           stream.addTrack(mediaStreamTrack);
 
-          // We only proceed switching to WebRTC if we have at least video
-          // signal. We don’t want to switch yet if the only thing we have is an
+          // We only proceed switching to WebRTC if we have at least a video
+          // track. We don’t want to switch yet if the only thing we have is an
           // audio track.
-          // It’s also important that we hold off on emitting the switch-over
-          // event (`VideoStreamingModeChangedEvent`) until the video playback
-          // has started, to ensure a smooth visual transition of the remote
-          // screen without any flickering/interruption.
+          // It’s also important that we hold off on displaying the WebRTC
+          // stream until the video playback has started, to ensure a smooth
+          // visual transition of the remote screen without any flickering or
+          // interruption.
           if (mediaStreamTrack.kind === "video") {
             // We optimistically unmute before we start the playback, because we
             // cannot tell ahead of time whether audio is blocked by the


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1190.

This adds a mechanism that tries to unmute the video stream on “best effort” basis, taking into account (or rather: working around) the blocking policies for audio autoplay of the browser.

## Audio autoplay policies

Here is a brief primer on the situation. Note, the policies can slightly differ between browsers. I have tested in Chrome and Firefox.

Audio autoplay is only allowed if: (See [MDN docs](https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide) for more details)

- The user has interacted with the website prior to the playback (e.g., by clicking somewhere)
- The user has allowed audio-autoplay explicitly per their browser settings (Firefox only, at least as of now)
- The browser has automagically determined that the website is “good”. In Chrome, you can go to `about://media-engagement` to see the internal scores.

This all wouldn’t be a big problem, however, browsers apparently decided to “punish” websites for policy violations by stopping the video element altogether. So attempting to unmute despite audio being blocked won’t just “silently” be disregarded, but it instead will pause the entire video stream.

## Approach

Our unmuting strategy is two-fold:

- We optimistically try to unmute right away.
  - That might fail, in which case we fall back to muting and trying again.
  - But it also might succeed, e.g. in case our internal “media engagement” score is high, or the user unblocked our site per their settings, our the user had already interacted with the website while it was loading.
- Otherwise, we intercept the very first user interaction and use that opportunity to unmute. That might still fail, however, in case the user wished to explicitly block audio per settings. It’s also a bit obscure what exactly qualifies as “user interaction”, so to a certain degree we just have to try and see what happens.

## Notes

- Although I couldn’t see that it would lead to actual problems to issue `video.play()` calls redundantly, it still feels wrong to me to do it mindlessly. I think we can’t really prevent some redundant calls, but I tried to avoid it where it was easily possible.
- I inlined the previous `_enableWebrtc` logic, because otherwise I felt it was confusing to have multiple internal methods that “enable” or “play” video, and it’s not as clear anymore what the actual difference is.

All in all, I would conclude that this implementation feels more like a heuristic approach, instead of a clear, deterministic control flow. I think the latter would only be possible at the expense of a very complex, rigorous implementation, due to there being so many dynamic factors at play:

- We are depending on browser settings that we can’t determine ahead of time.
- We receive multiple streams, in our case even duplicate ones, and their order or time of arrival is not guaranteed.
- There are multiple, independent triggers, that can all kick off simultaneously trying to do the same thing, and based off a multitude of different initial states.
- A call to [`video.play()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play) is asynchronous, so we don’t know how long it will take, or what will happen in the meantime while the call is in-flight.

I have spent quite a bit of time with testing, both by erratically poking around, and by intentionally trying to provoke certain situations that I could think of. It seems as this approach here does work somewhat reliable, but I think there is still a slight chance of some weird edge-case slipping through, or something else that we haven’t considered.

See also my [comment about testing](https://github.com/tiny-pilot/tinypilot/issues/1190#issuecomment-1410068616).

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1288"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>