### PR TITLE
Make nginx install the last step of the Ansible role

### DIFF
--- a/ansible-role/tasks/main.yml
+++ b/ansible-role/tasks/main.yml
@@ -4,9 +4,6 @@
   tags:
     - ustreamer
 
-- name: install nginx
-  import_tasks: nginx.yml
-
 - name: create the `lib` directory if it does not exist
   file:
     path: "{{ tinypilot_privileged_dir }}/lib"
@@ -73,3 +70,6 @@
   systemd:
     name: tinypilot
     enabled: yes
+
+- name: install nginx
+  import_tasks: nginx.yml


### PR DESCRIPTION
In TinyPilot Pro, we recently made nginx the last step of the Ansible role (https://github.com/tiny-pilot/tinypilot-pro/pull/836), so this makes the parallel change in Community to keep the two repos aligned.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1413"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>