### PR TITLE
Fix shellcheck issues in ansible-role-ustreamer

### DIFF
--- a/ansible-role-ustreamer/tests/check-trailing-newline
+++ b/ansible-role-ustreamer/tests/check-trailing-newline
@@ -17,7 +17,7 @@ FILES=$(find . \
 
 SUCCESS=0
 
-for F in ${FILES[*]}
+for F in "${FILES[@]}"
 do
   if ! [[ -s "$F" && -z "$(tail -c 1 "$F")" ]]; then
     printf "File must end in a trailing newline: %s\n" "$F"


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot/issues/1426
Dependent on https://github.com/tiny-pilot/tinypilot/pull/1434

Caveat: This change is just to satisfy the [`check_bash` CI check](https://app.circleci.com/pipelines/github/tiny-pilot/tinypilot/3462/workflows/cd3bda98-6f98-4a4c-b860-0222cb4cf272/jobs/19191). We'll soon remove the `ansible-role-ustreamer/tests/check-trailing-newline` script entirely.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1436"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>