### PR TITLE
Easily trigger CI builds for testing/debugging

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -3,6 +3,11 @@ parameters:
   ansible_role_changed:
     type: boolean
     default: false
+  # Creating the bundle assumes an ARMv7 build, so we only do this on master,
+  # because it's slow building ARMv7 binaries from a CircleCI AMD64 instance.
+  build_branch:
+    type: string
+    default: master
 jobs:
   check_whitespace:
     docker:
@@ -90,11 +95,9 @@ jobs:
           command: ./dev-scripts/enable-multiarch-docker
       - run:
           name: Build Debian package
-          # Building ARMv7 binaries is slow, so we only build them on the master
-          # branch.
           command: |
             set -exu
-            if [[ "${CIRCLE_BRANCH}" == 'master' ]]; then
+            if [[ "${CIRCLE_BRANCH}" == '<< pipeline.parameters.build_branch >>' ]]; then
               readonly BUILD_TARGETS='linux/arm/v7,linux/amd64'
             else
               readonly BUILD_TARGETS='linux/amd64'
@@ -161,7 +164,7 @@ jobs:
           condition:
             or:
               - << pipeline.parameters.ansible_role_changed >>
-              - equal: [master, << pipeline.git.branch >>]
+              - equal: [<< pipeline.parameters.build_branch >>, << pipeline.git.branch >>]
           steps:
             - run:
                 name: Skipping job because files weren't changed
@@ -289,12 +292,9 @@ workflows:
       - build_bundle:
           requires:
             - build_debian_package
-          # Creating the bundle assumes an ARMv7 build, so we only do this on
-          # master, because it's slow building the ARMv7 binaries from a
-          # CircleCI AMD64 instance.
           filters:
             branches:
-              only: master
+              only: << pipeline.parameters.build_branch >>
       - verify_bundle:
           requires:
             - build_bundle

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -5,7 +5,7 @@ parameters:
     default: false
   # Creating the bundle assumes an ARMv7 build, so we only do this on master,
   # because it's slow building ARMv7 binaries from a CircleCI AMD64 instance.
-  build_branch:
+  bundle_build_branch:
     type: string
     default: master
 jobs:
@@ -97,7 +97,7 @@ jobs:
           name: Build Debian package
           command: |
             set -exu
-            if [[ "${CIRCLE_BRANCH}" == '<< pipeline.parameters.build_branch >>' ]]; then
+            if [[ "${CIRCLE_BRANCH}" == '<< pipeline.parameters.bundle_build_branch >>' ]]; then
               readonly BUILD_TARGETS='linux/arm/v7,linux/amd64'
             else
               readonly BUILD_TARGETS='linux/amd64'
@@ -166,7 +166,7 @@ jobs:
               - << pipeline.parameters.ansible_role_changed >>
               - equal:
                   [
-                    << pipeline.parameters.build_branch >>,
+                    << pipeline.parameters.bundle_build_branch >>,
                     << pipeline.git.branch >>,
                   ]
           steps:
@@ -298,7 +298,7 @@ workflows:
             - build_debian_package
           filters:
             branches:
-              only: << pipeline.parameters.build_branch >>
+              only: << pipeline.parameters.bundle_build_branch >>
       - verify_bundle:
           requires:
             - build_bundle

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -6,8 +6,8 @@ parameters:
   # Creating the bundle assumes an ARMv7 build, so we only do this on master,
   # because it's slow building ARMv7 binaries from a CircleCI AMD64 instance.
   bundle_build_branch:
-    type: string
-    default: master
+    type: boolean
+    default: << pipeline.parameters.ansible_role_changed >>
 jobs:
   check_whitespace:
     docker:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1,8 +1,10 @@
 version: 2.1
 parameters:
-  ansible_role_changed:
+  ansible_role_changed: &ansible_role_changed
     type: boolean
     default: false
+  copy_ansible_role_changed:
+    <<: *ansible_role_changed
   # Creating the bundle assumes an ARMv7 build, so we only do this on master,
   # because it's slow building ARMv7 binaries from a CircleCI AMD64 instance.
   bundle_build_branch:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -6,8 +6,8 @@ parameters:
   # Creating the bundle assumes an ARMv7 build, so we only do this on master,
   # because it's slow building ARMv7 binaries from a CircleCI AMD64 instance.
   bundle_build_branch:
-    type: boolean
-    default: << pipeline.parameters.ansible_role_changed >>
+    type: string
+    default: master
 jobs:
   check_whitespace:
     docker:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -7,7 +7,7 @@ parameters:
   # because it's slow building ARMv7 binaries from a CircleCI AMD64 instance.
   build_branch:
     type: string
-    default: << pipeline.git.branch >>
+    default: master
 jobs:
   check_whitespace:
     docker:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -7,7 +7,7 @@ parameters:
   # because it's slow building ARMv7 binaries from a CircleCI AMD64 instance.
   build_branch:
     type: string
-    default: master
+    default: << pipeline.git.branch >>
 jobs:
   check_whitespace:
     docker:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1,10 +1,8 @@
 version: 2.1
 parameters:
-  ansible_role_changed: &ansible_role_changed
+  ansible_role_changed:
     type: boolean
     default: false
-  copy_ansible_role_changed:
-    <<: *ansible_role_changed
   # Creating the bundle assumes an ARMv7 build, so we only do this on master,
   # because it's slow building ARMv7 binaries from a CircleCI AMD64 instance.
   bundle_build_branch:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -164,7 +164,11 @@ jobs:
           condition:
             or:
               - << pipeline.parameters.ansible_role_changed >>
-              - equal: [<< pipeline.parameters.build_branch >>, << pipeline.git.branch >>]
+              - equal:
+                  [
+                    << pipeline.parameters.build_branch >>,
+                    << pipeline.git.branch >>,
+                  ]
           steps:
             - run:
                 name: Skipping job because files weren't changed


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot-pro/issues/931

This PR adds an additional `bundle_build_branch` CI pipeline parameter that specifies which branch triggers a build (i.e., running `build_debian_package`, `build_ansible_role`, and `build_bundle`). In TinyPilot Pro, this would eventually also create a microSD image.

We can now manually trigger a build with a one-line change https://github.com/tiny-pilot/tinypilot/pull/1442/commits/ea8b10e3c825fa002246c9a59c50c7ed58260c5d

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1442"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>