### PR TITLE
Backport “external link button” from Pro

### DIFF
--- a/app/static/css/button.css
+++ b/app/static/css/button.css
@@ -93,3 +93,11 @@ button:disabled,
   cursor: pointer;
   color: #555;
 }
+
+.btn-external-link {
+  background-image: url("/img/external-link-icon.svg");
+  background-repeat: no-repeat;
+  background-position: top 49% right 1.2em;
+  background-size: 0.75em;
+  padding-right: 2.5em;
+}

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -230,6 +230,19 @@
       <p>
         <span class="btn-text">Click Me</span>
       </p>
+      <h3>Button for External Links</h3>
+      <p>
+        If a button opens an external website, then it should be an
+        “Action”-type button with an “External Link” icon on the right-hand
+        side. External links should open in a new tab by default.
+      </p>
+      <a
+        href="about:blank"
+        target="_blank"
+        class="btn btn-action btn-external-link"
+        rel="noopener noreferer"
+        >Open Link</a
+      >
 
       <h2 class="section">Input</h2>
       <ul>


### PR DESCRIPTION
In https://github.com/tiny-pilot/tinypilot-pro/pull/781#pullrequestreview-1333485007 (in Pro), we introduced a UI for a button that opens a weblink, instead of performing some app-internal action.

I realized that we actually already had that pattern in the Community repo, where we [open external links in the `<feature-pro>` dialog](https://github.com/tiny-pilot/tinypilot/blob/d62555d2e80f14d1d5b23640cc33549c5e7768e9/app/templates/custom-elements/feature-pro-dialog.html#L9-L11). So I thought it would be worthwhile to back-port this button, and make the UI consistent. So this PR adds the respective styles, and describes the usage rules in the styleguide. The [next PR would then change the `<feature-pro>` dialog](https://github.com/tiny-pilot/tinypilot/pull/1326).

<img width="697" alt="Screenshot 2023-03-14 at 14 50 02" src="https://user-images.githubusercontent.com/83721279/225022158-32776181-db7e-4ba9-9cc0-664c5fd4b5ce.png">

The “external link button” aims to be consistent with the “external link menu items” of the “Help” menu.

<img width="232" alt="Screenshot 2023-03-14 at 14 55 30" src="https://user-images.githubusercontent.com/83721279/225023832-d81adc13-4a2d-435c-92da-ff73f0d33cc7.png">

**Note to self:** After merging this into Pro, we need to refactor the [“instructions link”](https://github.com/tiny-pilot/tinypilot-pro/blob/1d69a61c0329b4f78db9ccbbbf979af64637c5d3/app/templates/custom-elements/update-prompt-manual.html#L30-L38) there.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1325"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>