### PR TITLE
Simplify heredoc in TinyPilot postinst

### DIFF
--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -52,15 +52,16 @@ fi
 # Populate TinyPilot's Flask settings file.
 pushd /opt/tinypilot
 readonly TINYPILOT_APP_SETTINGS='/home/tinypilot/app_settings.cfg'
-SETTINGS_TEMPLATE='
+
+
+SETTINGS_TEMPLATE="$(cat <<-'EOF'
 # This configuration file is an actual Python file. Only variables in uppercase
 # are recognized as config keys.
 
-KEYBOARD_PATH = "{{ tinypilot_keyboard_interface }}"
-MOUSE_PATH = "{{ tinypilot_mouse_interface }}"
-'
-# Strip leading newline.
-SETTINGS_TEMPLATE="${SETTINGS_TEMPLATE:1}"
+KEYBOARD_PATH = '{{ tinypilot_keyboard_interface }}'
+MOUSE_PATH = '{{ tinypilot_mouse_interface }}'
+EOF
+)"
 readonly SETTINGS_TEMPLATE
 . venv/bin/activate && \
   PYTHONPATH=/opt/tinypilot/app \

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -52,8 +52,6 @@ fi
 # Populate TinyPilot's Flask settings file.
 pushd /opt/tinypilot
 readonly TINYPILOT_APP_SETTINGS='/home/tinypilot/app_settings.cfg'
-
-
 SETTINGS_TEMPLATE="$(cat <<-'EOF'
 # This configuration file is an actual Python file. Only variables in uppercase
 # are recognized as config keys.


### PR DESCRIPTION
Per @jdeanwallace's comment (https://github.com/tiny-pilot/tinypilot/pull/1404#pullrequestreview-1479361539), there's a simpler way of generating the template file without having to bend around single quotes, so we should use it.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1441"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>