### PR TITLE
Proposal for remote dev procedures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,20 +63,41 @@ To run TinyPilot on a non-Pi machine, run:
 
 For more complex changes it is useful to test your feature branch on a Raspberry Pi, in order to verify them in the real production environment.
 
-### Setup SSH keys for login
+The following setup and helper scripts aim to provide a unified workflow.
 
-1. [Generate SSH keys and upload your public key](https://www.raspberrypi.org/documentation/remote-access/ssh/passwordless.md) to your device. Please use strong keys, e.g., ED25519 or RSA 4096+.
-2. Verify that you can login with your SSH keys.
-3. On the device, disable password-based login by specifying `PasswordAuthentication no` in `/etc/ssh/sshd_config`. Reboot afterwards.
+### SSH setup
 
-### SSH agent forwarding
+On your local machine, you should [generate separate SSH keys](https://www.raspberrypi.org/documentation/remote-access/ssh/passwordless.md) for the testing device. Please use strong keys, e.g., ED25519 or RSA 4096+.
 
-In case you need SSH keys for accessing the Git repositories (e.g., for testing TinyPilot's Pro version), please enable SSH agent forwarding in your local `~/.ssh/config`.
+Add the following section to your `~/.ssh/config` file, so that your SSH keys are picked up automatically.
 
 ```
-Host tinypilot
-  ForwardAgent yes
+Host tinypilot tinypilot.local
+	User root
+	IdentityFile ~/.ssh/tinypilot
 ```
+
+For more convenience (but also less security), you can disable integrity checks. You should only do this for your testing device, only if the testing device is within a local network, and only if the testing device is connected to a non-sensitive target machine.
+
+```
+Host tinypilot tinypilot.local
+	User root
+	IdentityFile ~/.ssh/tinypilot
+	UserKnownHostsFile /dev/null
+	StrictHostKeyChecking no
+```
+
+### Bootstrapping a new Voyager testing device
+
+You only need to carry out the bootstrapping procedure once for a pristine device / SD card.
+
+For accessing your testing device via the command line, make sure that the SSH agent on the device is enabled.
+
+Run the [`bootstrap` dev-script](./dev-scripts/remote/bootstrap) in order to populate your SSH key, and to set up some basic system config.
+
+### Installing dev builds on the device
+
+You can push and install dev bundles to your testing device by using the [`push-bundle` dev-script](./dev-scripts/remote/push-bundle).
 
 ## Architecture
 

--- a/dev-scripts/remote/.env.dev
+++ b/dev-scripts/remote/.env.dev
@@ -1,0 +1,5 @@
+# The hostname of the TinyPilot testing device.
+TINYTESTPILOT_SSH_HOSTNAME=raspberrypi.local
+
+# The local path to the SSH key that should be used when bootstrapping.
+TINYTESTPILOT_SSH_KEY=~/.ssh/tinypilot

--- a/dev-scripts/remote/bootstrap
+++ b/dev-scripts/remote/bootstrap
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# Bootstraps a TinyPilot Voyager device for testing purposes.
+# This uploads SSH keys to the device, and it ensures that all Voyager-specific
+# prerequisites are met.
+
+# Exit on unset variable.
+set -u
+
+# Exit on first error.
+set -e
+
+print_help() {
+  cat << EOF
+Usage: ${0##*/} [-h] ssh_connection
+Bootstraps a new TinyPilot Voyager device for testing purposes.
+  ssh_connection: The default SSH connection string, e.g.: pi@raspberrypi
+  -h Display this help and exit.
+EOF
+}
+
+# Parse command-line arguments.
+while getopts 'h' opt; do
+  case "${opt}" in
+    h)
+      print_help
+      exit
+      ;;
+    *)
+      print_help >&2
+      exit 1
+  esac
+done
+
+# Ensure config is present.
+if [[ -z "${TINYTESTPILOT_SSH_KEY}" ]]; then
+  echo 'Environment variable $TINYTESTPILOT_SSH_KEY must be specified.' >&2
+  exit 1
+fi
+
+# Ensure 'ssh_connection' is given.
+shift "$((OPTIND - 1))"
+if (( $# == 0 )); then
+  echo 'Input parameter missing: ssh_connection' >&2
+  exit 1
+fi
+
+# Echo commands before executing them, by default to stderr.
+set -x
+
+readonly SSH_DEFAULT_CONNECTION="$1"
+
+SSH_PUBLIC_KEY="$(<"${TINYTESTPILOT_SSH_KEY}.pub")"
+readonly SSH_PUBLIC_KEY
+
+# Execute bootstrap procedure:
+# - Upload SSH public key.
+# - Set up tinypilot user and group.
+# - Setup Voyager config.
+ssh "${SSH_DEFAULT_CONNECTION}" << ENDSSH
+set -eu
+
+sudo su
+
+# Register developer’s SSH key for root account.
+mkdir -p /root/.ssh
+echo "${SSH_PUBLIC_KEY}" > /root/.ssh/authorized_keys
+
+# Set up tinypilot user (unless it exists).
+if ! id tinypilot &>/dev/null; then
+  addgroup --system tinypilot
+  adduser \
+    --system \
+    --shell /bin/bash \
+    --ingroup tinypilot \
+    --home "/home/tinypilot" \
+    tinypilot
+fi
+
+# Setup config for Voyager device (unless it exists).
+su tinypilot
+if [[ ! -f ~/settings.yml ]]; then
+  touch ~/settings.yml
+  echo 'ustreamer_capture_device: tc358743' >> ~/settings.yml
+fi
+ENDSSH

--- a/dev-scripts/remote/push-bundle
+++ b/dev-scripts/remote/push-bundle
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# Proxy script for pushing/installing a bundle to a remote testing device.
+#
+# Examples:
+#  install-bundle https://example.com/tinypilot-community-20230103T1619Z-1.8.0-74+7623988.tgz
+#  install-bundle /local/path/tinypilot-community-20230103T1619Z-1.8.0-74+7623988.tgz
+
+# Exit on unset variable.
+set -u
+
+# Exit on first error.
+set -e
+
+SCRIPT_PATH=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+readonly SCRIPT_PATH
+
+print_help() {
+  cat << EOF
+Usage: ${0##*/} [-h] bundle_path
+Install the specified TinyPilot bundle on a remote TinyPilot testing device.
+  bundle_path: Local filesystem path or web URL.
+  -h Display this help and exit.
+EOF
+}
+
+# Parse command-line arguments.
+while getopts 'h' opt; do
+  case "${opt}" in
+    h)
+      print_help
+      exit
+      ;;
+    *)
+      print_help >&2
+      exit 1
+  esac
+done
+
+# Ensure config is present.
+if [[ -z "${TINYTESTPILOT_SSH_HOSTNAME}" ]]; then
+  echo 'Environment variable $TINYTESTPILOT_SSH_HOSTNAME must be specified.' >&2
+  exit 1
+fi
+
+# Ensure 'bundle_path' is given.
+shift "$((OPTIND - 1))"
+if (( $# == 0 )); then
+  echo 'Input parameter missing: bundle_path' >&2
+  exit 1
+fi
+
+# Echo commands before executing them, by default to stderr.
+set -x
+
+readonly BUNDLE_PATH="$1"
+
+# Download bundle, if path is a web URL.
+if [[ "${BUNDLE_PATH}" == http* ]]; then
+  pushd "$(mktemp -d)"
+  curl \
+   --fail \
+   --location \
+   --output bundle.tgz \
+   "${BUNDLE_PATH}"
+  ls -lah
+  BUNDLE_FILE_PATH="${PWD}/bundle.tgz"
+  readonly BUNDLE_FILE_PATH
+  popd
+else
+  readonly BUNDLE_FILE_PATH="${BUNDLE_PATH}"
+fi
+
+# Sync install script and bundle to device.
+rsync "${SCRIPT_PATH}/../../scripts/install-bundle" "root@${TINYTESTPILOT_SSH_HOSTNAME}:/tmp/install-bundle"
+rsync "${BUNDLE_FILE_PATH}" "root@${TINYTESTPILOT_SSH_HOSTNAME}:/tmp/bundle.tgz"
+
+# Delegate to install script.
+ssh "root@${TINYTESTPILOT_SSH_HOSTNAME}" << ENDSSH
+/tmp/install-bundle /tmp/bundle.tgz
+ENDSSH

--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -2,9 +2,8 @@
 #
 # Install TinyPilot from a TinyPilot bundle tarball.
 #
-# Examples:
+# Example:
 #  sudo install-bundle /tmp/tinypilot-community-20230103T1619Z-1.8.0-74+7623988.tgz
-#  sudo install-bundle https://example.com/tinypilot-community-20230103T1619Z-1.8.0-74+7623988.tgz
 #
 # This script is only for development, though unlike other dev scripts, it
 # installs on the device. Regular users should use the get-tinypilot.sh or
@@ -30,7 +29,7 @@ print_help() {
   cat << EOF
 Usage: ${0##*/} [-h] bundle_path
 Install the specified TinyPilot bundle on the system.
-  bundle_path: Local filesystem path or URL to TinyPilot bundle.
+  bundle_path: Local filesystem path
   -h Display this help and exit.
 EOF
 }
@@ -58,17 +57,7 @@ fi
 # Echo commands before executing them, by default to stderr.
 set -x
 
-readonly BUNDLE_PATH="$1"
-
-if [[ "${BUNDLE_PATH}" == http* ]]; then
-  cd "$(mktemp --directory)"
-  wget "${BUNDLE_PATH}"
-  BUNDLE_FILE_PATH="${PWD}/$(find . -name '*.tgz')"
-  readonly BUNDLE_FILE_PATH
-else
-  readonly BUNDLE_FILE_PATH="${BUNDLE_PATH}"
-fi
-
+readonly BUNDLE_FILE_PATH="$1"
 readonly LEGACY_INSTALLER_DIR='/opt/tinypilot-updater'
 readonly INSTALLER_DIR='/mnt/tinypilot-installer'
 readonly RAMDISK_SIZE='500m'


### PR DESCRIPTION
Proposal to resolve https://github.com/tiny-pilot/tinypilot/issues/1073.

Here is a proposal for how we can re-define / refine our development workflow for on-device testing.

## Some upfront considerations

I realized that the two things that I do most often are:

- Bootstrapping (setting up) new SD cards for doing tests in a clean environment. I routinely wipe my SD cards for testing (depending on what I work on up to several times per day), and in my book it would be cool to have better utilities for this.
- Performing full installs of bundles, both on “fresh” devices, and also on devices that already have an installation. Although the installation of bundles takes a few minutes each time, I think this is the cleanest and safest way currently to test changes on device.

I’m regularly using the [`install-bundle` script](https://github.com/tiny-pilot/tinypilot/blob/master/scripts/install-bundle). On the one hand, this is pretty handy, especially the “fetch from URL” bit; on the other hand, it’s a bit inconvenient to use on fresh SD cards, because the script obviously doesn’t exist on the device. So for my taste, it would work best to facilitate the dev procedures from the dev machine, rather than from the device. That way, we are independent of the device state.

I also rarely build bundles locally, but I mostly download them from CircleCI nowadays. That’s a bit slower, but I find the local process a bit tedious and error prone (you first have to build the Debian package; then copy that over into the `bundler/bundle/` directory; then kick off the `create-bundle` script; then `rsync` the bundle to the device; then install the bundle).

As mentioned in the ticket, I had cobbled together some local scripts over time, with which I’ve tried to automate these procedures as best as possible. For me personally, it would be cool to make these workflows more mature and standardized. But whether or not that make sense would depend on how it works best for everyone else.

This PR demonstrates what I would have in mind, and should serve as starting point for a discussion. I’d be curious for feedback, and curious to learn about your testing workflows. Maybe we can find a good way that works for everyone. If the workflows and preferences are too wide apart, I think it would also be okay to leave the situation as it is right now (but to still update and improve the documentation in any event).

## Proposal

- Introduce a separate class of dev-scripts for helping with remote testing on device (i.e., “remote dev-scripts”). These scripts are run from the local dev machine, and they rely on a certain SSH configuration being present in order for them to work.
  - One is for bootstrapping new devices. I suppose we all use Voyager devices for testing, so we could either default to that, or offer two variants.
  - One is for “pushing” bundles to a device. This also has to sync up the `install-bundle` script along with the bundle, to conveniently allow installing bundles on a fresh device. It would make sense to me to relocate the downloading logic to this script, and keep the “server-side” one more basic.
- Update the documentation in `CONTRIBUTING.md`. The description is currently still quite rough, though. It would also make sense to me to document some “tips” like how to disable the SSH integrity check, because those can be pretty annoying. As far as I’m concerned, I don’t worry too much about the security of my testing device, since it’s inside a local network, and I only connect it to a “non-sensitive” target machine.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1407"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>