### PR TITLE
Remove logic for patching the HID kernel module

### DIFF
--- a/ansible-role/handlers/main.yml
+++ b/ansible-role/handlers/main.yml
@@ -8,8 +8,3 @@
   service:
     name: tinypilot
     state: restarted
-
-- name: start usb-gadget service
-  service:
-    name: usb-gadget
-    state: started

--- a/ansible-role/tasks/install_usb_gadget.yml
+++ b/ansible-role/tasks/install_usb_gadget.yml
@@ -19,7 +19,6 @@
     path: "{{ config_txt_path }}"
     create: no
     line: dtoverlay=dwc2
-  register: boot_config_lineinfile
   when: boot_config_stat.stat.exists
 
 - name: check for an /etc/modules file
@@ -32,13 +31,7 @@
     path: /etc/modules
     create: no
     line: dwc2
-  register: modules_lineinfile
   when: etc_modules_stat.stat.exists
-
-- name: determine if a reboot is required
-  set_fact:
-    reboot_required: >-
-      {{ boot_config_lineinfile.changed or modules_lineinfile.changed }}
 
 - name: create TinyPilot privileged folder
   file:
@@ -77,44 +70,3 @@
     name: usb-gadget
     enabled: yes
     daemon_reload: "{{ usb_gadget_template.changed }}"
-
-# This custom USB HID kernel module fixes compatibility issues in pre-boot for
-# OS X systems. The patch already exists in kernal versions >= 5.15.
-# Issue: https://github.com/tiny-pilot/ansible-role-tinypilot/issues/151
-- name: check the HID module file
-  ansible.builtin.stat:
-    path: /lib/modules/{{ ansible_kernel }}/kernel/drivers/usb/gadget/function/usb_f_hid.ko
-    checksum_algorithm: sha256
-  register: hid_module_stat
-
-- name: save whether the HID module should be patched
-  set_fact:
-    patch_hid_module: >-
-      {{ ansible_kernel is version('5.15', '<')
-         and ansible_kernel is version('5.10', '>=')
-         and hid_module_stat.stat.checksum is defined
-         and hid_module_stat.stat.checksum != '45f9c885e8b0e1d2fdaf4aec2179a38ad9a1c76c71f44c997c99a865fdfe72d7' }}
-
-- name: ensure HID module is not in use
-  service:
-    name: usb-gadget
-    state: stopped
-  when: patch_hid_module and not reboot_required
-
-- name: unload HID module
-  command: modprobe --remove usb_f_hid
-  when: patch_hid_module and not reboot_required
-
-- name: patch HID module
-  get_url:
-    url: https://github.com/tiny-pilot/hid-backport/raw/master/bin/usb_f_hid.ko
-    dest: "{{ hid_module_stat.stat.path }}"
-    mode: "0644"
-    force: yes
-  when: patch_hid_module
-
-- name: load HID module
-  command: modprobe usb_f_hid
-  when: patch_hid_module and not reboot_required
-  notify:
-    - start usb-gadget service


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1311
Dependent on https://github.com/tiny-pilot/tinypilot/issues/1348

Now that we've dropped support for Debian Buster (i.e., kernel versions < 5.15) we no longer need to patch the HID kernel module.

### Notes

This PR (mostly) reverts the [original keyboard HID module patch](https://github.com/tiny-pilot/ansible-role-tinypilot/pull/159/files).