### PR TITLE
Drop Ubuntu support from Ansible role

### DIFF
--- a/ansible-role/meta/main.yml
+++ b/ansible-role/meta/main.yml
@@ -11,9 +11,6 @@ galaxy_info:
     - name: Debian
       versions:
         - bullseye
-    - name: Ubuntu
-      versions:
-        - bionic
 
   galaxy_tags:
     - raspberrypi

--- a/ansible-role/tasks/install_usb_gadget.yml
+++ b/ansible-role/tasks/install_usb_gadget.yml
@@ -3,18 +3,17 @@
   lineinfile:
     path: /boot/config.txt
     line: dtoverlay=dwc2
-
-- name: check for an /etc/modules file
-  stat:
-    path: /etc/modules
-  register: etc_modules_stat
+  # Skip this step when running under molecule, as this path doesn't exist
+  # in standard Debian.
+  tags: molecule-notest
 
 - name: enable dwc2 driver in modules
   lineinfile:
     path: /etc/modules
-    create: no
     line: dwc2
-  when: etc_modules_stat.stat.exists
+  # Skip this step when running under molecule, as this path doesn't exist
+  # in standard Debian.
+  tags: molecule-notest
 
 - name: create TinyPilot privileged folder
   file:

--- a/ansible-role/tasks/install_usb_gadget.yml
+++ b/ansible-role/tasks/install_usb_gadget.yml
@@ -1,25 +1,8 @@
 ---
-- name: set the path to config.txt on non-Ubuntu systems
-  set_fact:
-    config_txt_path: /boot/config.txt
-  when: ansible_distribution != 'Ubuntu'
-
-- name: set the path to config.txt for Ubuntu
-  set_fact:
-    config_txt_path: /boot/firmware/config.txt
-  when: ansible_distribution == 'Ubuntu'
-
-- name: check for a boot config file
-  stat:
-    path: "{{ config_txt_path }}"
-  register: boot_config_stat
-
 - name: enable dwc2 driver in boot config
   lineinfile:
-    path: "{{ config_txt_path }}"
-    create: no
+    path: /boot/config.txt
     line: dtoverlay=dwc2
-  when: boot_config_stat.stat.exists
 
 - name: check for an /etc/modules file
   stat:


### PR DESCRIPTION
We added this very early in the project (https://github.com/tiny-pilot/ansible-role-tinypilot/pull/77), and I don't think there are many users still on Ubuntu, if any.

We dropped Ubuntu support for ansible-role-ustreamer six months ago (https://github.com/tiny-pilot/ansible-role-ustreamer/pull/63), so I suspect that TinyPilot doesn't fully work on Ubuntu anyway.

This also simplifies the logic around writing to `/boot/config.txt` and `/etc/modules`, which are Raspbian-specific paths. We partially added conditional logic for writing to these files for CI and partly to accommodate non-Raspbian distros. If we're not supporting other distros, I think a simpler approach is to more explicitly skip these steps in CI (under molecule).

Removing Ubuntu support simplifies our Ansible logic and ultimately helps ease our transition away from Ansible.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1416"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>