### PR TITLE
Clarify wording around syncing Community to Pro

### DIFF
--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -27,9 +27,12 @@ jobs:
           assignees: ${{ github.actor }}
           title: Merge changes from community repository
           body: |
-            Merge the last changes from community repository :
+            ${{ github.actor }}, please merge the last changes from community repository:
 
             https://github.com/tiny-pilot/tinypilot/commit/${{ github.sha }}
 
-            **Do not use "Squash and merge" !**
+            **Do not use "Squash and merge"!**
+
             Merge this PR with a merge commit, keeping the commit history.
+
+            (If you accidentally squash, it's not a disaster, but it will create a bit of noise on the subsequent PR from Community)


### PR DESCRIPTION
Update the wording on the message team members see when we need to sync changes from Community to Pro:

* Make it clear that a human must take action to complete the process
* Make an accidental squash and merge less scary
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1324"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>