### PR TITLE
Explicitly require sudo for enable-mock-scripts

### DIFF
--- a/dev-scripts/enable-mock-scripts
+++ b/dev-scripts/enable-mock-scripts
@@ -6,6 +6,13 @@
 # Exit build script on first failure.
 set -e
 
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "This script requires root privileges." >&2
+  echo "Please re-run with sudo:" >&2
+  echo "  sudo ${0}" >&2
+  exit 1
+fi
+
 # Echo commands before executing them, by default to stderr.
 set -x
 


### PR DESCRIPTION
We expect developers to run `enable-mock-scripts` using sudo, but we don't include our standard `EUID` check at the top of the file to prevent users from accidentally running without sudo. If the user runs the script without sudo, they'll likely hit a non-obvious error about file permissions.

This change adds an explicit check in `enable-mock-scripts ` that the developer executed it with sudo. If a developer runs the script without sudo permissions, they'll see a clear error message telling them to re-run with sudo.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1378"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>