### PR TITLE
Update Github Actions to a version that support Node 16

### DIFF
--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -2,7 +2,7 @@ name: Merge community changes into pro repo
 on:
   push:
     branches:
-      - merge-pro
+      - master
 jobs:
   updateFork:
     runs-on: ubuntu-latest
@@ -14,7 +14,7 @@ jobs:
       - name: Reset the default branch with upstream changes
         run: |
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
-          git fetch upstream merge-pro:upstream-master
+          git fetch upstream master:upstream-master
           git reset --hard upstream-master
       - name: Get the URL of the original community PR
         run: |
@@ -37,7 +37,7 @@ jobs:
           # If the committer to the community repo (github.actor) has no access
           # to the pro repo, the PR will be unassigned.
           assignees: ${{ github.actor }}
-          title: "[TEST] Merge changes from community repository"
+          title: Merge changes from community repository
           body: |
             Related ${{ env.COMMUNITY_PR_URL }}
 

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -2,7 +2,7 @@ name: Merge community changes into pro repo
 on:
   push:
     branches:
-      - master
+      - merge-pro
 jobs:
   updateFork:
     runs-on: ubuntu-latest
@@ -14,7 +14,7 @@ jobs:
       - name: Reset the default branch with upstream changes
         run: |
           git remote add upstream https://github.com/tiny-pilot/tinypilot.git
-          git fetch upstream master:upstream-master
+          git fetch upstream merge-pro:upstream-master
           git reset --hard upstream-master
       - name: Get the URL of the original community PR
         run: |
@@ -37,7 +37,7 @@ jobs:
           # If the committer to the community repo (github.actor) has no access
           # to the pro repo, the PR will be unassigned.
           assignees: ${{ github.actor }}
-          title: Merge changes from community repository
+          title: "[TEST] Merge changes from community repository"
           body: |
             Related ${{ env.COMMUNITY_PR_URL }}
 

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -7,7 +7,7 @@ jobs:
   updateFork:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: tiny-pilot/tinypilot-pro
           token: ${{ secrets.PR_BOT_PAT }}
@@ -29,7 +29,7 @@ jobs:
           readonly COMMUNITY_PR_URL
           echo "COMMUNITY_PR_URL=${COMMUNITY_PR_URL}" >> "${GITHUB_ENV}"
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.PR_BOT_PAT }}
           branch: community-changes-${{ github.sha }}


### PR DESCRIPTION
Our Github workflow, that automatically creates a TinyPilot Pro PR with TinyPilot Community changes, has [started to fail](https://github.com/tiny-pilot/tinypilot/actions/runs/5280147817) because [Github Actions is deprecating Node 12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).

<img width="524" alt="Screen Shot 2023-06-15 at 16 48 16" src="https://github.com/tiny-pilot/tinypilot/assets/6730025/d1c05fa7-44af-465a-9d15-75f0ad69484d">


This PR upgrades each of the Github Actions that we use to a version that supports Node 16.

Tested via https://github.com/tiny-pilot/tinypilot-pro/pull/938

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1447"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>