### PR TITLE
Pass on full update log when update error occurs

### DIFF
--- a/app/templates/custom-elements/error-dialog.html
+++ b/app/templates/custom-elements/error-dialog.html
@@ -4,7 +4,7 @@
 
     #details {
       padding: 0.5rem;
-      max-height: 50vh;
+      max-height: 30vh;
       overflow: auto;
       opacity: 0.7;
       border: 1px solid black;

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -335,7 +335,9 @@
             this.dispatchEvent(
               new DialogFailedEvent({
                 title: "Failed to Complete Update",
-                details: error,
+                // Include full update logs in the error details, as it likely
+                // contains specific information about the error.
+                details: `${error}\n\n${this.elements.updateLogs.textContent}`,
               })
             );
             return;


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot/issues/1307.

This PR includes the full text of the update logs in the `details` field of the `DialogFailedEvent`, i.e. [whatever we previously appended and displayed in the ongoing update logs](https://github.com/tiny-pilot/tinypilot/blob/8f9b03b5d7e2712a0ade6d8e6966ccad58699841/app/templates/custom-elements/update-dialog.html#L305-L310).

In a later (but independent) PR, we’ll add the `<share-logs-button>` to the `<error-dialog>` after update failures, so that the text can be shared more easily.

Note, this is the first instance were the `details` text is intentionally lengthy; usually, it’s one or two sentences. While seeing now how long texts actually render, I’d suggest to reduce the `max-height` of the “Details” box a bit, to avoid the “Close” button of the dialog being pushed down too much – especially on smaller view ports.

For testing this, I found it handy to make the [`getUpdateStatus` controller](https://github.com/tiny-pilot/tinypilot/blob/8f9b03b5d7e2712a0ade6d8e6966ccad58699841/app/static/js/controllers.js#L160) return a hard-coded error (to provoke and trigger the failure in the frontend).

<img width="1057" alt="Screenshot 2023-03-24 at 16 12 05" src="https://user-images.githubusercontent.com/83721279/227566040-8b7b32a7-9bb0-4cc2-8c7b-fc5fb9b0b5ea.png">

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1338"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>