### PR TITLE
Use default font family for on-screen keyboard

### DIFF
--- a/app/templates/custom-elements/key.html
+++ b/app/templates/custom-elements/key.html
@@ -6,6 +6,7 @@
       float: left;
       width: 50px;
       height: 50px;
+      font-family: "Overpass", sans-serif;
       font-size: 12px;
       background-color: #fff;
       line-height: 16px;


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot/issues/1304.

The key labels of our on-screen keyboard used to be rendered in the system’s default `sans-serif` font, e.g. Arial. This PR fixes this, and make all keys render in our default font family “Overpass”. That way, the on-screen keyboard is in line with the rest of the app.

Note that the font family definition usually comes to the frontend components via the `@import "css/style.css"` directive, so we normally don’t have to specify the font explicitly. We cannot do this here, however, because `style.css` would then also override all button styles.

<img width="1037" alt="Screenshot 2023-04-20 at 14 54 58" src="https://user-images.githubusercontent.com/83721279/233372315-24d375e4-b62f-42ba-8c8d-d7dcf3902655.png">

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1366"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>