### PR TITLE
Update dialog: subscribe to prompts directly for events

### DIFF
--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -173,12 +173,18 @@
               location.reload();
             });
 
-          this.shadowRoot.addEventListener("update-prompt-confirmed", () => {
-            this._doUpdate();
-          });
-          this.shadowRoot.addEventListener("update-prompt-canceled", () => {
-            this.dispatchEvent(new DialogClosedEvent());
-          });
+          this.elements.updatePromptAutomatic.addEventListener(
+            "update-prompt-confirmed",
+            () => {
+              this._doUpdate();
+            }
+          );
+          this.elements.updatePromptAutomatic.addEventListener(
+            "update-prompt-canceled",
+            () => {
+              this.dispatchEvent(new DialogClosedEvent());
+            }
+          );
         }
 
         get _state() {


### PR DESCRIPTION
As discussed in https://github.com/tiny-pilot/tinypilot/pull/1315, we can make the event subscriptions specific to the child component that we expect the events from, in order to lean on the safe sides with our control flows.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1318"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>