### PR TITLE
Add ESLint rule to prevent parameter reassignment

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,6 +21,7 @@ module.exports = {
     "no-constant-binary-expression": "error",
     "no-duplicate-imports": "error",
     "no-lonely-if": "error",
+    "no-param-reassign": "error",
     "no-unused-private-class-members": "error",
     "no-useless-return": "error",
     "no-var": "error",

--- a/app/templates/custom-elements/on-screen-keyboard.html
+++ b/app/templates/custom-elements/on-screen-keyboard.html
@@ -367,6 +367,7 @@
         }
 
         onKeyClick(key, code, isModifier) {
+          let adjustedKey = key;
           // Make uppercase when shift is active – but only if no other modifier
           // is pressed at the same time.
           if (
@@ -382,13 +383,13 @@
               "ControlRight",
             ].every((m) => !this.isModifierKeyPressed(m))
           ) {
-            key = this.getShiftedKeyValue(key);
+            adjustedKey = this.getShiftedKeyValue(adjustedKey);
           }
 
-          this.emitKeyEvent("keydown", key, code);
+          this.emitKeyEvent("keydown", adjustedKey, code);
 
           if (!isModifier) {
-            this.emitKeyEvent("keyup", key, code);
+            this.emitKeyEvent("keyup", adjustedKey, code);
 
             // Remove pressed state from all modifier keys if non-modifier key
             // was pressed.


### PR DESCRIPTION
We violated this rule in one spot, so I adjusted the code to avoid assigning to a function parameter variable.