### PR TITLE
Enable the dwc2 driver from the Debian package install

### DIFF
--- a/ansible-role/tasks/install_usb_gadget.yml
+++ b/ansible-role/tasks/install_usb_gadget.yml
@@ -1,20 +1,4 @@
 ---
-- name: enable dwc2 driver in boot config
-  lineinfile:
-    path: /boot/config.txt
-    line: dtoverlay=dwc2
-  # Skip this step when running under molecule, as this path doesn't exist
-  # in standard Debian.
-  tags: molecule-notest
-
-- name: enable dwc2 driver in modules
-  lineinfile:
-    path: /etc/modules
-    line: dwc2
-  # Skip this step when running under molecule, as this path doesn't exist
-  # in standard Debian.
-  tags: molecule-notest
-
 - name: create TinyPilot privileged folder
   file:
     path: "{{ tinypilot_privileged_dir }}"

--- a/debian-pkg/debian/rules
+++ b/debian-pkg/debian/rules
@@ -3,9 +3,5 @@
 %:
 	dh $@
 
-execute_after_dh_fixperms:
-  chmod 0700 /opt/tinypilot-privileged/init-usb-gadget
-	chmod 0700 /opt/tinypilot-privileged/remove-usb-gadget
-
 override_dh_installsystemd:
 	dh_installsystemd --name=tinypilot-updater --no-start --no-enable

--- a/debian-pkg/debian/rules
+++ b/debian-pkg/debian/rules
@@ -3,5 +3,9 @@
 %:
 	dh $@
 
+execute_after_dh_fixperms:
+  chmod 0700 /opt/tinypilot-privileged/init-usb-gadget
+	chmod 0700 /opt/tinypilot-privileged/remove-usb-gadget
+
 override_dh_installsystemd:
 	dh_installsystemd --name=tinypilot-updater --no-start --no-enable

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -30,6 +30,18 @@ adduser \
 
 chown -R "${TINYPILOT_USER}:${TINYPILOT_GROUP}" /opt/tinypilot
 
+if [[ "$(lsb_release --id --short)" == 'Raspbian' ]] ; then
+  readonly MODULES_PATH="/etc/modules"
+  if ! grep --quiet '^dwc2\( \|$\)' "${MODULES_PATH}" ; then
+    echo "dwc2" | tee --append "${MODULES_PATH}"
+  fi
+
+  readonly BOOT_CONFIG_PATH="/boot/config.txt"
+  if ! grep --quiet '^dtoverlay=dwc2\( \|$\)' "${BOOT_CONFIG_PATH}" ; then
+    echo "dtoverlay=dwc2" | tee --append "${BOOT_CONFIG_PATH}"
+  fi
+fi
+
 # Use TinyPilot's settings to override uStreamer's runtime variables.
 if [[ ! -L "${USTREAMER_CONFIG_FILE}" ]]; then
   ln \

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -32,13 +32,13 @@ chown -R "${TINYPILOT_USER}:${TINYPILOT_GROUP}" /opt/tinypilot
 
 # Enable the dwc2 kernel driver, which we need to emulate USB devices with USB
 # OTG.
-readonly MODULES_PATH="/etc/modules"
+readonly MODULES_PATH='/etc/modules'
 if ! grep --quiet '^dwc2\( \|$\)' "${MODULES_PATH}" ; then
-  echo "dwc2" | tee --append "${MODULES_PATH}"
+  echo 'dwc2' | tee --append "${MODULES_PATH}"
 fi
-readonly BOOT_CONFIG_PATH="/boot/config.txt"
+readonly BOOT_CONFIG_PATH='/boot/config.txt'
 if ! grep --quiet '^dtoverlay=dwc2\( \|$\)' "${BOOT_CONFIG_PATH}" ; then
-  echo "dtoverlay=dwc2" | tee --append "${BOOT_CONFIG_PATH}"
+  echo 'dtoverlay=dwc2' | tee --append "${BOOT_CONFIG_PATH}"
 fi
 
 # Use TinyPilot's settings to override uStreamer's runtime variables.

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -33,11 +33,11 @@ chown -R "${TINYPILOT_USER}:${TINYPILOT_GROUP}" /opt/tinypilot
 # Enable the dwc2 kernel driver, which we need to emulate USB devices with USB
 # OTG.
 readonly MODULES_PATH='/etc/modules'
-if ! grep --quiet '^dwc2\( \|$\)' "${MODULES_PATH}" ; then
+if ! grep --quiet '^dwc2$' "${MODULES_PATH}" ; then
   echo 'dwc2' | tee --append "${MODULES_PATH}"
 fi
 readonly BOOT_CONFIG_PATH='/boot/config.txt'
-if ! grep --quiet '^dtoverlay=dwc2\( \|$\)' "${BOOT_CONFIG_PATH}" ; then
+if ! grep --quiet '^dtoverlay=dwc2$' "${BOOT_CONFIG_PATH}" ; then
   echo 'dtoverlay=dwc2' | tee --append "${BOOT_CONFIG_PATH}"
 fi
 

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -30,16 +30,15 @@ adduser \
 
 chown -R "${TINYPILOT_USER}:${TINYPILOT_GROUP}" /opt/tinypilot
 
-if [[ "$(lsb_release --id --short)" == 'Raspbian' ]] ; then
-  readonly MODULES_PATH="/etc/modules"
-  if ! grep --quiet '^dwc2\( \|$\)' "${MODULES_PATH}" ; then
-    echo "dwc2" | tee --append "${MODULES_PATH}"
-  fi
-
-  readonly BOOT_CONFIG_PATH="/boot/config.txt"
-  if ! grep --quiet '^dtoverlay=dwc2\( \|$\)' "${BOOT_CONFIG_PATH}" ; then
-    echo "dtoverlay=dwc2" | tee --append "${BOOT_CONFIG_PATH}"
-  fi
+# Install the dwc2 kernel driver, which we need to emulate USB devices with USB
+# OTG.
+readonly MODULES_PATH="/etc/modules"
+if ! grep --quiet '^dwc2\( \|$\)' "${MODULES_PATH}" ; then
+  echo "dwc2" | tee --append "${MODULES_PATH}"
+fi
+readonly BOOT_CONFIG_PATH="/boot/config.txt"
+if ! grep --quiet '^dtoverlay=dwc2\( \|$\)' "${BOOT_CONFIG_PATH}" ; then
+  echo "dtoverlay=dwc2" | tee --append "${BOOT_CONFIG_PATH}"
 fi
 
 # Use TinyPilot's settings to override uStreamer's runtime variables.

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -30,7 +30,7 @@ adduser \
 
 chown -R "${TINYPILOT_USER}:${TINYPILOT_GROUP}" /opt/tinypilot
 
-# Install the dwc2 kernel driver, which we need to emulate USB devices with USB
+# Enable the dwc2 kernel driver, which we need to emulate USB devices with USB
 # OTG.
 readonly MODULES_PATH="/etc/modules"
 if ! grep --quiet '^dwc2\( \|$\)' "${MODULES_PATH}" ; then


### PR DESCRIPTION
In continuing our War on Ansible, this strips the logic for enabling the dwc2 kernel driver (USB OTG functionality) from Ansible and reimplements it in the Debian install script.

I originally added a check to make sure we're installing on Raspbian to mirror the checks we were doing to avoid failing in molecule in CI, but I realized that if it's not a Raspbian system, the installer will just create the missing files, which isn't a problem.

### Testing

I tested this by building a TinyPilot Pro microSD image with this branch and https://github.com/tiny-pilot/tinypilot/pull/1418:

https://github.com/tiny-pilot/tinypilot-pro/tree/debian-dwc2-scratch

On boot, the USB emulation functionality worked fine. `/boot/config.txt` and `/etc/modules` had the expected contents.

Then, I tried building an updated bundle and installed that on top of the image, and everything still worked correctly, files still had their expected contents.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1417"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>