### PR TITLE
Limit installer's OS version check to Raspbian only

### DIFF
--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -48,7 +48,8 @@ if grep -q "^Model *: Raspberry Pi 3" /proc/cpuinfo ; then
 fi
 
 # Prevent installation on OS versions lower than Raspberry Pi OS 11 "Bullseye".
-if (( "$(lsb_release --release --short)" < 11 )); then
+if [[ "$(lsb_release --id --short)" == 'Raspbian' ]] \
+    && (( "$(lsb_release --release --short)" < 11 )); then
   echo "TinyPilot no longer supports Raspberry Pi OS 10 \"Buster\" or lower." >&2
   echo "To install TinyPilot, you'll need to upgrade your operating system to Raspberry Pi OS 11 \"Bullseye\"." >&2
   exit 1

--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -51,7 +51,7 @@ fi
 # Note: the distro ID is called "Raspbian" because the 32-bit version of the
 # Raspberry Pi operating system is based on Raspbian repos (an independent
 # open-source project). Similarly, the the 64-bit version of the Raspberry Pi
-# operating system is based on Debian and it's distro ID would be "Debian".
+# operating system is based on Debian and its distro ID would be "Debian".
 if [[ "$(lsb_release --id --short)" == 'Raspbian' ]] \
     && (( "$(lsb_release --release --short)" < 11 )); then
   echo "TinyPilot no longer supports Raspberry Pi OS 10 \"Buster\" or lower." >&2

--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -48,6 +48,10 @@ if grep -q "^Model *: Raspberry Pi 3" /proc/cpuinfo ; then
 fi
 
 # Prevent installation on OS versions lower than Raspberry Pi OS 11 "Bullseye".
+# Note: the distro ID is called "Raspbian" because the 32-bit version of the
+# Raspberry Pi operating system is based on Raspbian repos (an independent
+# open-source project). Similarly, the the 64-bit version of the Raspberry Pi
+# operating system is based on Debian and it's distro ID would be "Debian".
 if [[ "$(lsb_release --id --short)" == 'Raspbian' ]] \
     && (( "$(lsb_release --release --short)" < 11 )); then
   echo "TinyPilot no longer supports Raspberry Pi OS 10 \"Buster\" or lower." >&2


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1361#issuecomment-1522489669 (again 🤭)


<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1380"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>