### PR TITLE
Fix version on about page.

### DIFF
--- a/app/templates/custom-elements/about-dialog.html
+++ b/app/templates/custom-elements/about-dialog.html
@@ -98,7 +98,7 @@
 
         _checkVersion() {
           getVersion()
-            .then((version) => {
+            .then(({ version }) => {
               this.shadowRoot.getElementById(
                 "version-number"
               ).innerText = this._formatVersion(version);


### PR DESCRIPTION
Navigating to "Help" > "About" displays this in TinyPilot Community
<img width="877" alt="Screen Shot 2023-03-17 at 15 56 31" src="https://user-images.githubusercontent.com/6730025/225925742-6f0f6b11-b316-4bbb-8656-57ad565400d0.png">

And this in TinyPilot Pro:

<img width="876" alt="Screen Shot 2023-03-17 at 15 59 09" src="https://user-images.githubusercontent.com/6730025/225926493-a1b04ff8-7758-4c54-812d-a6d897f8fdd2.png">

We've introduced a regression via https://github.com/tiny-pilot/tinypilot/pull/1315 when we changed the `getVersion` controller from returning a version string to returning an object.

This PR uses ES6 destructuring to extract the version string from the object.