### PR TITLE
Always build Ansible role on master branch

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -130,7 +130,7 @@ jobs:
           condition:
             or:
               - << pipeline.parameters.ansible_role_changed >>
-              - equal: [build-ansible-master, << pipeline.git.branch >>]
+              - equal: [master, << pipeline.git.branch >>]
           steps:
             - run:
                 name: Skipping job because files weren't changed

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -127,7 +127,10 @@ jobs:
     working_directory: ~/project/ansible-role
     steps:
       - unless:
-          condition: << pipeline.parameters.ansible_role_changed >>
+          condition:
+            or:
+              - << pipeline.parameters.ansible_role_changed >>
+              - equal: [master, << pipeline.git.branch >>]
           steps:
             - run:
                 name: Skipping job because files weren't changed

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -130,7 +130,7 @@ jobs:
           condition:
             or:
               - << pipeline.parameters.ansible_role_changed >>
-              - equal: [master, << pipeline.git.branch >>]
+              - equal: [build-ansible-master, << pipeline.git.branch >>]
           steps:
             - run:
                 name: Skipping job because files weren't changed

--- a/ansible-role/test.txt
+++ b/ansible-role/test.txt
@@ -1,0 +1,1 @@
+Hello, World!

--- a/ansible-role/test.txt
+++ b/ansible-role/test.txt
@@ -1,1 +1,0 @@
-Hello, World!


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1409

To avoid not testing the Ansible build for an extended period of time, we would rather opt for always building the Ansible role on the master branch.

Notes:
* I found an example of a similar CircleCI condition we were after, [here](https://discuss.circleci.com/t/advanced-logic-in-config/36011).
* I've tested that the Ansible role builds for the following conditions, separately:
    * Test `branch == 'build-ansible-master'` condition https://github.com/tiny-pilot/tinypilot/pull/1410/commits/492f8a9d0b13f19efca3ccf814021d6248787e95
    * Test `ansible_role_changed == True` condition https://github.com/tiny-pilot/tinypilot/pull/1410/commits/39e5f9fde35a4eb1e541122994db407152d37c0d

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1410"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>