### PR TITLE
Prevent installation on OS versions lower than Raspberry Pi OS 11 "Bullseye"

### DIFF
--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -47,6 +47,12 @@ if grep -q "^Model *: Raspberry Pi 3" /proc/cpuinfo ; then
   exit 1
 fi
 
+# Prevent installation on OS versions lower than Raspberry Pi OS 11 "Bullseye".
+if [[ "$(lsb_release --release --short)" -lt 11 ]]; then
+  echo "TinyPilot no longer supports Raspberry Pi OS 10 \"Buster\"." >&2
+  echo "To install TinyPilot, you'll need to upgrade your operating system to Raspberry Pi OS 11 \"Bullseye\"." >&2
+fi
+
 # Abort installation if the read-only filesystem is enabled
 if grep -q "boot=overlay" /proc/cmdline ; then
   echo 'The read-only filesystem is enabled.' >&2

--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -49,7 +49,7 @@ fi
 
 # Prevent installation on OS versions lower than Raspberry Pi OS 11 "Bullseye".
 if [[ "$(lsb_release --release --short)" -lt 11 ]]; then
-  echo "TinyPilot no longer supports Raspberry Pi OS 10 \"Buster\"." >&2
+  echo "TinyPilot no longer supports Raspberry Pi OS 10 \"Buster\" or lower." >&2
   echo "To install TinyPilot, you'll need to upgrade your operating system to Raspberry Pi OS 11 \"Bullseye\"." >&2
 fi
 


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1361
Dependent on https://github.com/tiny-pilot/tinypilot/pull/1358

### Notes

I have slightly extended the suggested error message (https://github.com/tiny-pilot/tinypilot/commit/936ef9be2586d914dc85c7a3c8d5f7139b2ab07e). 
