### PR TITLE
Remove 'Error: ' prefix from stderr messages

### DIFF
--- a/dev-scripts/check-trailing-whitespace
+++ b/dev-scripts/check-trailing-whitespace
@@ -15,7 +15,7 @@ while read -r line; do
     --binary-files=without-match \
     --exclude="*third-party*" \
     "${line}"; then
-    echo "ERROR: Found trailing whitespace";
+    echo "Found trailing whitespace" >&2 ;
     exit 1;
   fi
 done < <(git ls-files)

--- a/dev-scripts/enable-mock-scripts
+++ b/dev-scripts/enable-mock-scripts
@@ -21,7 +21,7 @@ readonly MOCK_SCRIPTS_DIR="${SCRIPT_DIR}/mock-scripts"
 if [[ -L "${PRIVILEGED_SCRIPTS_DIR}" ]]; then
   rm "${PRIVILEGED_SCRIPTS_DIR}"
 elif [[ -d "${PRIVILEGED_SCRIPTS_DIR}" ]]; then
-  echo "Error: ${PRIVILEGED_SCRIPTS_DIR} exists and is not a symlink" >&2
+  echo "${PRIVILEGED_SCRIPTS_DIR} exists and is not a symlink" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Our convention for messages printed to stderr is to omit any prefixes:

>Error messages don't have any prefixes like ERROR: or WARNING:.

https://github.com/tiny-pilot/style-guides#error-messages

To observe our style conventions more consistently, this change removes an "error" prefix from two error message.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1379"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>