### PR TITLE
Install compatible `cryptography` version

### DIFF
--- a/app/license_notice.py
+++ b/app/license_notice.py
@@ -192,7 +192,7 @@ _LICENSE_METADATA = [
         name='cryptography',
         homepage_url='https://cryptography.io',
         license_url=
-        'https://raw.githubusercontent.com/pyca/cryptography/38.0.3/LICENSE.BSD'
+        'https://raw.githubusercontent.com/pyca/cryptography/38.0.1/LICENSE.BSD'
     ),
     LicenseMetadata(
         name='packaging',

--- a/bundler/bundle/requirements.txt
+++ b/bundler/bundle/requirements.txt
@@ -7,7 +7,7 @@ ansible==2.10.7
 # Indirect dependencies.
 ansible-base==2.10.17
 cffi==1.15.1
-cryptography==38.0.3
+cryptography==38.0.1
 Jinja2==3.1.2
 MarkupSafe==2.1.1
 packaging==21.3


### PR DESCRIPTION
Currently, TinyPilot fails to install altogether. The bundle installer cannot resolve the dependency on the `cryptography` pip package version 38.0.3, because there is [no working piwheel yet for that version](https://www.piwheels.org/project/cryptography/), and building from source would require a Rust toolchain to be set up.

[`cryptography` 38.0.2 was yanked](https://cryptography.io/en/39.0.0/changelog/#yanked), so it looks as we currently can only install 38.0.1 via piwheels.

@mtlynch I’ve tested this on the device, so feel free to merge directly in case you agree with the approach.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1293"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>