### PR TITLE
Move style guide documentation to dedicated repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,14 +98,7 @@ TinyPilot accepts various options through environment variables:
 
 ## Code style conventions
 
-TinyPilot follows Google code style conventions:
-
-- [Python](https://google.github.io/styleguide/pyguide.html)
-- [HTML/CSS](https://google.github.io/styleguide/htmlcssguide.html)
-- [Shell](https://google.github.io/styleguide/shellguide.html)
-- ~~[JavaScript](https://google.github.io/styleguide/jsguide.html)~~ - We are "loosely inspired" by the JS style guide, but don't observe it strictly
-
-TinyPilot uses automated linters and formatters as much as possible to automate style conventions.
+See [tinypilot/style-guides](https://github.com/tiny-pilot/style-guides).
 
 ## Web Components Conventions
 


### PR DESCRIPTION
Corresponds with: https://github.com/tiny-pilot/style-guides/pull/1
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1309"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>