### PR TITLE
Keyboard overflow without calculating the width

### DIFF
--- a/app/templates/custom-elements/on-screen-keyboard.html
+++ b/app/templates/custom-elements/on-screen-keyboard.html
@@ -5,24 +5,19 @@
     :host {
       --key-size: 46px; /* Must be divisible by 2 */
       --block-spacing: 8px;
-      --keyboard-width: calc(21 * var(--key-size) + 8 * var(--block-spacing));
       --keyboard-height: calc(5 * var(--key-size) + 2 * var(--block-spacing));
 
+      display: flex;
       position: fixed;
       bottom: 31px; /* Same as status bar height */
       right: 0;
       left: 0;
       margin: 0 auto;
       transition: 0.5s;
-      max-width: var(--keyboard-width);
       /* If the viewport width is too small to fit the full keyboard, we make
          the keyboard drawer horizontally scrollable. We only want to show the
          scroll bar, however, if scrolling is actually applicable. */
       overflow-x: auto;
-      border: 1px solid #333;
-      border-bottom: 0;
-      border-top-left-radius: var(--border-radius);
-      border-top-right-radius: var(--border-radius);
     }
 
     :host(:not([is-shown])) {
@@ -45,10 +40,16 @@
 
     .keyboard {
       display: flex;
+      position: relative;
+      margin: 0 auto;
       box-sizing: border-box;
       background-color: #f7f7f7;
       padding: var(--block-spacing);
       color: #333;
+      border: 1px solid #333;
+      border-bottom: 0;
+      border-top-left-radius: var(--border-radius);
+      border-top-right-radius: var(--border-radius);
     }
 
     .keyboard-block {
@@ -69,12 +70,12 @@
       padding: 1px;
     }
   </style>
-  <img
-    src="/img/angle-down-icon.svg"
-    id="collapse-button"
-    title="Collapse Keyboard"
-  />
   <div class="keyboard">
+    <img
+      src="/img/angle-down-icon.svg"
+      id="collapse-button"
+      title="Collapse Keyboard"
+    />
     <div class="keyboard-block" style="--columns: 3;">
       <keyboard-key class="hidden"></keyboard-key>
       <keyboard-key class="hidden"></keyboard-key>

--- a/app/templates/custom-elements/on-screen-keyboard.html
+++ b/app/templates/custom-elements/on-screen-keyboard.html
@@ -14,6 +14,7 @@
       left: 0;
       margin: 0 auto;
       transition: 0.5s;
+      max-width: fit-content;
       /* If the viewport width is too small to fit the full keyboard, we make
          the keyboard drawer horizontally scrollable. We only want to show the
          scroll bar, however, if scrolling is actually applicable. */
@@ -32,6 +33,7 @@
       background-color: #333;
       padding: 4px 8px;
       cursor: pointer;
+      border-top-left-radius: var(--border-radius);
     }
 
     #collapse-button:hover {
@@ -40,8 +42,6 @@
 
     .keyboard {
       display: flex;
-      position: relative;
-      margin: 0 auto;
       box-sizing: border-box;
       background-color: #f7f7f7;
       padding: var(--block-spacing);


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot/issues/1304

This PR is to address the following keyboard overflow bug:
<img width="841" alt="Screen Shot 2023-04-29 at 10 25 25" src="https://user-images.githubusercontent.com/6730025/235292833-46319ade-20dd-436a-a946-34255ae6fa5e.png">


Also, as mentioned in https://github.com/tiny-pilot/tinypilot/pull/1381#issue-1688795641, explore the possibility of achieving keyboard overflow without calculating the full width of the keyboard. Demo:

https://user-images.githubusercontent.com/6730025/235293223-73a0ffc6-8d06-4fe1-985b-d4f7b435fedd.mov

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1382"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>