### PR TITLE
Upgrade to shellcheck v0.9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           command: ./dev-scripts/check-trailing-newline
   check_bash:
     docker:
-      - image: koalaman/shellcheck-alpine:v0.7.1
+      - image: koalaman/shellcheck-alpine:v0.9.0
     steps:
       - run:
           name: Install dependencies

--- a/ansible-role/files/init-usb-gadget
+++ b/ansible-role/files/init-usb-gadget
@@ -11,7 +11,8 @@ set -x
 # Treat undefined environment variables as errors.
 set -u
 
-readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+readonly SCRIPT_DIR
 # shellcheck source=lib/usb-gadget.sh
 source "${SCRIPT_DIR}/lib/usb-gadget.sh"
 

--- a/ansible-role/files/lib/usb-gadget.sh
+++ b/ansible-role/files/lib/usb-gadget.sh
@@ -3,20 +3,32 @@
 # Shared parameters and functionality for the usb gadget.
 # See: docs/usb-gadget-driver.md
 
-export readonly USB_DEVICE_DIR="g1"
-export readonly USB_GADGET_PATH="/sys/kernel/config/usb_gadget"
-export readonly USB_DEVICE_PATH="${USB_GADGET_PATH}/${USB_DEVICE_DIR}"
+export USB_DEVICE_DIR="g1"
+readonly USB_DEVICE_DIR
+export USB_GADGET_PATH="/sys/kernel/config/usb_gadget"
+readonly USB_GADGET_PATH
+export USB_DEVICE_PATH="${USB_GADGET_PATH}/${USB_DEVICE_DIR}"
+readonly USB_DEVICE_PATH
 
-export readonly USB_STRINGS_DIR="strings/0x409"
-export readonly USB_KEYBOARD_FUNCTIONS_DIR="functions/hid.keyboard"
-export readonly USB_MOUSE_FUNCTIONS_DIR="functions/hid.mouse"
-export readonly USB_MASS_STORAGE_NAME="mass_storage.0"
-export readonly USB_MASS_STORAGE_FUNCTIONS_DIR="functions/${USB_MASS_STORAGE_NAME}"
+export USB_STRINGS_DIR="strings/0x409"
+readonly USB_STRINGS_DIR
+export USB_KEYBOARD_FUNCTIONS_DIR="functions/hid.keyboard"
+readonly USB_KEYBOARD_FUNCTIONS_DIR
+export USB_MOUSE_FUNCTIONS_DIR="functions/hid.mouse"
+readonly USB_MOUSE_FUNCTIONS_DIR
+export USB_MASS_STORAGE_NAME="mass_storage.0"
+readonly USB_MASS_STORAGE_NAME
+export USB_MASS_STORAGE_FUNCTIONS_DIR="functions/${USB_MASS_STORAGE_NAME}"
+readonly USB_MASS_STORAGE_FUNCTIONS_DIR
 
-export readonly USB_CONFIG_INDEX=1
-export readonly USB_CONFIG_DIR="configs/c.${USB_CONFIG_INDEX}"
-export readonly USB_ALL_CONFIGS_DIR="configs/*"
-export readonly USB_ALL_FUNCTIONS_DIR="functions/*"
+export USB_CONFIG_INDEX=1
+readonly USB_CONFIG_INDEX
+export USB_CONFIG_DIR="configs/c.${USB_CONFIG_INDEX}"
+readonly USB_CONFIG_DIR
+export USB_ALL_CONFIGS_DIR="configs/*"
+readonly USB_ALL_CONFIGS_DIR
+export USB_ALL_FUNCTIONS_DIR="functions/*"
+readonly USB_ALL_FUNCTIONS_DIR
 
 function usb_gadget_activate {
   ls /sys/class/udc > "${USB_DEVICE_PATH}/UDC"

--- a/ansible-role/files/remove-usb-gadget
+++ b/ansible-role/files/remove-usb-gadget
@@ -11,7 +11,8 @@ set -x
 # Treat undefined environment variables as errors.
 set -u
 
-readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+readonly SCRIPT_DIR
 # shellcheck source=lib/usb-gadget.sh
 source "${SCRIPT_DIR}/lib/usb-gadget.sh"
 

--- a/debian-pkg/opt/tinypilot-privileged/scripts/change-hostname
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/change-hostname
@@ -8,7 +8,8 @@ set -u
 # Exit on first error.
 set -e
 
-readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+readonly SCRIPT_DIR
 # shellcheck source=lib/markers.sh
 . "${SCRIPT_DIR}/lib/markers.sh"
 
@@ -83,7 +84,8 @@ fi
 printf "%s\n" "${NEW_HOSTNAME}" > /etc/hostname
 
 # Populate corresponding entry to `etc/hosts`.
-readonly OLD_ETC_HOSTS=$(printf "%s\n" "${etc_hosts_original[@]}")
+OLD_ETC_HOSTS=$(printf "%s\n" "${etc_hosts_original[@]}")
+readonly OLD_ETC_HOSTS
 printf "%s\n127.0.1.1 %s\n%s\n%s\n" \
   "${MARKER_START}" "${NEW_HOSTNAME}" "${MARKER_END}" "${OLD_ETC_HOSTS}" \
   > /etc/hosts

--- a/debian-pkg/opt/tinypilot-privileged/scripts/set-static-ip
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/set-static-ip
@@ -45,7 +45,8 @@ print_help_nudge() {
   echo "  set-static-ip --help" >&2
 }
 
-readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+readonly SCRIPT_DIR
 readonly CONFIG_FILE="/etc/dhcpcd.conf"
 # shellcheck source=lib/markers.sh
 . "${SCRIPT_DIR}/lib/markers.sh"
@@ -133,7 +134,7 @@ fi
 set -u
 
 # Use the unset-static-ip script to remove any existing configuration.
-"${SCRIPT_DIR}/unset-static-ip" --quiet --interface ${INTERFACE}
+"${SCRIPT_DIR}/unset-static-ip" --quiet --interface "${INTERFACE}"
 
 # Only proceed if no other configuration exists.
 if grep -q "^interface ${INTERFACE}" "${CONFIG_FILE}" ; then

--- a/debian-pkg/opt/tinypilot-privileged/scripts/unset-static-ip
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/unset-static-ip
@@ -27,7 +27,8 @@ unset-static-ip \\
 EOF
 }
 
-readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+readonly SCRIPT_DIR
 readonly CONFIG_FILE="/etc/dhcpcd.conf"
 # shellcheck source=lib/markers.sh
 . "${SCRIPT_DIR}/lib/markers.sh"
@@ -110,7 +111,8 @@ if [[ "${#section[@]}" -ne 0 ]] ; then
 fi
 
 # Convert array of lines to a single string.
-readonly OLD_CONFIG_FILE=$(printf "%s\n" "${dhcpcd_original[@]}")
+OLD_CONFIG_FILE=$(printf "%s\n" "${dhcpcd_original[@]}")
+readonly OLD_CONFIG_FILE
 
 # Write original file contents back to the file.
 echo "${OLD_CONFIG_FILE}" | sudo tee "${CONFIG_FILE}" > /dev/null

--- a/dev-scripts/enable-mock-scripts
+++ b/dev-scripts/enable-mock-scripts
@@ -13,7 +13,8 @@ set -x
 set -u
 
 readonly PRIVILEGED_SCRIPTS_DIR="/opt/tinypilot-privileged/scripts"
-readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+readonly SCRIPT_DIR
 readonly MOCK_SCRIPTS_DIR="${SCRIPT_DIR}/mock-scripts"
 
 # If there's an existing symlink, remove it.

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -27,7 +27,7 @@ readonly SCRIPT_DIR
 # Detect TinyPilot Pro if the README file has a TinyPilot Pro header.
 readonly TINYPILOT_README="${SCRIPT_DIR}/README.md"
 if [[ -f "${TINYPILOT_README}" ]]; then
-  if [[ "$(head -n 1 ${TINYPILOT_README})" = "# TinyPilot Pro" ]]; then
+  if [[ "$(head -n 1 "${TINYPILOT_README}")" = "# TinyPilot Pro" ]]; then
     HAS_PRO_INSTALLED=1
   fi
 fi


### PR DESCRIPTION
Also fix new bash lint that the new version picks up, mainly around `readonly`.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1337"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>