### PR TITLE
Add ARIA roles to menu bar elements

### DIFF
--- a/app/templates/custom-elements/menu-bar.html
+++ b/app/templates/custom-elements/menu-bar.html
@@ -173,52 +173,66 @@
   </style>
 
   <div class="logo"><img src="/img/logo.svg" alt="TinyPilot logo" /></div>
-  <ul class="groups header-item">
-    <li class="group">
-      <a>System</a>
-      <ul class="items">
-        <li class="item pro-badge">
-          <a data-onclick-event="mass-storage-dialog-requested"
+  <ul class="groups header-item" role="menu">
+    <li class="group" role="presentation">
+      <a role="menuitem">System</a>
+      <ul class="items" role="group">
+        <li class="item pro-badge" role="presentation">
+          <a data-onclick-event="mass-storage-dialog-requested" role="menuitem"
             >Virtual Media</a
           >
         </li>
-        <li class="item">
-          <a data-onclick-event="update-dialog-requested">Update</a>
+        <li class="item" role="presentation">
+          <a data-onclick-event="update-dialog-requested" role="menuitem"
+            >Update</a
+          >
         </li>
-        <li class="item">
-          <a data-onclick-event="change-hostname-dialog-requested">Hostname</a>
+        <li class="item" role="presentation">
+          <a
+            data-onclick-event="change-hostname-dialog-requested"
+            role="menuitem"
+            >Hostname</a
+          >
         </li>
-        <li class="item">
-          <a data-onclick-event="video-settings-dialog-requested"
+        <li class="item" role="presentation">
+          <a
+            data-onclick-event="video-settings-dialog-requested"
+            role="menuitem"
             >Video Settings</a
           >
         </li>
-        <li class="item">
-          <a data-onclick-event="debug-logs-dialog-requested">Logs</a>
+        <li class="item" role="presentation">
+          <a data-onclick-event="debug-logs-dialog-requested" role="menuitem"
+            >Logs</a
+          >
         </li>
-        <li class="item">
-          <a data-onclick-event="shutdown-dialog-requested">Power</a>
+        <li class="item" role="presentation">
+          <a data-onclick-event="shutdown-dialog-requested" role="menuitem"
+            >Power</a
+          >
         </li>
       </ul>
     </li>
 
-    <li class="group">
-      <a>Actions</a>
-      <ul class="items">
-        <li class="item">
-          <a data-onclick-event="paste-requested">Paste</a>
+    <li class="group" role="presentation">
+      <a role="menuitem">Actions</a>
+      <ul class="items" role="group">
+        <li class="item" role="presentation">
+          <a data-onclick-event="paste-requested" role="menuitem">Paste</a>
         </li>
-        <li class="item">
-          <a id="screenshot-btn" href="/snapshot">Screenshot</a>
+        <li class="item" role="presentation">
+          <a id="screenshot-btn" href="/snapshot" role="menuitem">Screenshot</a>
         </li>
-        <li class="item pro-badge">
-          <a data-onclick-event="wake-on-lan-dialog-requested">Wake on LAN</a>
+        <li class="item pro-badge" role="presentation">
+          <a data-onclick-event="wake-on-lan-dialog-requested" role="menuitem"
+            >Wake on LAN</a
+          >
         </li>
-        <li class="item subgroup">
-          <a>Keyboard Shortcuts</a>
-          <ul class="items">
-            <li class="item">
-              <a data-onclick-event="ctrl-alt-del-requested"
+        <li class="item subgroup" role="presentation">
+          <a role="menuitem">Keyboard Shortcuts</a>
+          <ul class="items" role="group">
+            <li class="item" role="presentation">
+              <a data-onclick-event="ctrl-alt-del-requested" role="menuitem"
                 >Ctrl + Alt + Del</a
               >
             </li>
@@ -227,48 +241,56 @@
       </ul>
     </li>
 
-    <li class="group">
-      <a>View</a>
-      <ul class="items">
-        <li class="item subgroup">
-          <a>Cursor</a>
-          <ul id="cursor-list" class="items">
+    <li class="group" role="presentation">
+      <a role="menuitem">View</a>
+      <ul class="items" role="group">
+        <li class="item subgroup" role="presentation">
+          <a role="menuitem">Cursor</a>
+          <ul id="cursor-list" class="items" role="group">
             <!-- JavaScript populates this list dynamically. -->
           </ul>
         </li>
-        <li class="item" id="keyboard-menu-item">
-          <a data-onclick-event="keyboard-visibility-toggled">Show Keyboard</a>
+        <li class="item" id="keyboard-menu-item" role="presentation">
+          <a data-onclick-event="keyboard-visibility-toggled" role="menuitem"
+            >Show Keyboard</a
+          >
         </li>
-        <li class="item" id="keystroke-history-menu-item">
-          <a data-onclick-event="keystroke-history-toggled"
+        <li class="item" id="keystroke-history-menu-item" role="presentation">
+          <a data-onclick-event="keystroke-history-toggled" role="menuitem"
             >Enable Key History</a
           >
         </li>
-        <li class="item">
-          <a data-onclick-event="fullscreen-requested">Full Screen</a>
+        <li class="item" role="presentation">
+          <a data-onclick-event="fullscreen-requested" role="menuitem"
+            >Full Screen</a
+          >
         </li>
       </ul>
     </li>
 
-    <li class="group">
-      <a>Help</a>
-      <ul class="items">
-        <li class="item">
-          <a data-onclick-event="about-dialog-requested">About</a>
+    <li class="group" role="presentation">
+      <a role="menuitem">Help</a>
+      <ul class="items" role="group">
+        <li class="item" role="presentation">
+          <a data-onclick-event="about-dialog-requested" role="menuitem"
+            >About</a
+          >
         </li>
-        <li class="item external-link">
+        <li class="item external-link" role="presentation">
           <a
             href="https://tinypilotkvm.com/product/tinypilot-pro?ref=tinypilot-app"
             rel="noopener noreferrer"
             target="_blank"
+            role="menuitem"
             >Upgrade to Pro</a
           >
         </li>
-        <li class="item external-link">
+        <li class="item external-link" role="presentation">
           <a
             href="https://github.com/tiny-pilot/tinypilot"
             rel="noopener noreferrer"
             target="_blank"
+            role="menuitem"
             >Github</a
           >
         </li>
@@ -321,6 +343,7 @@
           for (const cursorOption of screenCursorOptions.splice(1)) {
             const cursorLink = document.createElement("a");
             cursorLink.setAttribute("href", "#");
+            cursorLink.setAttribute("role", "menuitem");
             cursorLink.innerText = cursorOption;
             cursorLink.addEventListener("click", (evt) => {
               this.emitCustomEvent("cursor-selected", { cursor: cursorOption });
@@ -330,6 +353,7 @@
             listItem.appendChild(cursorLink);
             listItem.classList.add("cursor-option", "item");
             listItem.setAttribute("cursor", cursorOption);
+            listItem.setAttribute("role", "presentation");
             cursorList.appendChild(listItem);
           }
         }

--- a/app/templates/custom-elements/menu-bar.html
+++ b/app/templates/custom-elements/menu-bar.html
@@ -173,7 +173,7 @@
   </style>
 
   <div class="logo"><img src="/img/logo.svg" alt="TinyPilot logo" /></div>
-  <ul class="groups header-item" role="menu">
+  <ul class="groups header-item" role="menubar">
     <li class="group" role="presentation">
       <a role="menuitem">System</a>
       <ul class="items" role="group">

--- a/e2e/about.spec.js
+++ b/e2e/about.spec.js
@@ -4,8 +4,8 @@ test("shows about page, license, privacy policy, and dependency pages and licens
   page,
 }) => {
   await page.goto("/");
-  await page.getByText("Help", { exact: true }).hover();
-  await page.getByText("About", { exact: true }).click();
+  await page.getByRole("menuitem", { name: "Help" }).hover();
+  await page.getByRole("menuitem", { name: "About" }).click();
   await expect(
     page.getByRole("heading", { name: "About TinyPilot" })
   ).toBeVisible();

--- a/e2e/debug-logs.spec.js
+++ b/e2e/debug-logs.spec.js
@@ -31,8 +31,8 @@ test("loads debug logs and generates a shareable URL for them", async ({
 }) => {
   await page.goto("/");
 
-  await page.getByText("System", { exact: true }).hover();
-  await page.getByText("Logs", { exact: true }).click();
+  await page.getByRole("menuitem", { name: "System" }).hover();
+  await page.getByRole("menuitem", { name: "Logs" }).click();
   await expect(page.getByRole("heading", { name: "Debug Logs" })).toBeVisible();
 
   await page.getByRole("button", { name: "Get Shareable URL" }).click();


### PR DESCRIPTION
This change adds four Accessible Rich Internet Applications (ARIA) roles to our menu bar. This allows us to use clearer semantics in our end-to-end tests and better present the UI to assistive technologies.

I largely based the role assignment on these examples:

* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menuitem_role#examples
* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/group_role#examples

### `menubar`

>A menubar is a presentation of menu that usually remains visible and is usually presented horizontally.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menubar_role

I applied this to the top-level container for our menu.

I debated between `menubar` and `menu`, but `menubar` felt like the closer fit.

### `menuitem`

>The `menuitem` role indicates the element is an option in a set of choices contained by a `menu` or `menubar`.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menuitem_role

I applied this to every `<a>` tag in our menu bar.

### `presentation`

>The `presentation` role and its synonym `none` remove an element's implicit ARIA semantics from being exposed to the accessibility tree.

>The content of the element will still be available to assistive technologies; it is only the semantics of the container — and in some instance, required associated descendants — which will no longer expose their mappings to the accessibility API.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role

I applied this to every `<li>` element in our menu, as my understanding is that we want to tell assistive tools that they're not *really* list items.

### `group`

>The group role identifies a set of user interface objects that is not intended to be included in a page summary or table of contents by assistive technologies.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/group_role

I applied this to every `<ul>` in the menu that represented a group of menu items.

---

I also changed our end-to-end tests to make more use of `getByRole`, which is Playwright's recommended method for locating page elements:

>We recommend prioritizing role locators to locate elements, as it is the closest way to how users and assistive technology perceive the page.

https://playwright.dev/docs/locators#locate-by-role

### Implementation note

There's pretty much a 1:1 mapping between our CSS classes and these new ARIA roles. I started trying to replace the classes and changed the CSS selectors to use the `role` attributes, but it got a little hairy, so I decided to limit these changes to just adding the proper ARIA roles without messing with CSS.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1452"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>