### PR TITLE
Refactor defaults in update settings

### DIFF
--- a/app/update/settings.py
+++ b/app/update/settings.py
@@ -49,16 +49,15 @@ class Settings:
     """
 
     def __init__(self, data):
-        self._data = data
-        if not self._data:
-            self._data = {}
+        # Merge the defaults with data, with data taking precedence.
+        self._data = {**_DEFAULTS, **(data if data else {})}
 
     def as_dict(self):
         return self._data
 
     @property
     def ustreamer_desired_fps(self):
-        return self._get('ustreamer_desired_fps')
+        return self._data['ustreamer_desired_fps']
 
     @ustreamer_desired_fps.setter
     def ustreamer_desired_fps(self, value):
@@ -66,7 +65,7 @@ class Settings:
 
     @property
     def ustreamer_quality(self):
-        return self._get('ustreamer_quality')
+        return self._data['ustreamer_quality']
 
     @ustreamer_quality.setter
     def ustreamer_quality(self, value):
@@ -74,14 +73,11 @@ class Settings:
 
     @property
     def ustreamer_h264_bitrate(self):
-        return self._get('ustreamer_h264_bitrate')
+        return self._data['ustreamer_h264_bitrate']
 
     @ustreamer_h264_bitrate.setter
     def ustreamer_h264_bitrate(self, value):
         self._data['ustreamer_h264_bitrate'] = value
-
-    def _get(self, prop_name):
-        return self._data.get(prop_name, _DEFAULTS[prop_name])
 
 
 def load():

--- a/app/update/settings.py
+++ b/app/update/settings.py
@@ -20,6 +20,14 @@ import video_service
 
 _SETTINGS_FILE_PATH = os.path.expanduser('~/settings.yml')
 
+# Define default settings for TinyPilot values. The YAML data in
+# _SETTINGS_FILE_PATH take precedence over these defaults.
+_DEFAULTS = {
+    'ustreamer_desired_fps': video_service.DEFAULT_FRAME_RATE,
+    'ustreamer_quality': video_service.DEFAULT_MJPEG_QUALITY,
+    'ustreamer_h264_bitrate': video_service.DEFAULT_H264_BITRATE,
+}
+
 
 class Error(Exception):
     pass
@@ -36,9 +44,6 @@ class SaveSettingsError(Error):
 class Settings:
     """Manages the parameters for the update process in a YAML file.
 
-    To avoid polluting the settings file with unnecessary default values, we
-    unset them instead of hard-coding the defaults in the file.
-
     For historical/compatibility reasons, the naming of the uStreamer properties
     is not in line with the naming conventions in the code.
     """
@@ -53,41 +58,30 @@ class Settings:
 
     @property
     def ustreamer_desired_fps(self):
-        return self._data.get('ustreamer_desired_fps',
-                              video_service.DEFAULT_FRAME_RATE)
+        return self._get('ustreamer_desired_fps')
 
     @ustreamer_desired_fps.setter
     def ustreamer_desired_fps(self, value):
-        self._set_or_clear('ustreamer_desired_fps', value,
-                           video_service.DEFAULT_FRAME_RATE)
+        self._data['ustreamer_desired_fps'] = value
 
     @property
     def ustreamer_quality(self):
-        return self._data.get('ustreamer_quality',
-                              video_service.DEFAULT_MJPEG_QUALITY)
+        return self._get('ustreamer_quality')
 
     @ustreamer_quality.setter
     def ustreamer_quality(self, value):
-        self._set_or_clear('ustreamer_quality', value,
-                           video_service.DEFAULT_MJPEG_QUALITY)
+        self._data['ustreamer_quality'] = value
 
     @property
     def ustreamer_h264_bitrate(self):
-        return self._data.get('ustreamer_h264_bitrate',
-                              video_service.DEFAULT_H264_BITRATE)
+        return self._get('ustreamer_h264_bitrate')
 
     @ustreamer_h264_bitrate.setter
     def ustreamer_h264_bitrate(self, value):
-        self._set_or_clear('ustreamer_h264_bitrate', value,
-                           video_service.DEFAULT_H264_BITRATE)
+        self._data['ustreamer_h264_bitrate'] = value
 
-    def _set_or_clear(self, prop_name, value, default_value):
-        if value == default_value:
-            if prop_name in self._data:
-                del self._data[prop_name]
-            return
-
-        self._data[prop_name] = value
+    def _get(self, prop_name):
+        return self._data.get(prop_name, _DEFAULTS[prop_name])
 
 
 def load():
@@ -127,6 +121,13 @@ def _from_file(settings_file):
 
 
 def _to_file(settings, settings_file):
-    """Writes a Settings object to a file."""
-    if settings.as_dict():
-        yaml.safe_dump(settings.as_dict(), settings_file)
+    """Writes a Settings object to a file, excluding any default values."""
+    # To avoid polluting the settings file with unnecessary default values, we
+    # exclude them instead of hard-coding the defaults in the file.
+    settings_without_defaults = {}
+    for key, value in settings.as_dict().items():
+        if (key not in _DEFAULTS) or (value != _DEFAULTS[key]):
+            settings_without_defaults[key] = value
+
+    if settings_without_defaults:
+        yaml.safe_dump(settings_without_defaults, settings_file)

--- a/app/update/settings_test.py
+++ b/app/update/settings_test.py
@@ -35,8 +35,10 @@ class UpdateSettingsTest(unittest.TestCase):
         with open(self.settings_file_path, encoding='utf-8') as mock_file:
             return mock_file.read()
 
-    def test_returns_empty_settings_if_no_settings_file_exists(self):
-        self.assertEqual({}, update.settings.load().as_dict())
+    def test_as_dict_returns_default_settings_if_no_settings_file_exists(self):
+        settings_dict = update.settings.load().as_dict()
+        self.assertEqual(30, settings_dict['ustreamer_desired_fps'])
+        self.assertEqual(3, len(settings_dict))
 
     def test_populates_empty_file_with_blank_settings(self):
         self.make_mock_settings_file('')


### PR DESCRIPTION
In https://github.com/tiny-pilot/tinypilot/pull/1404 @jdeanwallace suggested consolidating the default values we need during update/install into `app/update/settings.py`.

I thought that was a good idea, so I'm doing a bit of refactoring of `app/update/settings.py` in preparation of that effort.

This is a pure refactoring and should have no functional effects outside of the `settings` module. We're changing the behavior of `as_dict`, but we don't call that outside of `settings`.

The idea of the change was that previously, we were avoiding saving any setting to the `Settings` object's internal dict if the value matched our defaults. The goal was to avoid writing out default values to the settings file because once we write them to the file, we can't tell if the user selected it explicitly or if it was just the implicit default.

I think it's a little cleaner if we unconditionally save data to the `Settings` internal dict (even if the setting matches our defaults), and push the cleanup later to just before we write the data to a file. This also makes it easy for us to collect all the default values in a single dict at the top of the file, whereas before they were sprinkled across several places in the code.

The benefit of saving all the data (including defaults) in the internal `Settings` dict is that then we can use the `as_dict` method to get the full set of settings, which we can use in #1404 to render templates.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1433"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>