### PR TITLE
Install uStreamer via Debian package instead of building from source

### DIFF
--- a/ansible-role/molecule/default/molecule.yml
+++ b/ansible-role/molecule/default/molecule.yml
@@ -26,7 +26,7 @@ provisioner:
     # parameter. See
     # https://github.com/ansible-community/molecule/issues/3065#issuecomment-835897461
     extra-vars: >
-      ustreamer_debian_package_path=https://github.com/tiny-pilot/ustreamer-debian/releases/download/5.38-20230524143200/ustreamer_5.38-20230524143200_amd64.deb
+      ustreamer_debian_package_path=https://github.com/tiny-pilot/ustreamer-debian/releases/download/ustreamer_5.38-20230525134432/ustreamer_5.38-20230525134432_amd64.deb
 verifier:
   name: ansible
 scenario:

--- a/ansible-role/molecule/default/molecule.yml
+++ b/ansible-role/molecule/default/molecule.yml
@@ -22,8 +22,11 @@ provisioner:
           ansible_user: root
           tinypilot_debian_package_path: /opt/debian-pkgs/${TINYPILOT_DEBIAN_PACKAGE}
   options:
-    extra-vars:
-      ustreamer_debian_package_path: https://github.com/tiny-pilot/ustreamer-debian/releases/download/5.38-20230524143200/ustreamer_5.38-20230524143200_amd64.deb
+    # This variable expects a string, just like `--extra-vars` command-line
+    # parameter. See
+    # https://github.com/ansible-community/molecule/issues/3065#issuecomment-835897461
+    extra-vars: >
+      ustreamer_debian_package_path=https://github.com/tiny-pilot/ustreamer-debian/releases/download/5.38-20230524143200/ustreamer_5.38-20230524143200_amd64.deb
 verifier:
   name: ansible
 scenario:

--- a/ansible-role/molecule/default/molecule.yml
+++ b/ansible-role/molecule/default/molecule.yml
@@ -21,7 +21,9 @@ provisioner:
         vars:
           ansible_user: root
           tinypilot_debian_package_path: /opt/debian-pkgs/${TINYPILOT_DEBIAN_PACKAGE}
-          ustreamer_debian_package_path: https://github.com/tiny-pilot/ustreamer-debian/releases/download/5.38-20230524143200/ustreamer_5.38-20230524143200_amd64.deb
+  options:
+    extra-vars:
+      ustreamer_debian_package_path: https://github.com/tiny-pilot/ustreamer-debian/releases/download/5.38-20230524143200/ustreamer_5.38-20230524143200_amd64.deb
 verifier:
   name: ansible
 scenario:

--- a/ansible-role/molecule/default/molecule.yml
+++ b/ansible-role/molecule/default/molecule.yml
@@ -21,6 +21,7 @@ provisioner:
         vars:
           ansible_user: root
           tinypilot_debian_package_path: /opt/debian-pkgs/${TINYPILOT_DEBIAN_PACKAGE}
+          ustreamer_debian_package_path: https://github.com/tiny-pilot/ustreamer-debian/releases/download/5.38-20230524143200/ustreamer_5.38-20230524143200_amd64.deb
 verifier:
   name: ansible
 scenario:

--- a/ansible-role/vars/main.yml
+++ b/ansible-role/vars/main.yml
@@ -13,7 +13,7 @@ tinypilot_privileged_dir: /opt/tinypilot-privileged
 # override the default variables in the uStreamer role.
 ustreamer_interface: "127.0.0.1"
 ustreamer_port: 8001
-ustreamer_debian_package_path: https://github.com/tiny-pilot/ustreamer-debian/releases/download/5.38-20230524143200/ustreamer_5.38-20230524143200_armhf.deb
+ustreamer_debian_package_path: https://github.com/tiny-pilot/ustreamer-debian/releases/download/ustreamer_5.38-20230525134432/ustreamer_5.38-20230525134432_armhf.deb
 # Assigning `ustreamer_h264_sink` will make the uStreamer role install the Janus
 # server on the system, and thus enable H264 video streaming.
 ustreamer_h264_sink: tinypilot::ustreamer::h264

--- a/ansible-role/vars/main.yml
+++ b/ansible-role/vars/main.yml
@@ -13,8 +13,7 @@ tinypilot_privileged_dir: /opt/tinypilot-privileged
 # override the default variables in the uStreamer role.
 ustreamer_interface: "127.0.0.1"
 ustreamer_port: 8001
-ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git
-ustreamer_repo_version: v5.38
+ustreamer_debian_package_path: https://github.com/tiny-pilot/ustreamer-debian/releases/download/5.38-20230524143200/ustreamer_5.38-20230524143200_armhf.deb
 # Assigning `ustreamer_h264_sink` will make the uStreamer role install the Janus
 # server on the system, and thus enable H264 video streaming.
 ustreamer_h264_sink: tinypilot::ustreamer::h264


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/ansible-role-ustreamer/issues/100

This PR specifies the URL to our [uStreamer Debian package release](https://github.com/tiny-pilot/ustreamer-debian/releases/tag/ustreamer_5.38-20230525134432) (via the `ustreamer_debian_package_path` variable) and avoids unnecessarily specifying uStreamer git variables (i.e., `ustreamer_repo` and `ustreamer_repo_version `) in the TinyPilot Ansible role. 

Notes:

* By default our Ansible role will install uStreamer for `armhf` architecture. However, to test the Ansible role in CI, we needed to [override the `ustreamer_debian_package_path` value to point to uStreamer for `amd64` architecture](https://github.com/tiny-pilot/tinypilot/pull/1408/files#diff-a820d54bd8941675036b81b0e7d1b08afee2821c526e5806ab6c8482ec0880d4R24-R29).

I've tested this build on device.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1408"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>