### PR TITLE
Correct comment annotations of `set -x`

### DIFF
--- a/ansible-role/files/init-usb-gadget
+++ b/ansible-role/files/init-usb-gadget
@@ -5,7 +5,7 @@
 # Exit on first error.
 set -e
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Treat undefined environment variables as errors.

--- a/ansible-role/files/remove-usb-gadget
+++ b/ansible-role/files/remove-usb-gadget
@@ -5,7 +5,7 @@
 # Exit on first error.
 set -e
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Treat undefined environment variables as errors.

--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -8,7 +8,7 @@ set -e
 # Exit on unset variable.
 set -u
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # shellcheck disable=SC1091 # Don’t follow sourced script.

--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -11,7 +11,7 @@ set -e
 # Exit on unset variable.
 set -u
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Change directory to repository root.

--- a/bundler/verify-bundle
+++ b/bundler/verify-bundle
@@ -5,7 +5,7 @@
 # Exit script on first failure.
 set -e
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Exit on unset variable.

--- a/debian-pkg/opt/tinypilot-privileged/scripts/update
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/update
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Treat undefined environment variables as errors.

--- a/dev-scripts/build
+++ b/dev-scripts/build
@@ -3,7 +3,7 @@
 # Exit build script on first failure.
 set -e
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Exit on unset variable.

--- a/dev-scripts/build-debian-pkg
+++ b/dev-scripts/build-debian-pkg
@@ -3,7 +3,7 @@
 # Exit build script on first failure.
 set -e
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Exit on unset variable.

--- a/dev-scripts/build-javascript
+++ b/dev-scripts/build-javascript
@@ -3,7 +3,7 @@
 # Exit build script on first failure.
 set -e
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Exit on unset variable.

--- a/dev-scripts/build-python
+++ b/dev-scripts/build-python
@@ -3,7 +3,7 @@
 # Exit build script on first failure.
 set -e
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Exit on unset variable.

--- a/dev-scripts/check-style
+++ b/dev-scripts/check-style
@@ -5,7 +5,7 @@
 # Exit build script on first failure.
 set -e
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Exit on unset variable.

--- a/dev-scripts/enable-mock-scripts
+++ b/dev-scripts/enable-mock-scripts
@@ -6,7 +6,7 @@
 # Exit build script on first failure.
 set -e
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Exit on unset variable.

--- a/dev-scripts/fix-style
+++ b/dev-scripts/fix-style
@@ -5,7 +5,7 @@
 # Exit build script on first failure.
 set -e
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Exit on unset variable.

--- a/dev-scripts/install-from-source
+++ b/dev-scripts/install-from-source
@@ -10,7 +10,7 @@
 # Exit build script on first failure.
 set -e
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Exit on unset variable.

--- a/dev-scripts/lint-sql
+++ b/dev-scripts/lint-sql
@@ -5,7 +5,7 @@
 # Exit build script on first failure.
 set -e
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Exit on unset variable.

--- a/dev-scripts/remote-scripts/pull
+++ b/dev-scripts/remote-scripts/pull
@@ -3,7 +3,7 @@
 # Exit build script on first failure.
 set -e
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Exit on unset variable.

--- a/dev-scripts/serve-dev
+++ b/dev-scripts/serve-dev
@@ -3,7 +3,7 @@
 # Exit build script on first failure.
 set -e
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Exit on unset variable.

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -10,7 +10,7 @@ set -e
 # Exit on unset variable.
 set -u
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Check if the user is accidentally downgrading from TinyPilot Pro.

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -3,7 +3,7 @@
 # Exit build script on first failure.
 set -e
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Exit on unset variable.

--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -55,7 +55,7 @@ if (( $# == 0 )); then
   exit 1
 fi
 
-# Print commands to terminal (stderr).
+# Echo commands before executing them, by default to stderr.
 set -x
 
 readonly BUNDLE_PATH="$1"


### PR DESCRIPTION
In contrast to what our comments say, `set -x` actually prints to `stderr`, not to `stdout`.

Bash sends the output of `set -x` to whatever [`BASH_XTRACEFD` is set to be](https://www.gnu.org/software/bash/manual/bash.html#index-BASH_005fXTRACEFD), which by default is the file descriptor `2`, i.e. `stderr`.

I’ve slightly rephrased the comment text, to highlight the general mechanism (printing to terminal) rather than the concrete details (which stream it uses).

Note to self: after merging to Pro, fix all additional occurrences.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1331"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>