### PR TITLE
Simplify placement of the usb-gadget service definition

### DIFF
--- a/ansible-role/files/usb-gadget.service
+++ b/ansible-role/files/usb-gadget.service
@@ -5,9 +5,9 @@ After=syslog.target
 [Service]
 Type=oneshot
 User=root
-ExecStart={{ tinypilot_privileged_dir }}/init-usb-gadget
+ExecStart=/opt/tinypilot_privileged/init-usb-gadget
 RemainAfterExit=true
-ExecStop={{ tinypilot_privileged_dir }}/remove-usb-gadget
+ExecStop=/opt/tinypilot-privileged/remove-usb-gadget
 StandardOutput=journal
 
 [Install]

--- a/ansible-role/files/usb-gadget.service
+++ b/ansible-role/files/usb-gadget.service
@@ -5,7 +5,7 @@ After=syslog.target
 [Service]
 Type=oneshot
 User=root
-ExecStart=/opt/tinypilot_privileged/init-usb-gadget
+ExecStart=/opt/tinypilot-privileged/init-usb-gadget
 RemainAfterExit=true
 ExecStop=/opt/tinypilot-privileged/remove-usb-gadget
 StandardOutput=journal

--- a/ansible-role/tasks/install_usb_gadget.yml
+++ b/ansible-role/tasks/install_usb_gadget.yml
@@ -57,16 +57,16 @@
     mode: "0700"
 
 - name: install usb-gadget initializer as a service
-  template:
-    src: usb-gadget.systemd.j2
+  copy:
+    src: usb-gadget.service
     dest: /lib/systemd/system/usb-gadget.service
     owner: root
     group: root
     mode: "0644"
-  register: usb_gadget_template
+  register: usb_gadget_file
 
 - name: enable systemd usb-gadget initializer service file
   systemd:
     name: usb-gadget
     enabled: yes
-    daemon_reload: "{{ usb_gadget_template.changed }}"
+    daemon_reload: "{{ usb_gadget_file.changed }}"


### PR DESCRIPTION
As part of the War on Ansible, I'd like to refactor a little bit how we place the usb-gadget systemd file.

We're unlikely to change the path of the TinyPilot privileged directory from the current `/opt/tinypilot-privileged`, so we should just hardcode it into the `usb-gadget` systemd file and save ourselves the extra Ansible logic of templating the file.

This will make it slightly easier to later port the systemd file into debhelper like we currently do with tinypilot-updater.

Tested on a Voyager 2a device.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1411"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>