### PR TITLE
Use sudo for cleanup procedure

### DIFF
--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -82,8 +82,8 @@ INSTALLER_DIR='/mnt/tinypilot-installer'
 
 # Remove temporary files & directories.
 clean_up() {
-  umount --lazy "${INSTALLER_DIR}" || true
-  rm -rf \
+  sudo umount --lazy "${INSTALLER_DIR}" || true
+  sudo rm -rf \
     "${LEGACY_INSTALLER_DIR}" \
     "${INSTALLER_DIR}"
 }


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1443.

When executing `get-tinypilot.sh` under a non-root user (but with `sudo` access), then the [`unmount` and `rm` commands in the `clean_up` function](https://github.com/tiny-pilot/tinypilot/blob/7c25815df640483c7caa266c2e94fdc28cf5ef59/get-tinypilot.sh#L85-L88) will yield errors:

```bash
+ clean_up
+ umount --lazy /mnt/tinypilot-installer
umount: /mnt/tinypilot-installer: must be superuser to unmount.
+ true
+ rm -rf /opt/tinypilot-updater /mnt/tinypilot-installer
rm: cannot remove '/mnt/tinypilot-installer/roles/ansible-role-nginx/vars/RedHat.yml': Permission denied
rm: cannot remove '/mnt/tinypilot-installer/roles/ansible-role-nginx/vars/OpenBSD.yml': Permission denied
rm: cannot remove '/mnt/tinypilot-installer/roles/ansible-role-nginx/vars/FreeBSD.yml': Permission denied
# ...
```

The reason is that [`mount` was executed with `sudo`](https://github.com/tiny-pilot/tinypilot/blob/7c25815df640483c7caa266c2e94fdc28cf5ef59/get-tinypilot.sh#L106), and both the [`$INSTALLER_DIR`](https://github.com/tiny-pilot/tinypilot/blob/7c25815df640483c7caa266c2e94fdc28cf5ef59/get-tinypilot.sh#L105) and the `$LEGACY_INSTALLER_DIR` (`/opt/tinypilot-updated`) folders are owned by `root`.

Therefore, we need to execute the respective “inverse” commands with `sudo` as well, to make the error go away.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1456"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>