### PR TITLE
Prevent VS Code from replacing tabs with spaces in rules file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,9 @@
     "editor.defaultFormatter": "ms-python.python",
     "editor.tabSize": 4
   },
+  "[rules]": {
+    "editor.insertSpaces": false
+  },
   "python.formatting.provider": "yapf",
   "python.linting.pylintEnabled": true,
   "python.linting.enabled": true,


### PR DESCRIPTION
The Debian rules file (`debian-pkg/debian/rules`) is annoyingly strict about using tabs instead of spaces, so we should configure standard VS Code project settings to insert tabs for the Tab key instead of replacing tabs with spaces, if that's the developer's default VS Code setting.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1355"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>