### PR TITLE
Remove obsolete `systemd-config` Ansible tag

### DIFF
--- a/ansible-role/tasks/main.yml
+++ b/ansible-role/tasks/main.yml
@@ -68,8 +68,6 @@
   notify:
     - reload TinyPilot systemd config
     - restart TinyPilot service
-  tags:
-    - systemd-config
 
 - name: enable systemd TinyPilot service file
   systemd:


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/ansible-role-ustreamer/issues/90, see https://github.com/tiny-pilot/ansible-role-ustreamer/pull/95.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1308"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>