### PR TITLE
Perform updates/installs in RAMdisk

### DIFF
--- a/bundler/README.md
+++ b/bundler/README.md
@@ -35,9 +35,9 @@ Our CircleCI pipeline automatically builds and uploads new bundles to Gatekeeper
 
 [`get-tinypilot.sh`](../get-tinypilot.sh) (`get-tinypilot-pro.sh` for Pro) facilitates the installation process.
 
-For installing TinyPilot on the device, `get-tinypilot.sh` unpacks the bundle to `/mnt/tinypilot/installer` and invokes the [`install`](bundle/install) script.
+For installing TinyPilot on the device, `get-tinypilot.sh` unpacks the bundle to `/mnt/tinypilot-installer/installer` and invokes the [`install`](bundle/install) script.
 
-To avoid excessive writes to the filesystem, the bundle is downloaded and unpacked on a volatile RAMdisk mounted at `/mnt/tinypilot`.
+To avoid excessive writes to the filesystem, the bundle is downloaded and unpacked on a volatile RAMdisk mounted at `/mnt/tinypilot-installer`.
 
 On a fresh device, the user runs `get-tinypilot.sh` manually. On a device with an existing TinyPilot installation, TinyPilot’s update process invokes `get-tinypilot.sh` “under the hood”.
 
@@ -50,7 +50,7 @@ The installation procedure consists of the following steps. The procedure is sli
 ### TinyPilot Community
 
 1. `get-tinypilot.sh` retrieves latest bundle from Gatekeeper.
-1. `get-tinypilot.sh` unpacks bundle to `/opt/tinypilot-updater` and invokes `install` script.
+2. `get-tinypilot.sh` unpacks bundle to `/mnt/tinypilot-installer/installer` and invokes `install` script.
 
 ### TinyPilot Pro
 

--- a/bundler/README.md
+++ b/bundler/README.md
@@ -35,7 +35,7 @@ Our CircleCI pipeline automatically builds and uploads new bundles to Gatekeeper
 
 [`get-tinypilot.sh`](../get-tinypilot.sh) (`get-tinypilot-pro.sh` for Pro) facilitates the installation process.
 
-For installing TinyPilot on the device, `get-tinypilot.sh` unpacks the bundle to `/mnt/tinypilot-installer/installer` and invokes the [`install`](bundle/install) script.
+For installing TinyPilot on the device, `get-tinypilot.sh` unpacks the bundle to `/mnt/tinypilot-installer` and invokes the [`install`](bundle/install) script.
 
 To avoid excessive writes to the filesystem, the bundle is downloaded and unpacked on a volatile RAMdisk mounted at `/mnt/tinypilot-installer`.
 
@@ -50,7 +50,7 @@ The installation procedure consists of the following steps. The procedure is sli
 ### TinyPilot Community
 
 1. `get-tinypilot.sh` retrieves latest bundle from Gatekeeper.
-2. `get-tinypilot.sh` unpacks bundle to `/mnt/tinypilot-installer/installer` and invokes `install` script.
+2. `get-tinypilot.sh` unpacks bundle to `/mnt/tinypilot-installer` and invokes `install` script.
 
 ### TinyPilot Pro
 

--- a/bundler/README.md
+++ b/bundler/README.md
@@ -35,9 +35,9 @@ Our CircleCI pipeline automatically builds and uploads new bundles to Gatekeeper
 
 [`get-tinypilot.sh`](../get-tinypilot.sh) (`get-tinypilot-pro.sh` for Pro) facilitates the installation process.
 
-For installing TinyPilot on the device, `get-tinypilot.sh` unpacks the bundle to `/opt/tinypilot-updater` and invokes the [`install`](bundle/install) script.
+For installing TinyPilot on the device, `get-tinypilot.sh` unpacks the bundle to `/mnt/tinypilot/installer` and invokes the [`install`](bundle/install) script.
 
-Note that it’s necessary to persist the bundle folder on the device, because the application still relies on the Ansible roles being present for applying system changes. (We might refactor this in the future.)
+To avoid excessive writes to the filesystem, the bundle is downloaded and unpacked on a volatile RAMdisk mounted at `/mnt/tinypilot`.
 
 On a fresh device, the user runs `get-tinypilot.sh` manually. On a device with an existing TinyPilot installation, TinyPilot’s update process invokes `get-tinypilot.sh` “under the hood”.
 

--- a/bundler/verify-bundle
+++ b/bundler/verify-bundle
@@ -35,6 +35,14 @@ tar \
   --directory "${BUNDLE_DIR}"
 pushd "${BUNDLE_DIR}"
 
+# Check extracted bundle directory size.
+BUNDLE_DIR_SIZE_BYTES="$(du --summarize --bytes "${BUNDLE_DIR}" | cut --fields 1)"
+readonly BUNDLE_DIR_SIZE_BYTES
+if [[ "${BUNDLE_DIR_SIZE_BYTES}" -gt 500000000 ]]; then
+  >&2 echo "Bundle directory size is larger than 500mb, which exceeds the size of the installer's RAMdisk"
+  exit 1
+fi
+
 # Check that install script exists.
 if [[ ! -f install ]]; then
   >&2 echo 'Bundle is missing install script.'

--- a/bundler/verify-bundle
+++ b/bundler/verify-bundle
@@ -35,14 +35,6 @@ tar \
   --directory "${BUNDLE_DIR}"
 pushd "${BUNDLE_DIR}"
 
-# Check extracted bundle directory size.
-BUNDLE_DIR_SIZE_BYTES="$(du --summarize --bytes "${BUNDLE_DIR}" | cut --fields 1)"
-readonly BUNDLE_DIR_SIZE_BYTES
-if [[ "${BUNDLE_DIR_SIZE_BYTES}" -gt 500000000 ]]; then
-  >&2 echo "Bundle directory size is larger than 500mb, which exceeds the size of the installer's RAMdisk"
-  exit 1
-fi
-
 # Check that install script exists.
 if [[ ! -f install ]]; then
   >&2 echo 'Bundle is missing install script.'

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -54,10 +54,10 @@ if [[ "${HAS_PRO_INSTALLED}" = 1 ]]; then
   fi
 fi
 
+readonly LEGACY_INSTALLER_DIR='/opt/tinypilot-updater'
 readonly RAMDISK_DIR='/mnt/tinypilot-installer'
 readonly BUNDLE_FILE="${RAMDISK_DIR}/bundle.tgz"
 readonly INSTALLER_DIR="${RAMDISK_DIR}/installer"
-readonly LEGACY_INSTALLER_DIR='/opt/tinypilot-updater'
 
 # Remove temporary files & directories.
 clean_up() {

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -54,7 +54,14 @@ if [[ "${HAS_PRO_INSTALLED}" = 1 ]]; then
   fi
 fi
 
+# Historically, the TinyPilot bundle was unpacked to the device's disk, where it
+# persisted. Since the, we've moved to the use of a volatile RAMdisk, which
+# avoids excessive writes to the filesystem. As a result, this legacy installer
+# directory has been orphaned and is now removed as part of this script's
+# `clean_up` function.
+# https://github.com/tiny-pilot/tinypilot/issues/1357
 readonly LEGACY_INSTALLER_DIR='/opt/tinypilot-updater'
+
 readonly RAMDISK_DIR='/mnt/tinypilot-installer'
 readonly BUNDLE_FILE="${RAMDISK_DIR}/bundle.tgz"
 readonly INSTALLER_DIR="${RAMDISK_DIR}/installer"

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -65,11 +65,13 @@ readonly LEGACY_INSTALLER_DIR='/opt/tinypilot-updater'
 readonly INSTALLER_DIR='/mnt/tinypilot-installer'
 readonly BUNDLE_FILE="${INSTALLER_DIR}/bundle.tgz"
 
-# The RAMdisk size is based on the combined size of the following elements:
+# The RAMdisk size is broadly based on the combined size of the following:
 # - The TinyPilot bundle archive
 # - The unpacked TinyPilot bundle archive, after running the bundle's `install`
 #     script
-# - At least a 10% safety margin
+# - At least a 20% safety margin
+# Use the following command to help you estimate a sensible size allocation:
+#   du --summarize --total --bytes "${INSTALLER_DIR}" "${BUNDLE_FILE}"
 readonly RAMDISK_SIZE='500m'
 
 # Remove temporary files & directories.

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -66,6 +66,13 @@ readonly RAMDISK_DIR='/mnt/tinypilot-installer'
 readonly BUNDLE_FILE="${RAMDISK_DIR}/bundle.tgz"
 readonly INSTALLER_DIR="${RAMDISK_DIR}/installer"
 
+# The RAMdisk size is based on the combined size of the following elements:
+# - The TinyPilot bundle archive
+# - The unpacked TinyPilot bundle archive, after running the bundle's `install`
+#     script
+# - At least a 10% safety margin
+readonly RAMDISK_SIZE='500m'
+
 # Remove temporary files & directories.
 clean_up() {
   umount --lazy "${RAMDISK_DIR}" || true
@@ -88,7 +95,7 @@ trap 'clean_up' EXIT
 sudo mkdir "${RAMDISK_DIR}"
 sudo mount \
   --types tmpfs \
-  --options size=500m \
+  --options "size=${RAMDISK_SIZE}" \
   --source tmpfs \
   --target "${RAMDISK_DIR}" \
   --verbose

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -62,9 +62,8 @@ fi
 # https://github.com/tiny-pilot/tinypilot/issues/1357
 readonly LEGACY_INSTALLER_DIR='/opt/tinypilot-updater'
 
-readonly RAMDISK_DIR='/mnt/tinypilot-installer'
-readonly BUNDLE_FILE="${RAMDISK_DIR}/bundle.tgz"
-readonly INSTALLER_DIR="${RAMDISK_DIR}/installer"
+readonly INSTALLER_DIR='/mnt/tinypilot-installer'
+readonly BUNDLE_FILE="${INSTALLER_DIR}/bundle.tgz"
 
 # The RAMdisk size is based on the combined size of the following elements:
 # - The TinyPilot bundle archive
@@ -75,10 +74,10 @@ readonly RAMDISK_SIZE='500m'
 
 # Remove temporary files & directories.
 clean_up() {
-  umount --lazy "${RAMDISK_DIR}" || true
+  umount --lazy "${INSTALLER_DIR}" || true
   rm -rf \
     "${LEGACY_INSTALLER_DIR}" \
-    "${RAMDISK_DIR}"
+    "${INSTALLER_DIR}"
 }
 
 # Always clean up before exiting.
@@ -92,12 +91,12 @@ trap 'clean_up' EXIT
 # altogether, the possibility of using swap space is an acceptable compromise in
 # exchange for limiting memory usage.
 # https://github.com/tiny-pilot/tinypilot/issues/1357
-sudo mkdir "${RAMDISK_DIR}"
+sudo mkdir "${INSTALLER_DIR}"
 sudo mount \
   --types tmpfs \
   --options "size=${RAMDISK_SIZE}" \
   --source tmpfs \
-  --target "${RAMDISK_DIR}" \
+  --target "${INSTALLER_DIR}" \
   --verbose
 
 # Download tarball to RAMdisk.
@@ -114,7 +113,6 @@ fi
 
 # Extract tarball to installer directory. The installer directory and all its
 # content must have root ownership.
-sudo mkdir "${INSTALLER_DIR}"
 sudo tar \
   --gunzip \
   --extract \

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -74,7 +74,7 @@ trap 'clean_up' EXIT
 sudo mkdir "${RAMDISK_DIR}"
 sudo mount \
   --types tmpfs \
-  --options size=1g \
+  --options size=500m \
   --source tmpfs \
   --target "${RAMDISK_DIR}" \
   --verbose

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -57,11 +57,14 @@ fi
 readonly RAMDISK_DIR='/mnt/tinypilot-installer'
 readonly BUNDLE_FILE="${RAMDISK_DIR}/bundle.tgz"
 readonly INSTALLER_DIR="${RAMDISK_DIR}/installer"
+readonly LEGACY_INSTALLER_DIR='/opt/tinypilot-updater'
 
 # Remove temporary files & directories.
 clean_up() {
   umount --lazy "${RAMDISK_DIR}" || true
-  rm -rf "${RAMDISK_DIR}"
+  rm -rf \
+    "${LEGACY_INSTALLER_DIR}" \
+    "${RAMDISK_DIR}"
 }
 
 # Always clean up before exiting.

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -55,7 +55,7 @@ if [[ "${HAS_PRO_INSTALLED}" = 1 ]]; then
 fi
 
 # Historically, the TinyPilot bundle was unpacked to the device's disk, where it
-# persisted. Since the, we've moved to the use of a volatile RAMdisk, which
+# persisted. Since then, we've moved to the use of a volatile RAMdisk, which
 # avoids excessive writes to the filesystem. As a result, this legacy installer
 # directory has been orphaned and is now removed as part of this script's
 # `clean_up` function.

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -78,6 +78,13 @@ clean_up() {
 trap 'clean_up' EXIT
 
 # Mount volatile RAMdisk.
+# Note: `tmpfs` can use swap space when the device's physical memory is under
+# pressure. Alternatively, we could use `ramfs` which doesn't use swap space,
+# but also doesn't enforce a filesystem size limit, unlike `tmpfs`. Considering
+# that our goal is to reduce disk writes and not necessarily eliminate them
+# altogether, the possibility of using swap space is an acceptable compromise in
+# exchange for limiting memory usage.
+# https://github.com/tiny-pilot/tinypilot/issues/1357
 sudo mkdir "${RAMDISK_DIR}"
 sudo mount \
   --types tmpfs \

--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -69,11 +69,29 @@ else
   readonly BUNDLE_FILE_PATH="${BUNDLE_PATH}"
 fi
 
-readonly INSTALLER_DIR='/opt/tinypilot-updater'
+readonly RAMDISK_DIR='/mnt/tinypilot-installer'
+readonly INSTALLER_DIR="${RAMDISK_DIR}/installer"
+
+# Remove temporary files & directories.
+clean_up() {
+  umount --lazy "${RAMDISK_DIR}" || true
+  rm -rf "${RAMDISK_DIR}"
+}
+
+# Always clean up before exiting.
+trap 'clean_up' EXIT
+
+# Mount volatile RAMdisk.
+mkdir "${RAMDISK_DIR}"
+mount \
+  --types tmpfs \
+  --options size=1g \
+  --source tmpfs \
+  --target "${RAMDISK_DIR}" \
+  --verbose
 
 # Extract tarball to installer directory.
-rm -rf "${INSTALLER_DIR}"
-mkdir -p "${INSTALLER_DIR}"
+mkdir "${INSTALLER_DIR}"
 tar \
   --gunzip \
   --extract \

--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -70,31 +70,29 @@ else
 fi
 
 readonly LEGACY_INSTALLER_DIR='/opt/tinypilot-updater'
-readonly RAMDISK_DIR='/mnt/tinypilot-installer'
-readonly INSTALLER_DIR="${RAMDISK_DIR}/installer"
+readonly INSTALLER_DIR='/mnt/tinypilot-installer'
 
 # Remove temporary files & directories.
 clean_up() {
-  umount --lazy "${RAMDISK_DIR}" || true
+  umount --lazy "${INSTALLER_DIR}" || true
   rm -rf \
     "${LEGACY_INSTALLER_DIR}" \
-    "${RAMDISK_DIR}"
+    "${INSTALLER_DIR}"
 }
 
 # Always clean up before exiting.
 trap 'clean_up' EXIT
 
 # Mount volatile RAMdisk.
-mkdir "${RAMDISK_DIR}"
+mkdir "${INSTALLER_DIR}"
 mount \
   --types tmpfs \
   --options size=500m \
   --source tmpfs \
-  --target "${RAMDISK_DIR}" \
+  --target "${INSTALLER_DIR}" \
   --verbose
 
 # Extract tarball to installer directory.
-mkdir "${INSTALLER_DIR}"
 tar \
   --gunzip \
   --extract \

--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -69,13 +69,16 @@ else
   readonly BUNDLE_FILE_PATH="${BUNDLE_PATH}"
 fi
 
+readonly LEGACY_INSTALLER_DIR='/opt/tinypilot-updater'
 readonly RAMDISK_DIR='/mnt/tinypilot-installer'
 readonly INSTALLER_DIR="${RAMDISK_DIR}/installer"
 
 # Remove temporary files & directories.
 clean_up() {
   umount --lazy "${RAMDISK_DIR}" || true
-  rm -rf "${RAMDISK_DIR}"
+  rm -rf \
+    "${LEGACY_INSTALLER_DIR}" \
+    "${RAMDISK_DIR}"
 }
 
 # Always clean up before exiting.

--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -88,7 +88,7 @@ trap 'clean_up' EXIT
 mkdir "${RAMDISK_DIR}"
 mount \
   --types tmpfs \
-  --options size=1g \
+  --options size=500m \
   --source tmpfs \
   --target "${RAMDISK_DIR}" \
   --verbose

--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -71,6 +71,7 @@ fi
 
 readonly LEGACY_INSTALLER_DIR='/opt/tinypilot-updater'
 readonly INSTALLER_DIR='/mnt/tinypilot-installer'
+readonly RAMDISK_SIZE='500m'
 
 # Remove temporary files & directories.
 clean_up() {
@@ -87,7 +88,7 @@ trap 'clean_up' EXIT
 mkdir "${INSTALLER_DIR}"
 mount \
   --types tmpfs \
-  --options size=500m \
+  --options "size=${RAMDISK_SIZE}" \
   --source tmpfs \
   --target "${INSTALLER_DIR}" \
   --verbose


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1357
Blocked on https://github.com/tiny-pilot/tinypilot-pro/issues/775

To avoid excessive writes to the filesystem that could cause filesystem corruption, we now download and unpack the TinyPilot bundle to a temporary in-memory filesystem (i.e., RAMdisk).

### Notes

1. The RAMdisk is mounted at `/mnt/tinypilot-installer`. This means that the installer directory (i.e., the directory where the bundle is unpacked to) has been changed from `/opt/tinypilot-updater` to `/mnt/tinypilot-installer`. I thought it would be best to namespace the mount point with "-installer" to not clash with future possible TinyPilot filesystems.

1. All files in the RAMdisk is removed when the filesystem is unmounted. So during the install clean-up we use [`umount --lazy`](https://github.com/tiny-pilot/tinypilot/pull/1360/files#diff-27b61adb9d4cb364efeb0a1678eac61720021d2f227752b99026f619d6694f5aR64) to unmount the RAMdisk once the last open file is closed to avoid getting a "device busy" error.
1. The size of the installer directory (post-install) and bundle file, combined, is between 400-500mb. So the RAMdisk has been [provisioned to 500mb](https://github.com/tiny-pilot/tinypilot/pull/1360/files#diff-27b61adb9d4cb364efeb0a1678eac61720021d2f227752b99026f619d6694f5aR77).
    ```bash
    $ du -sh /opt/tinypilot-updater
    416M	/opt/tinypilot-updater
    $ du -sh tinypilot-community-20230411T1256Z-1.8.2-28+ccf10a4.tgz
    648K	tinypilot-community-20230411T1256Z-1.8.2-28+ccf10a4.tgz
    ```
    I [wanted to add a check](https://github.com/tiny-pilot/tinypilot/pull/1360/commits/ee065490294f9fbe1631e5a913bd8fc3e29b86c6) to ensure that we don't unknowingly exceed the RAMdisk limit of 500mb, but we currently don't run an e2e test that installs the bundle (and downloads all dependencies) in CI. So I dropped that check.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1360"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>