### PR TITLE
Fix dev script for enabling mock scripts

### DIFF
--- a/dev-scripts/enable-mock-scripts
+++ b/dev-scripts/enable-mock-scripts
@@ -24,4 +24,10 @@ elif [[ -d "${PRIVILEGED_SCRIPTS_DIR}" ]]; then
   exit 1
 fi
 
+# Create parent folder (in case it doesn’t exist).
+mkdir \
+  --parents \
+  "$(dirname "${PRIVILEGED_SCRIPTS_DIR}")"
+
+# Symlink folder with privileged scripts.
 ln -s "${MOCK_SCRIPTS_DIR}" "${PRIVILEGED_SCRIPTS_DIR}"


### PR DESCRIPTION
Our script for enabling the mock scripts has a bug, because it fails if the `/opt/tinypilot-privileged` folder doesn’t exist. I think that happened when we moved the privileged scripts to the `scripts/` subfolder: before, the parent folder for all the script files was `/opt`, which always exists on Debian; but now the parent is `/opt/tinypilot-privileged`, which doesn’t exist in a pristine dev environment.

I added an `mkdir -p` to ensure the parent is always there.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1329"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>