### PR TITLE
Add a yq binary mapping for armv6l

### DIFF
--- a/ansible-role-ustreamer/tasks/install_launcher.yml
+++ b/ansible-role-ustreamer/tasks/install_launcher.yml
@@ -5,8 +5,8 @@
   set_fact:
     ustreamer_yq_architecture_map:
       x86_64: amd64
-      armv7l: arm
       armv6l: arm
+      armv7l: arm
       aarch64: arm64
 
 - name: canonicalize yq binary architecture

--- a/ansible-role-ustreamer/tasks/install_launcher.yml
+++ b/ansible-role-ustreamer/tasks/install_launcher.yml
@@ -6,6 +6,7 @@
     ustreamer_yq_architecture_map:
       x86_64: amd64
       armv7l: arm
+      armv6l: arm
       aarch64: arm64
 
 - name: canonicalize yq binary architecture


### PR DESCRIPTION
Resolves #1449

On Pi Zero W, Ansible detects the architecture as `armv6l`. This PR updates our mappings of Ansible-semantics to yq-semantics names of architectures to include a mapping of `armv6l` -> `arm`.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1448"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>