### PR TITLE
Add support for a relative mouse.

### DIFF
--- a/ansible-role/defaults/main.yml
+++ b/ansible-role/defaults/main.yml
@@ -11,6 +11,7 @@ tinypilot_interface: "127.0.0.1"
 tinypilot_port: 8000
 tinypilot_keyboard_interface: /dev/hidg0
 tinypilot_mouse_interface: /dev/hidg1
+tinypilot_mouse_relative_interface: /dev/hidg2
 tinypilot_enable_debug_logging: no
 tinypilot_pip_args: ""
 tinypilot_app_settings_file: "/home/{{ tinypilot_user }}/app_settings.cfg"

--- a/ansible-role/files/init-usb-gadget
+++ b/ansible-role/files/init-usb-gadget
@@ -112,6 +112,8 @@ D=$(mktemp)
 echo -ne \\x05\\x01      # USAGE_PAGE (Generic Desktop)
 echo -ne \\x09\\x02      # USAGE (Mouse)
 echo -ne \\xA1\\x01      # COLLECTION (Application)
+echo -ne \\x09\\x01      # USAGE (Pointer)
+echo -ne \\xA1\\x00      # COLLECTION (Physical)
                          #   8-buttons
 echo -ne \\x05\\x09      #   USAGE_PAGE (Button)
 echo -ne \\x19\\x01      #   USAGE_MINIMUM (Button 1)
@@ -145,9 +147,62 @@ echo -ne \\x25\\x7F      #   LOGICAL_MAXIMUM (127)
 echo -ne \\x75\\x08      #   REPORT_SIZE (8)
 echo -ne \\x95\\x01      #   REPORT_COUNT (1)
 echo -ne \\x81\\x06      #   INPUT (Data,Var,Rel)
-echo -ne \\xC0           # END_COLLECTION
+echo -ne \\xC0           # END_COLLECTION (Physical)
+echo -ne \\xC0           # END_COLLECTION (Application)
 } >> "$D"
 cp "$D" "${USB_MOUSE_FUNCTIONS_DIR}/report_desc"
+
+# Mouse (Relative)
+mkdir -p "$USB_MOUSE_REL_FUNCTIONS_DIR"
+echo 0 > "${USB_MOUSE_REL_FUNCTIONS_DIR}/protocol"
+echo 0 > "${USB_MOUSE_REL_FUNCTIONS_DIR}/subclass"
+echo 7 > "${USB_MOUSE_REL_FUNCTIONS_DIR}/report_length"
+
+# Write the report descriptor
+D=$(mktemp)
+{
+echo -ne \\x05\\x01      # USAGE_PAGE (Generic Desktop)
+echo -ne \\x09\\x02      # USAGE (Mouse)
+echo -ne \\xA1\\x01      # COLLECTION (Application)
+echo -ne \\x09\\x01      # USAGE (Pointer)
+echo -ne \\xA1\\x00      # COLLECTION (Physical)
+                          # 8 Buttons
+echo -ne \\x05\\x09      #   USAGE_PAGE (Button)
+echo -ne \\x19\\x01      #   USAGE_MINIMUM (Button 1)
+echo -ne \\x29\\x08      #   USAGE_MAXIMUM (Button 5)
+echo -ne \\x15\\x00      #   LOGICAL_MINIMUM (0)
+echo -ne \\x25\\x01      #   LOGICAL_MAXIMUM (1)
+echo -ne \\x95\\x08      #   REPORT_COUNT (8)
+echo -ne \\x75\\x01      #   REPORT_SIZE (1)
+echo -ne \\x81\\x02      #   INPUT (Data,Var,Abs)
+                          # x,y relative movement
+echo -ne \\x05\\x01      #   USAGE_PAGE (Generic Desktop)
+echo -ne \\x09\\x30      #   USAGE (X)
+echo -ne \\x09\\x31      #   USAGE (Y)
+echo -ne \\x16\\x01\\x80 #   LOGICAL_MINIMUM (-32767)
+echo -ne \\x26\\xFF\\x7F #   LOGICAL_MAXIMUM (32767)
+echo -ne \\x95\\x02      #   REPORT_COUNT (2)
+echo -ne \\x75\\x10      #   REPORT_SIZE (16)
+echo -ne \\x81\\x06      #   INPUT (Data,Var,Rel)
+                          # vertical wheel
+echo -ne \\x09\\x38      #   USAGE (vertical wheel)
+echo -ne \\x15\\x81      #   LOGICAL_MINIMUM (-127)
+echo -ne \\x25\\x7F      #   LOGICAL_MAXIMUM (127)
+echo -ne \\x95\\x01      #   REPORT_COUNT (1)
+echo -ne \\x75\\x08      #   REPORT_SIZE (8)
+echo -ne \\x81\\x06      #   INPUT (Data,Var,Rel)
+                          # horizontal wheel
+echo -ne \\x05\\x0c      #   USAGE_PAGE (Generic Desktop)
+echo -ne \\x0A\\x02\\x38 #   USAGE (Consumer AC Pan)
+echo -ne \\x15\\x81      #   LOGICAL_MINIMUM (-127)
+echo -ne \\x25\\x7F      #   LOGICAL_MAXIMUM (127)
+echo -ne \\x95\\x01      #   REPORT_COUNT (1)
+echo -ne \\x75\\x08      #   REPORT_SIZE (8)
+echo -ne \\x81\\x06      #   INPUT (Data,Var,Rel)
+echo -ne \\xC0           # END_COLLECTION (Physical)
+echo -ne \\xC0           # END_COLLECTION (Application)
+} >> "$D"
+cp "$D" "${USB_MOUSE_REL_FUNCTIONS_DIR}/report_desc"
 
 mkdir -p "${USB_CONFIG_DIR}"
 echo 250 > "${USB_CONFIG_DIR}/MaxPower"
@@ -158,5 +213,6 @@ echo "Config ${USB_CONFIG_INDEX}: ECM network" > "${CONFIGS_STRINGS_DIR}/configu
 
 ln -s "${USB_KEYBOARD_FUNCTIONS_DIR}" "${USB_CONFIG_DIR}/"
 ln -s "${USB_MOUSE_FUNCTIONS_DIR}" "${USB_CONFIG_DIR}/"
+ln -s "${USB_MOUSE_REL_FUNCTIONS_DIR}" "${USB_CONFIG_DIR}/"
 
-usb_gadget_activate
+usb_gadget_activate "/dev/hidg0" "/dev/hidg1" "/dev/hidg2"

--- a/ansible-role/files/lib/usb-gadget.sh
+++ b/ansible-role/files/lib/usb-gadget.sh
@@ -16,6 +16,8 @@ export USB_KEYBOARD_FUNCTIONS_DIR="functions/hid.keyboard"
 readonly USB_KEYBOARD_FUNCTIONS_DIR
 export USB_MOUSE_FUNCTIONS_DIR="functions/hid.mouse"
 readonly USB_MOUSE_FUNCTIONS_DIR
+export USB_MOUSE_REL_FUNCTIONS_DIR="functions/hid.mouse_rel"
+readonly USB_MOUSE_REL_FUNCTIONS_DIR
 export USB_MASS_STORAGE_NAME="mass_storage.0"
 readonly USB_MASS_STORAGE_NAME
 export USB_MASS_STORAGE_FUNCTIONS_DIR="functions/${USB_MASS_STORAGE_NAME}"
@@ -32,8 +34,7 @@ readonly USB_ALL_FUNCTIONS_DIR
 
 function usb_gadget_activate {
   ls /sys/class/udc > "${USB_DEVICE_PATH}/UDC"
-  chmod 777 /dev/hidg0
-  chmod 777 /dev/hidg1
+  chmod 777 "$@"
 }
 export -f usb_gadget_activate
 

--- a/ansible-role/templates/tinypilot-app-settings.cfg.j2
+++ b/ansible-role/templates/tinypilot-app-settings.cfg.j2
@@ -3,3 +3,4 @@
 
 KEYBOARD_PATH = '{{ tinypilot_keyboard_interface }}'
 MOUSE_PATH = '{{ tinypilot_mouse_interface }}'
+RELATIVE_MOUSE_PATH = '{{ tinypilot_mouse_relative_interface }}'

--- a/app/hid/mouse.py
+++ b/app/hid/mouse.py
@@ -17,6 +17,20 @@ def send_mouse_event(mouse_path, buttons, relative_x, relative_y,
     hid_write.write_to_hid_interface(mouse_path, buf)
 
 
+def send_relative_mouse_event(mouse_path, buttons, move_x, move_y,
+                              vertical_wheel_delta, horizontal_wheel_delta):
+    # pylint: disable=invalid-name
+    buf = [0] * 7
+    buf[0] = buttons
+    buf[1] = move_x & 0xff
+    buf[2] = (move_x >> 8) & 0xff
+    buf[3] = move_y & 0xff
+    buf[4] = (move_y >> 8) & 0xff
+    buf[5] = _translate_vertical_wheel_delta(vertical_wheel_delta) & 0xff
+    buf[6] = horizontal_wheel_delta & 0xff
+    hid_write.write_to_hid_interface(mouse_path, buf)
+
+
 def _scale_mouse_coordinates(relative_x, relative_y):
     # This comes from LOGICAL_MAXIMUM in the mouse HID descriptor.
     max_hid_value = 32767.0

--- a/app/hid/mouse_test.py
+++ b/app/hid/mouse_test.py
@@ -33,3 +33,17 @@ class MouseTest(unittest.TestCase):
             # Byte 1-2 = 32767 * 0.0 = 0 = 0x0000
             # Byte 3-4 = 32767 * 1.0 = 32767 = 0x7fff (little-endian)
             self.assertEqual(b'\x00\x00\x00\xff\x7f\x00\x00', input_file.read())
+
+    def test_sends_relative_mouse_move_to_hid_interface(self):
+        with tempfile.NamedTemporaryFile() as input_file:
+            mouse.send_relative_mouse_event(mouse_path=input_file.name,
+                                            buttons=0,
+                                            move_x=314,
+                                            move_y=-159,
+                                            vertical_wheel_delta=0,
+                                            horizontal_wheel_delta=0)
+            input_file.seek(0)
+            # Byte 0   = No buttons pressed
+            # Byte 1-2 = 314 = 0x013A
+            # Byte 3-4 = -159 = 0xff61 (little-endian)
+            self.assertEqual(b'\x00\x3A\x01\x61\xff\x00\x00', input_file.read())

--- a/app/request_parsers/mouse_event_test.py
+++ b/app/request_parsers/mouse_event_test.py
@@ -7,12 +7,14 @@ class MouseEventTest(unittest.TestCase):
 
     def test_parses_valid_mouse_event(self):
         self.assertEqual(
-            mouse_event.MouseEvent(buttons=1,
+            mouse_event.MouseEvent(is_relative=False,
+                                   buttons=1,
                                    relative_x=0.5,
                                    relative_y=0.75,
                                    vertical_wheel_delta=0,
                                    horizontal_wheel_delta=0),
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 1,
                 'relativeX': 0.5,
                 'relativeY': 0.75,
@@ -22,12 +24,14 @@ class MouseEventTest(unittest.TestCase):
 
     def test_parses_valid_mouse_event_with_int_position(self):
         self.assertEqual(
-            mouse_event.MouseEvent(buttons=1,
+            mouse_event.MouseEvent(is_relative=False,
+                                   buttons=1,
                                    relative_x=0.0,
                                    relative_y=0.75,
                                    vertical_wheel_delta=0,
                                    horizontal_wheel_delta=0),
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 1,
                 'relativeX': 0,
                 'relativeY': 0.75,
@@ -37,12 +41,14 @@ class MouseEventTest(unittest.TestCase):
 
     def test_parses_valid_negative_vertical_scroll(self):
         self.assertEqual(
-            mouse_event.MouseEvent(buttons=0,
+            mouse_event.MouseEvent(is_relative=False,
+                                   buttons=0,
                                    relative_x=0.0,
                                    relative_y=0.75,
                                    vertical_wheel_delta=-1,
                                    horizontal_wheel_delta=0),
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 0,
                 'relativeY': 0.75,
@@ -52,12 +58,14 @@ class MouseEventTest(unittest.TestCase):
 
     def test_parses_valid_positive_vertical_scroll(self):
         self.assertEqual(
-            mouse_event.MouseEvent(buttons=0,
+            mouse_event.MouseEvent(is_relative=False,
+                                   buttons=0,
                                    relative_x=0.0,
                                    relative_y=0.75,
                                    vertical_wheel_delta=1,
                                    horizontal_wheel_delta=0),
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 0,
                 'relativeY': 0.75,
@@ -67,12 +75,14 @@ class MouseEventTest(unittest.TestCase):
 
     def test_parses_valid_negative_horizontal_scroll(self):
         self.assertEqual(
-            mouse_event.MouseEvent(buttons=0,
+            mouse_event.MouseEvent(is_relative=False,
+                                   buttons=0,
                                    relative_x=0.0,
                                    relative_y=0.75,
                                    vertical_wheel_delta=0,
                                    horizontal_wheel_delta=-1),
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 0,
                 'relativeY': 0.75,
@@ -82,12 +92,14 @@ class MouseEventTest(unittest.TestCase):
 
     def test_parses_valid_positive_horizontal_scroll(self):
         self.assertEqual(
-            mouse_event.MouseEvent(buttons=0,
+            mouse_event.MouseEvent(is_relative=False,
+                                   buttons=0,
                                    relative_x=0.0,
                                    relative_y=0.75,
                                    vertical_wheel_delta=0,
                                    horizontal_wheel_delta=1),
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 0,
                 'relativeY': 0.75,
@@ -95,14 +107,50 @@ class MouseEventTest(unittest.TestCase):
                 'horizontalWheelDelta': 1,
             }))
 
+    def test_parses_valid_relative_move1(self):
+        self.assertEqual(
+            mouse_event.MouseEvent(is_relative=True,
+                                   buttons=0,
+                                   relative_x=123,
+                                   relative_y=-456,
+                                   vertical_wheel_delta=0,
+                                   horizontal_wheel_delta=1),
+            mouse_event.parse_mouse_event({
+                'isRelative': True,
+                'buttons': 0,
+                'relativeX': 123,
+                'relativeY': -456,
+                'verticalWheelDelta': 0,
+                'horizontalWheelDelta': 1,
+            }))
+
+    def test_parses_valid_relative_move2(self):
+        self.assertEqual(
+            mouse_event.MouseEvent(is_relative=True,
+                                   buttons=0,
+                                   relative_x=-365,
+                                   relative_y=42,
+                                   vertical_wheel_delta=0,
+                                   horizontal_wheel_delta=1),
+            mouse_event.parse_mouse_event({
+                'isRelative': True,
+                'buttons': 0,
+                'relativeX': -365,
+                'relativeY': 42,
+                'verticalWheelDelta': 0,
+                'horizontalWheelDelta': 1,
+            }))
+
     def test_parses_valid_mouse_event_with_all_buttons_pressed(self):
         self.assertEqual(
-            mouse_event.MouseEvent(buttons=31,
+            mouse_event.MouseEvent(is_relative=False,
+                                   buttons=31,
                                    relative_x=0.5,
                                    relative_y=0.75,
                                    vertical_wheel_delta=0,
                                    horizontal_wheel_delta=0),
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 31,
                 'relativeX': 0.5,
                 'relativeY': 0.75,
@@ -113,6 +161,7 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_negative_buttons_value(self):
         with self.assertRaises(mouse_event.InvalidButtonStateError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': -1,
                 'relativeX': 0.5,
                 'relativeY': 0.75,
@@ -123,6 +172,7 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_too_high_buttons_value(self):
         with self.assertRaises(mouse_event.InvalidButtonStateError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 32,
                 'relativeX': 0.5,
                 'relativeY': 0.75,
@@ -133,6 +183,7 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_non_numeric_buttons_value(self):
         with self.assertRaises(mouse_event.InvalidButtonStateError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 'a',
                 'relativeX': 0.5,
                 'relativeY': 0.75,
@@ -143,6 +194,7 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_negative_relative_x_value(self):
         with self.assertRaises(mouse_event.InvalidRelativePositionError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': -0.001,
                 'relativeY': 0.75,
@@ -153,6 +205,7 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_negative_relative_y_value(self):
         with self.assertRaises(mouse_event.InvalidRelativePositionError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 0.5,
                 'relativeY': -0.001,
@@ -163,6 +216,7 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_too_high_relative_x_value(self):
         with self.assertRaises(mouse_event.InvalidRelativePositionError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 1.001,
                 'relativeY': 0.75,
@@ -173,6 +227,7 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_too_high_relative_y_value(self):
         with self.assertRaises(mouse_event.InvalidRelativePositionError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 0.5,
                 'relativeY': 1.001,
@@ -183,6 +238,7 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_non_float_relative_x_value(self):
         with self.assertRaises(mouse_event.InvalidRelativePositionError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 'a',
                 'relativeY': 0.75,
@@ -193,6 +249,7 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_non_float_relative_y_value(self):
         with self.assertRaises(mouse_event.InvalidRelativePositionError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 0.5,
                 'relativeY': 'b',
@@ -200,9 +257,20 @@ class MouseEventTest(unittest.TestCase):
                 'horizontalWheelDelta': 0,
             })
 
+    def test_rejects_missing_is_relative_field(self):
+        with self.assertRaises(mouse_event.MissingFieldErrorError):
+            mouse_event.parse_mouse_event({
+                'buttons': 0,
+                'relativeX': 0,
+                'relativeY': 0,
+                'verticalWheelDelta': 0,
+                'horizontalWheelDelta': 0,
+            })
+
     def test_rejects_missing_buttons_field(self):
         with self.assertRaises(mouse_event.MissingFieldErrorError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'relativeX': 0,
                 'relativeY': 0,
                 'verticalWheelDelta': 0,
@@ -212,6 +280,7 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_missing_relative_x_field(self):
         with self.assertRaises(mouse_event.MissingFieldErrorError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeY': 0,
                 'verticalWheelDelta': 0,
@@ -221,6 +290,7 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_missing_relative_y_field(self):
         with self.assertRaises(mouse_event.MissingFieldErrorError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 0,
                 'verticalWheelDelta': 0,
@@ -230,22 +300,27 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_missing_vertical_wheel_field(self):
         with self.assertRaises(mouse_event.MissingFieldErrorError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 0,
+                'relativeY': 0,
                 'horizontalWheelDelta': 0,
             })
 
     def test_rejects_missing_horizontal_wheel_field(self):
         with self.assertRaises(mouse_event.MissingFieldErrorError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 0,
+                'relativeY': 0,
                 'verticalWheelDelta': 0,
             })
 
     def test_rejects_string_vertical_wheel_value(self):
         with self.assertRaises(mouse_event.InvalidWheelValueError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 0.5,
                 'relativeY': 0.75,
@@ -256,6 +331,7 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_float_vertical_wheel_value(self):
         with self.assertRaises(mouse_event.InvalidWheelValueError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 0.5,
                 'relativeY': 0.75,
@@ -266,6 +342,7 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_too_high_vertical_wheel_value(self):
         with self.assertRaises(mouse_event.InvalidWheelValueError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 0.5,
                 'relativeY': 0.75,
@@ -276,6 +353,7 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_too_low_vertical_wheel_value(self):
         with self.assertRaises(mouse_event.InvalidWheelValueError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 0.5,
                 'relativeY': 0.75,
@@ -286,6 +364,7 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_string_horizontal_wheel_value(self):
         with self.assertRaises(mouse_event.InvalidWheelValueError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 0.5,
                 'relativeY': 0.75,
@@ -296,6 +375,7 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_float_horizontal_wheel_value(self):
         with self.assertRaises(mouse_event.InvalidWheelValueError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 0.5,
                 'relativeY': 0.75,
@@ -306,6 +386,7 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_too_high_horizontal_wheel_value(self):
         with self.assertRaises(mouse_event.InvalidWheelValueError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 0.5,
                 'relativeY': 0.75,
@@ -316,9 +397,102 @@ class MouseEventTest(unittest.TestCase):
     def test_rejects_too_low_horizontal_wheel_value(self):
         with self.assertRaises(mouse_event.InvalidWheelValueError):
             mouse_event.parse_mouse_event({
+                'isRelative': False,
                 'buttons': 0,
                 'relativeX': 0.5,
                 'relativeY': 0.75,
                 'verticalWheelDelta': 0,
                 'horizontalWheelDelta': -2,
+            })
+
+    def test_rejects_non_int_relative_x_value1(self):
+        with self.assertRaises(mouse_event.InvalidRelativeMovementError):
+            mouse_event.parse_mouse_event({
+                'isRelative': True,
+                'buttons': 0,
+                'relativeX': 'a',
+                'relativeY': 0,
+                'verticalWheelDelta': 0,
+                'horizontalWheelDelta': 0,
+            })
+
+    def test_rejects_non_int_relative_x_value2(self):
+        with self.assertRaises(mouse_event.InvalidRelativeMovementError):
+            mouse_event.parse_mouse_event({
+                'isRelative': True,
+                'buttons': 0,
+                'relativeX': 36.6,
+                'relativeY': 0,
+                'verticalWheelDelta': 0,
+                'horizontalWheelDelta': 0,
+            })
+
+    def test_rejects_non_int_relative_y_value1(self):
+        with self.assertRaises(mouse_event.InvalidRelativeMovementError):
+            mouse_event.parse_mouse_event({
+                'isRelative': True,
+                'buttons': 0,
+                'relativeX': 0,
+                'relativeY': 'a',
+                'verticalWheelDelta': 0,
+                'horizontalWheelDelta': 0,
+            })
+
+    def test_rejects_non_int_relative_y_value2(self):
+        with self.assertRaises(mouse_event.InvalidRelativeMovementError):
+            mouse_event.parse_mouse_event({
+                'isRelative': True,
+                'buttons': 0,
+                'relativeX': 0,
+                'relativeY': -55.5,
+                'verticalWheelDelta': 0,
+                'horizontalWheelDelta': 0,
+            })
+
+    def test_rejects_too_low_move_x_value(self):
+        with self.assertRaises(mouse_event.InvalidRelativeMovementError):
+            mouse_event.parse_mouse_event({
+                'isRelative': True,
+                'buttons': 0,
+                'relativeX': -32768,
+                'relativeY': 0,
+                'verticalWheelDelta': 0,
+                'horizontalWheelDelta': 0,
+            })
+
+    def test_rejects_too_high_move_x_value(self):
+        with self.assertRaises(mouse_event.InvalidRelativeMovementError):
+            mouse_event.parse_mouse_event({
+                'isRelative': True,
+                'buttons': 0,
+                'relativeX': 32768,
+                'relativeY': 0,
+                'verticalWheelDelta': 0,
+                'horizontalWheelDelta': 0,
+            })
+
+    def test_rejects_too_low_move_y_value(self):
+        with self.assertRaises(mouse_event.InvalidRelativeMovementError):
+            mouse_event.parse_mouse_event({
+                'isRelative': True,
+                'buttons': 0,
+                'relativeX': 0,
+                'relativeY': -32768,
+                'verticalWheelDelta': 0,
+                'horizontalWheelDelta': 0,
+                'relativeMoveX': 0,
+                'relativeMoveY': -1.1,
+            })
+
+    def test_rejects_too_high_move_y_value(self):
+        with self.assertRaises(mouse_event.InvalidRelativeMovementError):
+            mouse_event.parse_mouse_event({
+                'isRelative': True,
+                'buttons': 0,
+                'relativeX': 0,
+                'relativeY': 32768,
+                'verticalWheelDelta': 0,
+                'horizontalWheelDelta': 0,
+                'relativeMoveX': 0,
+                'relativeMoveY': 1.1,
             })

--- a/app/socket_api.py
+++ b/app/socket_api.py
@@ -53,13 +53,21 @@ def on_mouse_event(message):
     except mouse_event_request.Error as e:
         logger.error_sensitive('Failed to parse mouse event request: %s', e)
         return {'success': False}
-    mouse_path = flask.current_app.config.get('MOUSE_PATH')
     try:
-        fake_mouse.send_mouse_event(mouse_path, mouse_move_event.buttons,
-                                    mouse_move_event.relative_x,
-                                    mouse_move_event.relative_y,
-                                    mouse_move_event.vertical_wheel_delta,
-                                    mouse_move_event.horizontal_wheel_delta)
+        if mouse_move_event.is_relative:
+            mouse_path = flask.current_app.config.get('RELATIVE_MOUSE_PATH')
+            fake_mouse.send_relative_mouse_event(
+                mouse_path, mouse_move_event.buttons,
+                mouse_move_event.relative_x, mouse_move_event.relative_y,
+                mouse_move_event.vertical_wheel_delta,
+                mouse_move_event.horizontal_wheel_delta)
+        else:
+            mouse_path = flask.current_app.config.get('MOUSE_PATH')
+            fake_mouse.send_mouse_event(mouse_path, mouse_move_event.buttons,
+                                        mouse_move_event.relative_x,
+                                        mouse_move_event.relative_y,
+                                        mouse_move_event.vertical_wheel_delta,
+                                        mouse_move_event.horizontal_wheel_delta)
     except hid_write.WriteError as e:
         logger.error_sensitive('Failed to forward mouse event: %s', e)
         return {'success': False}

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -168,6 +168,7 @@ function onKeyDown(evt) {
 }
 
 function sendMouseEvent(
+  isRelative,
   buttons,
   relativeX,
   relativeY,
@@ -182,6 +183,7 @@ function sendMouseEvent(
   socket.emit(
     "mouse-event",
     {
+      isRelative,
       buttons,
       relativeX,
       relativeY,
@@ -330,6 +332,20 @@ menuBar.addEventListener("keystroke-history-toggled", () => {
 menuBar.addEventListener("keyboard-visibility-toggled", () => {
   onScreenKeyboard.show(!onScreenKeyboard.isShown());
 });
+menuBar.addEventListener("mouse-mode-toggled", () => {
+  const screen = document.getElementById("remote-screen");
+  screen.isMouseRelative = !screen.isMouseRelative;
+  menuBar.isRelativeMouseEnabled = screen.isMouseRelative;
+});
+document.addEventListener("pointerlockchange", () => {
+  menuBar.isRelativeMouseEnabled = document.pointerLockElement !== null;
+});
+document.addEventListener("pointerlockerror", () => {
+  menuBar.isRelativeMouseEnabled = false;
+  if (document.pointerLockElement !== null) {
+    document.exitPointerLock();
+  }
+});
 menuBar.addEventListener("shutdown-dialog-requested", () => {
   document.getElementById("shutdown-overlay").show();
 });
@@ -394,6 +410,7 @@ document
   .getElementById("remote-screen")
   .addEventListener("mouse-event", (evt) => {
     sendMouseEvent(
+      evt.detail.isRelative,
       evt.detail.buttons,
       evt.detail.relativeX,
       evt.detail.relativeY,

--- a/app/templates/custom-elements/menu-bar.html
+++ b/app/templates/custom-elements/menu-bar.html
@@ -247,6 +247,9 @@
         <li class="item">
           <a data-onclick-event="fullscreen-requested">Full Screen</a>
         </li>
+        <li class="item" id="mouse-mode-menu-item">
+          <a data-onclick-event="mouse-mode-toggled">Relative Mouse</a>
+        </li>
       </ul>
     </li>
 
@@ -346,6 +349,14 @@
           menuItem.classList.toggle("nav-selected", isEnabled);
         }
 
+        set isRelativeMouseEnabled(isEnabled) {
+          const menuItem = this.shadowRoot.getElementById(
+            "mouse-mode-menu-item"
+          );
+          menuItem.classList.toggle("nav-selected", isEnabled);
+          this.toggleHover(!isEnabled);
+        }
+
         emitCustomEvent(eventId, detail) {
           this.dispatchEvent(
             new CustomEvent(eventId, {
@@ -354,6 +365,30 @@
               composed: true,
             })
           );
+        }
+
+        toggleHover(isEnabled) {
+          for (const sheet of this.shadowRoot.styleSheets) {
+            if (sheet.cssRules) {
+              for (const rule of sheet.cssRules) {
+                if (rule.selectorText) {
+                  if (isEnabled) {
+                    rule.selectorText = rule.selectorText.replace(
+                      ":active",
+                      ":hover"
+                    );
+                  } else {
+                    setTimeout(() => {
+                      rule.selectorText = rule.selectorText.replace(
+                        ":hover",
+                        ":active"
+                      );
+                    }, 300);
+                  }
+                }
+              }
+            }
+          }
         }
 
         set cursor(newCursor) {

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -115,8 +115,18 @@
               this.fullscreenIsFullHeight = false;
             }
           });
+          let mouseSpeed = 1.0;
+          // eslint-disable-next-line eqeqeq
+          if (typeof URLSearchParams != "undefined") {
+            const searchParams = new URLSearchParams(window.location.search);
+            const newSpeed = parseFloat(searchParams.get("mouse-speed"));
+            if (!isNaN(newSpeed)) mouseSpeed = newSpeed;
+          }
           this.rateLimitedMouse = new RateLimitedMouse(
             this.millisecondsBetweenMouseEvents,
+            // eslint-disable-next-line capitalized-comments
+            false /*isMouseRelative:*/,
+            mouseSpeed,
             (mouseEvent) => {
               this.dispatchEvent(
                 new CustomEvent("mouse-event", {
@@ -194,17 +204,17 @@
             // Ensure that mouse drags don't attempt to drag the screen element.
             evt.preventDefault();
 
-            this.rateLimitedMouse.onMouseMove(evt);
+            this.rateLimitedMouse.onMouseMove(evt, this.isMouseRelative);
           });
           screenElement.addEventListener("mousedown", (evt) => {
-            this.rateLimitedMouse.onMouseDown(evt);
+            this.rateLimitedMouse.onMouseDown(evt, this.isMouseRelative);
           });
           screenElement.addEventListener("mouseup", (evt) => {
-            this.rateLimitedMouse.onMouseUp(evt);
+            this.rateLimitedMouse.onMouseUp(evt, this.isMouseRelative);
           });
           screenElement.addEventListener("wheel", (evt) => {
             evt.preventDefault();
-            this.rateLimitedMouse.onWheel(evt);
+            this.rateLimitedMouse.onWheel(evt, this.isMouseRelative);
           });
 
           // Ignore the context menu so that it doesn't block the screen when
@@ -230,6 +240,20 @@
 
         set millisecondsBetweenMouseEvents(newValue) {
           this.setAttribute("milliseconds-between-mouse-events", newValue);
+        }
+
+        get isMouseRelative() {
+          const currentScreen = this._getCurrentScreenElement();
+          return this.shadowRoot.pointerLockElement === currentScreen;
+        }
+
+        set isMouseRelative(newValue) {
+          const currentScreen = this._getCurrentScreenElement();
+          if (newValue === false) {
+            document.exitPointerLock();
+          } else if (this.shadowRoot.pointerLockElement !== currentScreen) {
+            currentScreen.requestPointerLock();
+          }
         }
 
         get cursor() {
@@ -384,6 +408,10 @@
             } catch {
               return;
             }
+            if (this.shadowRoot.pointerLockElement === this.elements.image) {
+              document.exitPointerLock();
+              this.elements.video.requestPointerLock();
+            }
             this.webrtcEnabled = true;
             this.elements.image.removeAttribute("src");
             this.dispatchEvent(new VideoStreamingModeChangedEvent("H264"));
@@ -488,6 +516,10 @@
         enableMjpeg() {
           if (this.elements.image.hasAttribute("src")) {
             return;
+          }
+          if (this.shadowRoot.pointerLockElement === this.elements.video) {
+            document.exitPointerLock();
+            this.elements.image.requestPointerLock();
           }
           this.elements.image.src = "/stream?advance_headers=1";
           this.webrtcEnabled = false;

--- a/dev_app_settings.cfg
+++ b/dev_app_settings.cfg
@@ -3,3 +3,4 @@
 
 KEYBOARD_PATH = '/dev/null'
 MOUSE_PATH = '/dev/null'
+RELATIVE_MOUSE_PATH = '/dev/null'


### PR DESCRIPTION
Adds support for a relative mouse.

I needed this for my NVR which doesn't recognize absolute position pointer. This adds new menu item in the 'View' menu which lets users enter a pointerlock-ed "relative" mouse mode. This mode must be exited with the Escape key.

Fixes #853

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1415"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>