### PR TITLE
Remove 'exact' option from e2e test matchers

### DIFF
--- a/e2e/about.spec.js
+++ b/e2e/about.spec.js
@@ -30,10 +30,7 @@ test("shows about page, license, privacy policy, and dependency pages and licens
 
   {
     const flaskProjectPagePromise = page.waitForEvent("popup");
-    await page
-      .getByRole("link", { name: "Flask", exact: true })
-      .first()
-      .click();
+    await page.getByRole("link", { name: "Flask" }).first().click();
     const flaskProjectPage = await flaskProjectPagePromise;
     await expect(flaskProjectPage).toHaveURL(
       new RegExp("https://flask.palletsprojects.com.*")
@@ -60,10 +57,7 @@ test("shows about page, license, privacy policy, and dependency pages and licens
 
   {
     const cryptographyProjectPagePromise = page.waitForEvent("popup");
-    await page
-      .getByRole("link", { name: "cryptography", exact: true })
-      .first()
-      .click();
+    await page.getByRole("link", { name: "cryptography" }).first().click();
     const cryptographyProjectPage = await cryptographyProjectPagePromise;
     await expect(cryptographyProjectPage).toHaveURL(
       new RegExp("https://cryptography.io.*")
@@ -85,7 +79,7 @@ test("shows about page, license, privacy policy, and dependency pages and licens
     await cryptographyLicensePage.close();
   }
 
-  await page.getByRole("button", { name: "Close", exact: true }).click();
+  await page.getByRole("button", { name: "Close" }).click();
   await expect(
     page.getByRole("heading", { name: "About TinyPilot" })
   ).not.toBeVisible();

--- a/e2e/debug-logs.spec.js
+++ b/e2e/debug-logs.spec.js
@@ -46,7 +46,7 @@ test("loads debug logs and generates a shareable URL for them", async ({
     "TinyPilot version: "
   );
 
-  await page.getByRole("button", { name: "Close", exact: true }).click();
+  await page.getByRole("button", { name: "Close" }).click();
   await expect(
     page.getByRole("heading", { name: "Debug Logs" })
   ).not.toBeVisible();


### PR DESCRIPTION
Our e2e code uses a mix of locators with the 'exact' option and locators that omit it, but we never chose a deliberate convention for this.

The `exact` option does a whole-string match and is case sensitive, whereas the default (or `exact: false`) does not.

In general, I prefer rigorous tests, but I don't think there's enough value in the `exact` option to outweigh the clutter it adds to the tests, so I move to drop it as the default and only use it in places where an exact match is especially important.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1453"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>