### PR TITLE
Revert "Bump cryptography from 38.0.3 to 39.0.1 in /ansible-role/molecule"

### DIFF
--- a/ansible-role/molecule/requirements.txt
+++ b/ansible-role/molecule/requirements.txt
@@ -28,7 +28,7 @@ click-completion==0.5.2
 click-help-colors==0.9.1
 commonmark==0.9.1
 cookiecutter==2.1.1
-cryptography==39.0.1
+cryptography==38.0.3
 distro==1.7.0
 docker==5.0.3
 enrich==1.2.7


### PR DESCRIPTION
Reverts tiny-pilot/tinypilot#1295

Fixes #1299 
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1302"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>