### PR TITLE
Simplify keyboard-block sizing

### DIFF
--- a/app/templates/custom-elements/key.html
+++ b/app/templates/custom-elements/key.html
@@ -8,8 +8,6 @@
 
     .key {
       position: relative;
-      display: block;
-      float: left;
       width: var(--width);
       height: var(--width);
       font-family: "Overpass", sans-serif;

--- a/app/templates/custom-elements/on-screen-keyboard.html
+++ b/app/templates/custom-elements/on-screen-keyboard.html
@@ -1,16 +1,8 @@
 <template id="on-screen-keyboard-template">
   <style>
-    :host {
-      /* Note: the --key-size needs to be in line with the width and margin of
-         the individual <key> component. */
-      --key-size: 46px;
-      --block-spacing: 8px;
-    }
-
     .keyboard {
-      --width: calc(21 * var(--key-size) + 6 * var(--block-spacing));
-      width: var(--width);
-      min-width: var(--width);
+      display: inline-flex;
+      gap: 14px;
       background-color: #f7f7f7;
       margin: 1rem auto;
       padding: 14px;
@@ -19,32 +11,16 @@
     }
 
     .keyboard-block {
-      display: inline-block;
-    }
-
-    #keyboard-block-left {
-      margin-right: var(--block-spacing);
-      width: calc(var(--key-size) * 3);
-    }
-
-    #keyboard-block-middle {
-      margin-left: var(--block-spacing);
-      margin-right: var(--block-spacing);
-      width: calc(var(--key-size) * 15);
-    }
-
-    #keyboard-block-right {
-      margin-left: var(--block-spacing);
-      width: calc(var(--key-size) * 3);
+      display: flex;
+      flex-direction: column;
     }
 
     .keyboard-row {
-      width: 100%;
-      float: left;
+      display: flex;
     }
   </style>
   <div class="keyboard">
-    <div id="keyboard-block-left" class="keyboard-block">
+    <div class="keyboard-block">
       <div class="keyboard-row">
         <keyboard-key class="hidden"></keyboard-key>
         <keyboard-key class="hidden"></keyboard-key>
@@ -77,7 +53,7 @@
       <!-- end keyboard-row -->
     </div>
 
-    <div id="keyboard-block-middle" class="keyboard-block">
+    <div class="keyboard-block">
       <div class="keyboard-row">
         <keyboard-key code="Backquote">
           <slot>~</slot>
@@ -272,7 +248,7 @@
       <!-- end keyboard-row -->
     </div>
 
-    <div id="keyboard-block-right" class="keyboard-block">
+    <div class="keyboard-block">
       <div class="keyboard-row">
         <keyboard-key code="PrintScreen">Print</keyboard-key>
         <keyboard-key code="ScrollLock">Scroll Lock</keyboard-key>


### PR DESCRIPTION
While reviewing https://github.com/tiny-pilot/tinypilot/pull/1369, I noticed a strange margin spacing between the [`.keyboard-block`](https://github.com/tiny-pilot/tinypilot/blob/de9ecd21954d6f4f38f7c01b954f9aade829c428/app/templates/custom-elements/on-screen-keyboard.html#L47)'s. Even when setting `margin: 0` there's still a slight gap. I'm not sure where this spacing is coming from. In the video below, notice the margin (i.e., orange area) around the `.keyboard-block`s that doesn't quite meet each other:

https://user-images.githubusercontent.com/6730025/233676804-638594d0-dd9d-47b9-bf8e-f4533eb15e0b.mov

This PR attempts to simplify the `.keyboard-block` sizing (i.e., width, margin) by acting as a flexible wrapper around the keys and relying on the individual key size to determine the ultimate keyboard size.

The result:
<img width="1063" alt="Screen Shot 2023-04-21 at 17 14 58" src="https://user-images.githubusercontent.com/6730025/233672833-c30431a1-24d0-4ef5-b262-55dec4857040.png">

When inspecting the keyboard, it's a bit easier to see how the spacing works:
<img width="1071" alt="Screen Shot 2023-04-21 at 17 14 43" src="https://user-images.githubusercontent.com/6730025/233672866-c1e82c7f-ea66-4b2b-b461-a88e1b12fab7.png">
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1370"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>