### PR TITLE
Extract “prompt” part of `<update-dialog>` component

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -129,18 +129,28 @@ def latest_release_get():
     Returns:
         On success, a JSON data structure with the following properties:
         version: str.
+        kind: str.
+        data: object (of kind-specific structure), or null.
 
         Example:
         {
             "version": "1.2.3-16+7a6c812",
+            "kind": "automatic",
+            "data": null,
         }
 
         Returns error object on failure.
     """
     try:
-        return json_response.success({'version': version.latest_version()})
+        update_info = version.latest_version()
     except version.Error as e:
         return json_response.error(e), 500
+
+    return json_response.success({
+        'version': update_info.version,
+        'kind': update_info.kind,
+        'data': update_info.data,
+    })
 
 
 @api_blueprint.route('/hostname', methods=['GET'])

--- a/app/static/js/controllers.js
+++ b/app/static/js/controllers.js
@@ -68,11 +68,13 @@ export async function getLatestRelease() {
     redirect: "error",
   })
     .then(processJsonResponse)
-    .then((versionResponse) => {
-      if (!versionResponse.hasOwnProperty("version")) {
-        throw new ControllerError("Missing expected version field");
-      }
-      return versionResponse.version;
+    .then((updateInfo) => {
+      ["version", "kind", "data"].forEach((field) => {
+        if (!updateInfo.hasOwnProperty(field)) {
+          throw new ControllerError(`Missing expected ${field} field`);
+        }
+      });
+      return updateInfo;
     });
 }
 
@@ -89,7 +91,7 @@ export async function getVersion() {
       if (!versionResponse.hasOwnProperty("version")) {
         throw new ControllerError("Missing expected version field");
       }
-      return versionResponse.version;
+      return versionResponse;
     });
 }
 

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -57,6 +57,14 @@
       display: flex;
       flex-direction: column-reverse;
     }
+
+    #update-prompt-automatic {
+      display: none;
+    }
+
+    :host([update-kind="automatic"]) #update-prompt-automatic {
+      display: block;
+    }
   </style>
 
   <div id="checking">
@@ -66,13 +74,10 @@
 
   <div id="update-available">
     <h3>Update TinyPilot</h3>
-    <p>
-      An update is available. Would you like to install the latest version?
-    </p>
-    <button id="confirm-update" class="btn-success" type="button">
-      Update
-    </button>
-    <button id="cancel-update" type="button">Cancel</button>
+    <update-prompt-automatic
+      id="update-prompt-automatic"
+    ></update-prompt-automatic>
+    <!-- Note: in Pro, we have more update kinds here. -->
   </div>
 
   <div id="latest">
@@ -153,17 +158,10 @@
             updateLogs: this.shadowRoot.querySelector(
               "#update-container .logs"
             ),
+            updatePromptAutomatic: this.shadowRoot.querySelector(
+              "#update-prompt-automatic"
+            ),
           };
-          this.shadowRoot
-            .getElementById("confirm-update")
-            .addEventListener("click", () => {
-              this._doUpdate();
-            });
-          this.shadowRoot
-            .getElementById("cancel-update")
-            .addEventListener("click", () => {
-              this.dispatchEvent(new DialogClosedEvent());
-            });
           this.shadowRoot
             .getElementById("ok-latest")
             .addEventListener("click", () => {
@@ -174,6 +172,19 @@
             .addEventListener("click", () => {
               location.reload();
             });
+
+          // Wire up update prompts. Note: due to alphabetic initialization
+          // order of our custom elements, any <update-prompt-...> components
+          // will become available *after* the <update-dialog> component, so we
+          // have to wrap their setup procedure into a callback.
+          customElements.whenDefined("update-prompt-automatic").then(() => {
+            this.elements.updatePromptAutomatic.onConfirm = () => {
+              this._doUpdate();
+            };
+            this.elements.updatePromptAutomatic.onCancel = () => {
+              this.dispatchEvent(new DialogClosedEvent());
+            };
+          });
         }
 
         get _state() {
@@ -189,17 +200,19 @@
           );
         }
 
+        _renderPrompt(updateInfo) {
+          this.setAttribute("update-kind", updateInfo.kind);
+        }
+
         checkVersion() {
           this._state = this.states.CHECKING;
 
           Promise.all([getVersion(), getLatestRelease()])
-            .then((versions) => {
-              const localVersion = versions[0];
-              const latestRelease = versions[1];
-
-              if (localVersion === latestRelease) {
+            .then(([localVersion, latestRelease]) => {
+              if (localVersion.version === latestRelease.version) {
                 this._state = this.states.LATEST;
               } else {
+                this._renderPrompt(latestRelease);
                 this._state = this.states.UPDATE_AVAILABLE;
               }
             })

--- a/app/templates/custom-elements/update-prompt-automatic.html
+++ b/app/templates/custom-elements/update-prompt-automatic.html
@@ -1,0 +1,47 @@
+<template id="update-prompt-automatic">
+  <style>
+    @import "css/style.css";
+    @import "css/button.css";
+  </style>
+
+  <p>
+    An update is available. Would you like to install the latest version?
+  </p>
+  <button id="confirm-update" class="btn-success" type="button">
+    Update
+  </button>
+  <button id="cancel-update" type="button">Cancel</button>
+</template>
+
+<script type="module">
+  (function () {
+    const template = document.querySelector("#update-prompt-automatic");
+
+    customElements.define(
+      "update-prompt-automatic",
+      class extends HTMLElement {
+        constructor() {
+          super();
+        }
+
+        connectedCallback() {
+          this.attachShadow({ mode: "open" }).appendChild(
+            template.content.cloneNode(true)
+          );
+        }
+
+        set onConfirm(handler) {
+          this.shadowRoot
+            .getElementById("confirm-update")
+            .addEventListener("click", handler);
+        }
+
+        set onCancel(handler) {
+          this.shadowRoot
+            .getElementById("cancel-update")
+            .addEventListener("click", handler);
+        }
+      }
+    );
+  })();
+</script>

--- a/app/version.py
+++ b/app/version.py
@@ -1,3 +1,4 @@
+import dataclasses
 import json
 import urllib.request
 
@@ -17,6 +18,16 @@ class VersionRequestError(Error):
 
 
 _VERSION_FILE = './VERSION'
+
+
+@dataclasses.dataclass
+class UpdateInfo:
+    """This data structure reflects the response of Gatekeeper’s
+    `/available-update` routes.
+    """
+    version: str
+    kind: str
+    data: dict
 
 
 def _is_debug():
@@ -52,10 +63,11 @@ def local_version():
 
 
 def latest_version():
-    """Requests the latest version from the TinyPilot Gatekeeper REST API.
+    """Requests info about the latest release from the TinyPilot Gatekeeper REST
+    API.
 
     Returns:
-        A version string (e.g., "1.2.3-16+7a6c812").
+        An UpdateInfo object, containing the information about the release.
 
     Raises:
         VersionRequestError: If an error occurred while making an HTTP request
@@ -89,9 +101,11 @@ def latest_version():
             'Failed to decode latest available version response body as a JSON'
             ' dictionary.')
 
-    if 'version' not in response_dict:
+    if not all(key in response_dict for key in ('version', 'kind', 'data')):
         raise VersionRequestError(
-            'Failed to get latest available version because of a missing field:'
-            ' version')
+            'Failed to get latest available version because of an incompatible'
+            ' response structure')
 
-    return response_dict['version']
+    return UpdateInfo(version=response_dict['version'],
+                      kind=response_dict['kind'],
+                      data=response_dict['data'])

--- a/app/version_test.py
+++ b/app/version_test.py
@@ -67,11 +67,13 @@ class VersionTest(TestCase):
     def test_latest_version_when_request_is_successful(self, mock_urlopen):
         mock_response = mock.Mock()
         mock_response.read.return_value = json.dumps({
-            'version': '1.2.3-16+7a6c812'
+            'version': '1.2.3-16+7a6c812',
+            'kind': 'automatic',
+            'data': None,
         }).encode('utf-8')
         mock_urlopen.return_value.__enter__.return_value = mock_response
 
-        self.assertEqual('1.2.3-16+7a6c812', version.latest_version())
+        self.assertEqual('1.2.3-16+7a6c812', version.latest_version().version)
 
     @mock.patch.object(urllib.request, 'urlopen')
     def test_latest_version_raises_request_error_when_response_is_not_utf_8(


### PR DESCRIPTION
This PRs is the proper implementation of the [POC for the update flow](https://github.com/tiny-pilot/tinypilot-pro/pull/764). It lays the groundwork for us to resolve https://github.com/tiny-pilot/tinypilot/issues/1284 in Pro. This PR is blocked on https://github.com/tiny-pilot/gatekeeper/pull/136.

A few notes, in addition to what we discussed in the POC:

- I took over your suggestion to place the prompt component right from the start, and I like that much better than what I initially came up with.
- I eventually decided to pull out the prompt component instead of keeping the different prompts inside `<update-dialog>` next to each other. The most compelling reason for me was that this will allow us to minimize the differences between Pro and Community in the `update-dialog.html` file. In Pro, we later only have to add a new, separate file for the `<update-prompt-manual>` component, and do minimal additional wiring in `<update-dialog>`. The downside is that we pay for that separation with some boilerplate code (which I’d mind less here, though).
- The `data` field is now mandatory – so [the field itself will always be there](https://github.com/tiny-pilot/gatekeeper/pull/136), it might just be `null`.
- In the frontend, I slightly refactored the `getVersion` controller function, to make the return structure on par with the one from `getLatestRelease`. That’s for purely aesthetic reasons.
- [When building the “manual” prompt in Pro](https://github.com/tiny-pilot/tinypilot/issues/1284), we are going to have to make one adjustment in the `_renderPrompt` function in Pro, to pass through that new `data` field. We could also establish the convention to *always* pass on that `data` field to the respective prompt component, but that might also feel weird in Community, since it would go into the void.

Note to self: when doing the upstream merge into Pro, we need to take over the changelog link, which is Pro-specific.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1312"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>