### PR TITLE
Update comment for set -e to match our new conventions

### DIFF
--- a/dev-scripts/build
+++ b/dev-scripts/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Exit build script on first failure.
+# Exit on first failure.
 set -e
 
 # Echo commands before executing them, by default to stderr.

--- a/dev-scripts/build-debian-pkg
+++ b/dev-scripts/build-debian-pkg
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Exit build script on first failure.
+# Exit on first failure.
 set -e
 
 # Echo commands before executing them, by default to stderr.

--- a/dev-scripts/build-javascript
+++ b/dev-scripts/build-javascript
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Exit build script on first failure.
+# Exit on first failure.
 set -e
 
 # Echo commands before executing them, by default to stderr.

--- a/dev-scripts/build-python
+++ b/dev-scripts/build-python
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Exit build script on first failure.
+# Exit on first failure.
 set -e
 
 # Echo commands before executing them, by default to stderr.

--- a/dev-scripts/check-for-init-py-files
+++ b/dev-scripts/check-for-init-py-files
@@ -2,7 +2,7 @@
 
 # Test if __init__.py file exists in directory containing .py files.
 
-# Exit build script on first failure.
+# Exit on first failure.
 set -e
 # Exit on unset variable.
 set -u

--- a/dev-scripts/check-style
+++ b/dev-scripts/check-style
@@ -2,7 +2,7 @@
 
 # Checks formatting for non-Python files.
 
-# Exit build script on first failure.
+# Exit on first failure.
 set -e
 
 # Echo commands before executing them, by default to stderr.

--- a/dev-scripts/enable-mock-scripts
+++ b/dev-scripts/enable-mock-scripts
@@ -3,7 +3,7 @@
 # Creates a symlink from /opt/tinypilot-privileged/scripts to dev-scripts/mock-scripts
 # to facilitate development on non-TinyPilot systems.
 
-# Exit build script on first failure.
+# Exit on first failure.
 set -e
 
 if [[ "${EUID}" -ne 0 ]]; then

--- a/dev-scripts/fix-style
+++ b/dev-scripts/fix-style
@@ -2,7 +2,7 @@
 
 # Fixes formatting for non-Python files.
 
-# Exit build script on first failure.
+# Exit on first failure.
 set -e
 
 # Echo commands before executing them, by default to stderr.

--- a/dev-scripts/install-from-source
+++ b/dev-scripts/install-from-source
@@ -7,7 +7,7 @@
 # get-tinypilot.sh script in the directory root. TinyPilot Pro users should use
 # get-tinypilot-pro.sh from the licensed URL.
 
-# Exit build script on first failure.
+# Exit on first failure.
 set -e
 
 # Echo commands before executing them, by default to stderr.

--- a/dev-scripts/lint-sql
+++ b/dev-scripts/lint-sql
@@ -2,7 +2,7 @@
 
 # Checks for SQL script anti-patterns.
 
-# Exit build script on first failure.
+# Exit on first failure.
 set -e
 
 # Echo commands before executing them, by default to stderr.

--- a/dev-scripts/remote-scripts/pull
+++ b/dev-scripts/remote-scripts/pull
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Exit build script on first failure.
+# Exit on first failure.
 set -e
 
 # Echo commands before executing them, by default to stderr.

--- a/dev-scripts/serve-dev
+++ b/dev-scripts/serve-dev
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Exit build script on first failure.
+# Exit on first failure.
 set -e
 
 # Echo commands before executing them, by default to stderr.

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Exit build script on first failure.
+# Exit on first failure.
 set -e
 
 # Echo commands before executing them, by default to stderr.


### PR DESCRIPTION
Our official conventions is that the comment above the bash `set -e` command in bash scripts should be more concise and not assume that it's a *build* script:

https://github.com/tiny-pilot/style-guides#options

This change updates all of our bash scripts to match this style rule.