### PR TITLE
Enable mock scripts for macOS.

### DIFF
--- a/dev-scripts/enable-mock-scripts
+++ b/dev-scripts/enable-mock-scripts
@@ -26,7 +26,7 @@ fi
 
 # Create parent folder (in case it doesn’t exist).
 mkdir \
-  --parents \
+  -p \
   "$(dirname "${PRIVILEGED_SCRIPTS_DIR}")"
 
 # Symlink folder with privileged scripts.


### PR DESCRIPTION
This PR changes `enable-mock-scripts` to use short-style parameters with `mktemp` because `mktemp` on macOS doesn't support long-style parameters.