### PR TITLE
Declare Bullseye as the minimum supported version

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See ["TinyPilot: Build a KVM Over IP for Under \$100"](https://mtlynch.io/tinypi
 
 ## Pre-requisites
 
-- Raspberry Pi OS Buster or later (32-bit)
+- Raspberry Pi OS Bullseye (32-bit)
 - python3-venv
 
 ## Simple installation

--- a/ansible-role/meta/main.yml
+++ b/ansible-role/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - buster
+        - bullseye
     - name: Ubuntu
       versions:
         - bionic

--- a/debian-pkg/Dockerfile
+++ b/debian-pkg/Dockerfile
@@ -57,7 +57,7 @@ XBS-Tinypilot-Version: ${TINYPILOT_VERSION}
 EOF
 
 RUN cat >changelog <<EOF
-tinypilot (${PKG_VERSION}) buster; urgency=medium
+tinypilot (${PKG_VERSION}) bullseye; urgency=medium
 
   * Latest TinyPilot release.
 


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1348

This PR is a non-functional change that replaces any mention of "buster", in documentation, with "bullseye".

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1358"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>