### PR TITLE
Introduce “Help” menu and move over “About” item from “System”

### DIFF
--- a/app/templates/custom-elements/menu-bar.html
+++ b/app/templates/custom-elements/menu-bar.html
@@ -185,9 +185,6 @@
           <a data-onclick-event="debug-logs-dialog-requested">Logs</a>
         </li>
         <li class="item">
-          <a data-onclick-event="about-dialog-requested">About</a>
-        </li>
-        <li class="item">
           <a data-onclick-event="shutdown-dialog-requested">Power</a>
         </li>
       </ul>
@@ -237,6 +234,15 @@
         </li>
         <li class="item">
           <a data-onclick-event="fullscreen-requested">Full Screen</a>
+        </li>
+      </ul>
+    </li>
+
+    <li class="group">
+      <a>Help</a>
+      <ul class="items">
+        <li class="item">
+          <a data-onclick-event="about-dialog-requested">About</a>
         </li>
       </ul>
     </li>


### PR DESCRIPTION
First step of https://github.com/tiny-pilot/tinypilot-pro/issues/731.

This PR introduces a new menu “Help” and moves over the “About” menu item from the “System” menu.

We’ll extend the new “Help” menu in [a subsequent PR](https://github.com/tiny-pilot/tinypilot/pull/1298).

<img width="752" alt="Screenshot 2023-02-08 at 15 52 32" src="https://user-images.githubusercontent.com/83721279/217571311-e005c0aa-5068-442c-99af-ec13e98d8476.png">

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1297"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>