### PR TITLE
Downgrade to cryptography 37.0.4 wheel.

### DIFF
--- a/app/license_notice.py
+++ b/app/license_notice.py
@@ -192,7 +192,7 @@ _LICENSE_METADATA = [
         name='cryptography',
         homepage_url='https://cryptography.io',
         license_url=
-        'https://raw.githubusercontent.com/pyca/cryptography/38.0.1/LICENSE.BSD'
+        'https://raw.githubusercontent.com/pyca/cryptography/37.0.4/LICENSE.BSD'
     ),
     LicenseMetadata(
         name='packaging',

--- a/bundler/bundle/requirements.txt
+++ b/bundler/bundle/requirements.txt
@@ -7,7 +7,7 @@ ansible==2.10.7
 # Indirect dependencies.
 ansible-base==2.10.17
 cffi==1.15.1
-cryptography==38.0.1
+cryptography==37.0.4
 Jinja2==3.1.2
 MarkupSafe==2.1.1
 packaging==21.3


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1299

The PR uses the [latest `cryptography` wheel available on Debian Buster](https://www.piwheels.org/project/cryptography/):

<img width="805" alt="Screen Shot 2023-02-08 at 18 30 59" src="https://user-images.githubusercontent.com/6730025/217596118-c8b53341-3197-46c4-b32f-fccd914e0655.png">

I've tested the [bundle](https://app.circleci.com/pipelines/github/tiny-pilot/tinypilot/3011/workflows/3f1380ee-79bf-4ae4-9490-6f4fb50e21b4/jobs/14269/artifacts) installation on a device running Raspberry Pi OS Lite Buster.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1303"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>