### PR TITLE
Clarify when to use CTA button vs. action button in dialogs

### DIFF
--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -162,7 +162,10 @@
         <li>
           If ever feasible, call-to-action buttons should only appear once. If
           there are multiple regular actions side by side, the “regular” action
-          button should be used.
+          button should be used. As a rule of thumb: the call-to-action button
+          terminates a dialog by triggering its main function; whereas the
+          action button executes secondary operations <em>within</em> a dialog,
+          while keeping the dialog open.
         </li>
         <li>
           Buttons should be disabled if it’s obvious that an operation cannot be


### PR DESCRIPTION
I added an additional explanation to clarify the usage of the CTA button vs. the “regular” action button in dialogs. (I felt like the style guide lacked clarity here.)
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1332"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>