### PR TITLE
Fall back to installing from disk when device has insufficient memory 

### DIFF
--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -77,6 +77,19 @@ FREE_MEMORY_MIB="$(free --mebi |
   cut --delimiter ' ' --fields 4)"
 readonly FREE_MEMORY_MIB
 
+INSTALLER_DIR='/mnt/tinypilot-installer'
+
+# Remove temporary files & directories.
+clean_up() {
+  umount --lazy "${INSTALLER_DIR}" || true
+  rm -rf \
+    "${LEGACY_INSTALLER_DIR}" \
+    "${INSTALLER_DIR}"
+}
+
+# Always clean up before exiting.
+trap 'clean_up' EXIT
+
 if (( "${FREE_MEMORY_MIB}" >= "${RAMDISK_SIZE_MIB}" )); then
   # Mount volatile RAMdisk.
   # Note: `tmpfs` can use swap space when the device's physical memory is under
@@ -86,7 +99,6 @@ if (( "${FREE_MEMORY_MIB}" >= "${RAMDISK_SIZE_MIB}" )); then
   # altogether, the possibility of using swap space is an acceptable compromise in
   # exchange for limiting memory usage.
   # https://github.com/tiny-pilot/tinypilot/issues/1357
-  INSTALLER_DIR='/mnt/tinypilot-installer'
   sudo mkdir "${INSTALLER_DIR}"
   sudo mount \
     --types tmpfs \
@@ -101,17 +113,6 @@ fi
 readonly INSTALLER_DIR
 
 readonly BUNDLE_FILE="${INSTALLER_DIR}/bundle.tgz"
-
-# Remove temporary files & directories.
-clean_up() {
-  umount --lazy "${INSTALLER_DIR}" || true
-  rm -rf \
-    "${LEGACY_INSTALLER_DIR}" \
-    "${INSTALLER_DIR}"
-}
-
-# Always clean up before exiting.
-trap 'clean_up' EXIT
 
 # Download tarball to RAMdisk.
 HTTP_CODE="$(curl https://gk.tinypilotkvm.com/community/download/latest \

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -77,6 +77,7 @@ FREE_MEMORY_MIB="$(free --mebi |
   cut --delimiter ' ' --fields 4)"
 readonly FREE_MEMORY_MIB
 
+# Assign a provisional installation directory for our `clean_up` function.
 INSTALLER_DIR='/mnt/tinypilot-installer'
 
 # Remove temporary files & directories.

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -69,15 +69,15 @@ readonly LEGACY_INSTALLER_DIR='/opt/tinypilot-updater'
 # - At least a 20% safety margin
 # Use the following command to help you estimate a sensible size allocation:
 #   du --summarize --total --bytes "${INSTALLER_DIR}" "${BUNDLE_FILE}"
-readonly RAMDISK_SIZE_MI=500
+readonly RAMDISK_SIZE_MIB=500
 
-FREE_MEMORY_MI="$(free --mebi |
+FREE_MEMORY_MIB="$(free --mebi |
   grep --fixed-strings 'Mem:' |
   tr --squeeze-repeats ' ' |
   cut --delimiter ' ' --fields 4)"
-readonly FREE_MEMORY_MI
+readonly FREE_MEMORY_MIB
 
-if (( "${FREE_MEMORY_MI}" > "${RAMDISK_SIZE_MI}" )); then
+if (( "${FREE_MEMORY_MIB}" > "${RAMDISK_SIZE_MIB}" )); then
   # Mount volatile RAMdisk.
   # Note: `tmpfs` can use swap space when the device's physical memory is under
   # pressure. Alternatively, we could use `ramfs` which doesn't use swap space,
@@ -90,7 +90,7 @@ if (( "${FREE_MEMORY_MI}" > "${RAMDISK_SIZE_MI}" )); then
   sudo mkdir "${INSTALLER_DIR}"
   sudo mount \
     --types tmpfs \
-    --options "size=${RAMDISK_SIZE_MI}m" \
+    --options "size=${RAMDISK_SIZE_MIB}m" \
     --source tmpfs \
     --target "${INSTALLER_DIR}" \
     --verbose

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -90,6 +90,8 @@ clean_up() {
 # Always clean up before exiting.
 trap 'clean_up' EXIT
 
+# Determine the installation directory. Use RAMdisk if there is enough memory,
+# otherwise, fall back to regular disk.
 if (( "${FREE_MEMORY_MIB}" >= "${RAMDISK_SIZE_MIB}" )); then
   # Mount volatile RAMdisk.
   # Note: `tmpfs` can use swap space when the device's physical memory is under

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -95,6 +95,7 @@ if (( "${FREE_MEMORY_MIB}" >= "${RAMDISK_SIZE_MIB}" )); then
     --target "${INSTALLER_DIR}" \
     --verbose
 else
+  # Fallback to installing from disk.
   INSTALLER_DIR="$(mktemp --directory)"
 fi
 readonly INSTALLER_DIR

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -77,7 +77,7 @@ FREE_MEMORY_MIB="$(free --mebi |
   cut --delimiter ' ' --fields 4)"
 readonly FREE_MEMORY_MIB
 
-if (( "${FREE_MEMORY_MIB}" > "${RAMDISK_SIZE_MIB}" )); then
+if (( "${FREE_MEMORY_MIB}" >= "${RAMDISK_SIZE_MIB}" )); then
   # Mount volatile RAMdisk.
   # Note: `tmpfs` can use swap space when the device's physical memory is under
   # pressure. Alternatively, we could use `ramfs` which doesn't use swap space,

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -110,7 +110,7 @@ if (( "${FREE_MEMORY_MIB}" >= "${RAMDISK_SIZE_MIB}" )); then
     --target "${INSTALLER_DIR}" \
     --verbose
 else
-  # Fallback to installing from disk.
+  # Fall back to installing from disk.
   INSTALLER_DIR="$(mktemp --directory)"
 fi
 readonly INSTALLER_DIR

--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -78,6 +78,7 @@ FREE_MEMORY_MIB="$(free --mebi |
   cut --delimiter ' ' --fields 4)"
 readonly FREE_MEMORY_MIB
 
+# Assign a provisional installation directory for our `clean_up` function.
 INSTALLER_DIR='/mnt/tinypilot-installer'
 
 # Remove temporary files & directories.

--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -70,8 +70,29 @@ else
 fi
 
 readonly LEGACY_INSTALLER_DIR='/opt/tinypilot-updater'
-readonly INSTALLER_DIR='/mnt/tinypilot-installer'
-readonly RAMDISK_SIZE='500m'
+readonly RAMDISK_SIZE_MIB=500
+
+FREE_MEMORY_MIB="$(free --mebi |
+  grep --fixed-strings 'Mem:' |
+  tr --squeeze-repeats ' ' |
+  cut --delimiter ' ' --fields 4)"
+readonly FREE_MEMORY_MIB
+
+if (( "${FREE_MEMORY_MIB}" >= "${RAMDISK_SIZE_MIB}" )); then
+  # Mount volatile RAMdisk.
+  INSTALLER_DIR='/mnt/tinypilot-installer'
+  sudo mkdir "${INSTALLER_DIR}"
+  sudo mount \
+    --types tmpfs \
+    --options "size=${RAMDISK_SIZE_MIB}m" \
+    --source tmpfs \
+    --target "${INSTALLER_DIR}" \
+    --verbose
+else
+  # Fallback to installing from disk.
+  INSTALLER_DIR="$(mktemp --directory)"
+fi
+readonly INSTALLER_DIR
 
 # Remove temporary files & directories.
 clean_up() {
@@ -83,15 +104,6 @@ clean_up() {
 
 # Always clean up before exiting.
 trap 'clean_up' EXIT
-
-# Mount volatile RAMdisk.
-mkdir "${INSTALLER_DIR}"
-mount \
-  --types tmpfs \
-  --options "size=${RAMDISK_SIZE}" \
-  --source tmpfs \
-  --target "${INSTALLER_DIR}" \
-  --verbose
 
 # Extract tarball to installer directory.
 tar \

--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -78,9 +78,21 @@ FREE_MEMORY_MIB="$(free --mebi |
   cut --delimiter ' ' --fields 4)"
 readonly FREE_MEMORY_MIB
 
+INSTALLER_DIR='/mnt/tinypilot-installer'
+
+# Remove temporary files & directories.
+clean_up() {
+  umount --lazy "${INSTALLER_DIR}" || true
+  rm -rf \
+    "${LEGACY_INSTALLER_DIR}" \
+    "${INSTALLER_DIR}"
+}
+
+# Always clean up before exiting.
+trap 'clean_up' EXIT
+
 if (( "${FREE_MEMORY_MIB}" >= "${RAMDISK_SIZE_MIB}" )); then
   # Mount volatile RAMdisk.
-  INSTALLER_DIR='/mnt/tinypilot-installer'
   sudo mkdir "${INSTALLER_DIR}"
   sudo mount \
     --types tmpfs \
@@ -93,17 +105,6 @@ else
   INSTALLER_DIR="$(mktemp --directory)"
 fi
 readonly INSTALLER_DIR
-
-# Remove temporary files & directories.
-clean_up() {
-  umount --lazy "${INSTALLER_DIR}" || true
-  rm -rf \
-    "${LEGACY_INSTALLER_DIR}" \
-    "${INSTALLER_DIR}"
-}
-
-# Always clean up before exiting.
-trap 'clean_up' EXIT
 
 # Extract tarball to installer directory.
 tar \

--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -91,6 +91,8 @@ clean_up() {
 # Always clean up before exiting.
 trap 'clean_up' EXIT
 
+# Determine the installation directory. Use RAMdisk if there is enough memory,
+# otherwise, fall back to regular disk.
 if (( "${FREE_MEMORY_MIB}" >= "${RAMDISK_SIZE_MIB}" )); then
   # Mount volatile RAMdisk.
   sudo mkdir "${INSTALLER_DIR}"

--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -104,7 +104,7 @@ if (( "${FREE_MEMORY_MIB}" >= "${RAMDISK_SIZE_MIB}" )); then
     --target "${INSTALLER_DIR}" \
     --verbose
 else
-  # Fallback to installing from disk.
+  # Fall back to installing from disk.
   INSTALLER_DIR="$(mktemp --directory)"
 fi
 readonly INSTALLER_DIR

--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -69,7 +69,21 @@ else
   readonly BUNDLE_FILE_PATH="${BUNDLE_PATH}"
 fi
 
+# Historically, the TinyPilot bundle was unpacked to the device's disk, where it
+# persisted. Since then, we've moved to the use of a volatile RAMdisk, which
+# avoids excessive writes to the filesystem. As a result, this legacy installer
+# directory has been orphaned and is now removed as part of this script's
+# `clean_up` function.
+# https://github.com/tiny-pilot/tinypilot/issues/1357
 readonly LEGACY_INSTALLER_DIR='/opt/tinypilot-updater'
+
+# The RAMdisk size is broadly based on the combined size of the following:
+# - The TinyPilot bundle archive
+# - The unpacked TinyPilot bundle archive, after running the bundle's `install`
+#     script
+# - At least a 20% safety margin
+# Use the following command to help you estimate a sensible size allocation:
+#   du --summarize --total --bytes "${INSTALLER_DIR}" "${BUNDLE_FILE}"
 readonly RAMDISK_SIZE_MIB=500
 
 FREE_MEMORY_MIB="$(free --mebi |
@@ -96,6 +110,13 @@ trap 'clean_up' EXIT
 # otherwise, fall back to regular disk.
 if (( "${FREE_MEMORY_MIB}" >= "${RAMDISK_SIZE_MIB}" )); then
   # Mount volatile RAMdisk.
+  # Note: `tmpfs` can use swap space when the device's physical memory is under
+  # pressure. Alternatively, we could use `ramfs` which doesn't use swap space,
+  # but also doesn't enforce a filesystem size limit, unlike `tmpfs`. Considering
+  # that our goal is to reduce disk writes and not necessarily eliminate them
+  # altogether, the possibility of using swap space is an acceptable compromise in
+  # exchange for limiting memory usage.
+  # https://github.com/tiny-pilot/tinypilot/issues/1357
   sudo mkdir "${INSTALLER_DIR}"
   sudo mount \
     --types tmpfs \


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1402

In order to accommodate users who want to install TinyPilot on devices with less than 500MB of RAM (i.e., Raspberry Pi Zero), the `get-tinypilot.sh` script now falls back to installing TinyPilot from disk if there isn't enough available memory to mount a RAMdisk.

Notes:
* The changes made to `get-tinypilot.sh` have also been copied over to the `scripts/install-bundle` script

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1406"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>