### PR TITLE
Don't package .lintianignore file in bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,14 +90,11 @@ jobs:
           root: ./debian-pkg/releases
           paths:
             - "*.deb"
-      - persist_to_workspace:
-          root: ./
-          paths:
-            - .lintianignore
   lint_debian_package:
     docker:
       - image: cimg/base:2022.11-22.04
     steps:
+      - checkout
       - attach_workspace:
           at: ./
       - run:


### PR DESCRIPTION
We're accidentally including the .lintianignore file in the Debian bundle, but it's not a production file, so we shouldn't include it.

We can avoid packaging the .lintianignore by keeping it out of the CircleCI persistent workspace.