### PR TITLE
Release modifier keycodes when browser window loses focus.

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -309,11 +309,14 @@ document.addEventListener("video-streaming-mode-changed", (evt) => {
     evt.detail.mode;
 });
 
-// To allow for keycode combinations to be pressed (e.g., ALT + TAB), we don't
-// automatically release modifier keycodes after being pressed. However, if we
-// are unable to capture modifier's "keyup" event, the keycode would appear
-// stuck. To avoid this, we release any modifier keycodes being pressed when the
-// browser window loses focus.
+// To allow for keycode combinations to be pressed (e.g., Alt + Tab), the
+// backend doesn't automatically release modifier keycodes after being pressed.
+// However, in the case where the user presses a combination like Alt + Tab,
+// for example, then the browser would only receive the "keydown" event for Alt,
+// since the Tab press is intercepted by the operating system and switches focus
+// to another application. That way, the modifier key appears stuck on the
+// target machine. To avoid this, we release any modifier keycodes being pressed
+// when the browser window loses focus.
 window.addEventListener("blur", () => {
   keyboardState
     .getAllPressedModifierKeys()

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -316,7 +316,7 @@ document.addEventListener("video-streaming-mode-changed", (evt) => {
 // browser window loses focus.
 window.addEventListener("blur", () => {
   for (const [keyCode, isPressed] of Object.entries(keyboardState.state)) {
-    if (isPressed) {
+    if (isPressed && isModifierCode(keyCode)) {
       onKeyUp(/*keyboardEvent=*/ { code: keyCode });
     }
   }

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -309,6 +309,20 @@ document.addEventListener("video-streaming-mode-changed", (evt) => {
     evt.detail.mode;
 });
 
+// To allow for keycode combinations to be pressed (e.g., ALT + TAB), we don't
+// automatically release modifier keycodes after being pressed. However, if we
+// are unable to capture modifier's "keyup" event, the keycode would appear
+// stuck. To avoid this, we release any modifier keycodes being pressed when the
+// browser window loses focus.
+window.addEventListener("blur", () => {
+  const isModifierKeyPressed = Object.entries(keyboardState.state).some(
+    ([keyCode, isPressed]) => isPressed === true && isModifierCode(keyCode)
+  );
+  if (isModifierKeyPressed) {
+    socket.emit("keyRelease");
+  }
+});
+
 const menuBar = document.getElementById("menu-bar");
 menuBar.cursor = settings.getScreenCursor();
 menuBar.addEventListener("cursor-selected", (evt) => {

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -315,11 +315,10 @@ document.addEventListener("video-streaming-mode-changed", (evt) => {
 // stuck. To avoid this, we release any modifier keycodes being pressed when the
 // browser window loses focus.
 window.addEventListener("blur", () => {
-  const isModifierKeyPressed = Object.entries(keyboardState.state).some(
-    ([keyCode, isPressed]) => isPressed === true && isModifierCode(keyCode)
-  );
-  if (isModifierKeyPressed) {
-    socket.emit("keyRelease");
+  for (const [keyCode, isPressed] of Object.entries(keyboardState.state)) {
+    if (isPressed) {
+      onKeyUp(/*keyboardEvent=*/ { code: keyCode });
+    }
   }
 });
 

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -315,11 +315,11 @@ document.addEventListener("video-streaming-mode-changed", (evt) => {
 // stuck. To avoid this, we release any modifier keycodes being pressed when the
 // browser window loses focus.
 window.addEventListener("blur", () => {
-  for (const [keyCode, isPressed] of Object.entries(keyboardState.state)) {
-    if (isPressed && isModifierCode(keyCode)) {
-      onKeyUp(/*keyboardEvent=*/ { code: keyCode });
-    }
-  }
+  keyboardState
+    .getAllPressedModifierKeys()
+    .forEach((keyCode) =>
+      onKeyUp(new KeyboardEvent("keyup", { code: keyCode }))
+    );
 });
 
 const menuBar = document.getElementById("menu-bar");

--- a/app/static/js/keyboardstate.js
+++ b/app/static/js/keyboardstate.js
@@ -20,15 +20,6 @@ export class KeyboardState {
   }
 
   /**
-   * Returns the current keyboard state, indicating which key codes are being
-   * pressed.
-   * @returns Object {[keyCode:string]: [isPressed:boolean]}
-   */
-  get state() {
-    return this._isKeyPressed;
-  }
-
-  /**
    * @param canonicalCode (string) The canonical key code.
    * @returns boolean
    */
@@ -87,5 +78,14 @@ export class KeyboardState {
         this._isKeyPressed[possibleCodes[0]] = true;
       }
     }
+  }
+
+  /**
+   * @returns {string[]} An unordered array of canonical key codes.
+   */
+  getAllPressedModifierKeys() {
+    return Object.entries(this._isKeyPressed)
+      .filter(([keyCode, isPressed]) => isPressed && isModifierCode(keyCode))
+      .map(([keyCode]) => keyCode);
   }
 }

--- a/app/static/js/keyboardstate.js
+++ b/app/static/js/keyboardstate.js
@@ -20,6 +20,15 @@ export class KeyboardState {
   }
 
   /**
+   * Returns the current keyboard state, indicating which key codes are being
+   * pressed.
+   * @returns Object {[keyCode:string]: [isPressed:boolean]}
+   */
+  get state() {
+    return this._isKeyPressed;
+  }
+
+  /**
    * @param canonicalCode (string) The canonical key code.
    * @returns boolean
    */

--- a/app/static/js/keyboardstate.test.js
+++ b/app/static/js/keyboardstate.test.js
@@ -56,8 +56,8 @@ describe("KeyboardState", () => {
       assert.strictEqual(true, keyboardState.isKeyPressed("AltLeft"));
       assert.strictEqual(true, keyboardState.isKeyPressed("ControlLeft"));
       assert.deepEqual(
-        ["AltLeft", "ControlLeft"],
-        keyboardState.getAllPressedModifierKeys()
+        new Set(["AltLeft", "ControlLeft"]),
+        new Set(keyboardState.getAllPressedModifierKeys())
       );
     });
   });

--- a/app/static/js/keyboardstate.test.js
+++ b/app/static/js/keyboardstate.test.js
@@ -41,4 +41,24 @@ describe("KeyboardState", () => {
     assert.strictEqual(false, keyboardState.isKeyPressed("ControlLeft"));
     assert.strictEqual(false, keyboardState.isKeyPressed("AltRight"));
   });
+
+  describe("#getAllPressedModifierKeys()", () => {
+    it("should return an array of pressed modifier keys", () => {
+      const keyboardState = new KeyboardState();
+      const event = {
+        code: "KeyE",
+        altKey: true,
+        ctrlKey: true,
+      };
+      keyboardState.onKeyDown(event);
+
+      assert.strictEqual(true, keyboardState.isKeyPressed("KeyE"));
+      assert.strictEqual(true, keyboardState.isKeyPressed("AltLeft"));
+      assert.strictEqual(true, keyboardState.isKeyPressed("ControlLeft"));
+      assert.deepEqual(
+        ["AltLeft", "ControlLeft"],
+        keyboardState.getAllPressedModifierKeys()
+      );
+    });
+  });
 });


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/361

Background:
For normal keys (i.e., non-modifier keys) we [automatically release the key after being pressed](https://github.com/tiny-pilot/tinypilot/blob/86fae61abb9502fe87d487c6f9da5abd7416c272/app/hid/keyboard.py#L10-L18). We don't do this for modifier keys, instead we wait for the "keyup" event to fire.

When a user presses `ALT+TAB` to change applications on their host machine, the "keydown" events would fire, but the "keyup" events do not fire because the focus has already been switched to a different application when the keys are eventually released. From the target machine's perspective, this causes the modifier keys to appear stuck.

To avoid this, we release any modifier keys currently being pressed once the browser window loses focus.

### Caveat
[As mentioned in the issue thread](https://github.com/tiny-pilot/tinypilot/issues/361#issuecomment-1420780726), there exists a case where this PR does not fix the issue:
> users will still experience the bug if they use `ALT+TAB`/`CMD+TAB` to "change" to the **same** application.

However, this is [still considered an decent enough fix](https://github.com/tiny-pilot/tinypilot/issues/361#issuecomment-1420816354):
> I think even if we can reduce the bug to only happen when you Alt+Tab back into the original window, that's still a decent fix.

### How to test

You can [use `evtest`](https://github.com/tiny-pilot/tinypilot/issues/361#issuecomment-1419699354) to confirm the fix.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1296"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>