### PR TITLE
Adjust dev instructions so they work on Python >= 3.7

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ The steps below show you how to quickly set up a development environment for Tin
 To install TinyPilot's dev packages, run the following command:
 
 ```bash
-python3.7 -m venv venv && \
+python3 -m venv venv && \
   . venv/bin/activate && \
   pip install --requirement requirements.txt && \
   pip install --requirement dev_requirements.txt && \


### PR DESCRIPTION
Our dev instructions hardcoded the Python version to 3.7. Let's just make it Python 3 and trust that the user followed the instructions to install 3.7 or higher.