### PR TITLE
Use RAMdisk based on available memory instead of free memory

### DIFF
--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -71,11 +71,11 @@ readonly LEGACY_INSTALLER_DIR='/opt/tinypilot-updater'
 #   du --summarize --total --bytes "${INSTALLER_DIR}" "${BUNDLE_FILE}"
 readonly RAMDISK_SIZE_MIB=500
 
-FREE_MEMORY_MIB="$(free --mebi |
+AVAILABLE_MEMORY_MIB="$(free --mebi |
   grep --fixed-strings 'Mem:' |
   tr --squeeze-repeats ' ' |
-  cut --delimiter ' ' --fields 4)"
-readonly FREE_MEMORY_MIB
+  cut --delimiter ' ' --fields 7)"
+readonly AVAILABLE_MEMORY_MIB
 
 # Assign a provisional installation directory for our `clean_up` function.
 INSTALLER_DIR='/mnt/tinypilot-installer'
@@ -93,7 +93,7 @@ trap 'clean_up' EXIT
 
 # Determine the installation directory. Use RAMdisk if there is enough memory,
 # otherwise, fall back to regular disk.
-if (( "${FREE_MEMORY_MIB}" >= "${RAMDISK_SIZE_MIB}" )); then
+if (( "${AVAILABLE_MEMORY_MIB}" >= "${RAMDISK_SIZE_MIB}" )); then
   # Mount volatile RAMdisk.
   # Note: `tmpfs` can use swap space when the device's physical memory is under
   # pressure. Alternatively, we could use `ramfs` which doesn't use swap space,

--- a/scripts/install-bundle
+++ b/scripts/install-bundle
@@ -86,11 +86,11 @@ readonly LEGACY_INSTALLER_DIR='/opt/tinypilot-updater'
 #   du --summarize --total --bytes "${INSTALLER_DIR}" "${BUNDLE_FILE}"
 readonly RAMDISK_SIZE_MIB=500
 
-FREE_MEMORY_MIB="$(free --mebi |
+AVAILABLE_MEMORY_MIB="$(free --mebi |
   grep --fixed-strings 'Mem:' |
   tr --squeeze-repeats ' ' |
-  cut --delimiter ' ' --fields 4)"
-readonly FREE_MEMORY_MIB
+  cut --delimiter ' ' --fields 7)"
+readonly AVAILABLE_MEMORY_MIB
 
 # Assign a provisional installation directory for our `clean_up` function.
 INSTALLER_DIR='/mnt/tinypilot-installer'
@@ -108,7 +108,7 @@ trap 'clean_up' EXIT
 
 # Determine the installation directory. Use RAMdisk if there is enough memory,
 # otherwise, fall back to regular disk.
-if (( "${FREE_MEMORY_MIB}" >= "${RAMDISK_SIZE_MIB}" )); then
+if (( "${AVAILABLE_MEMORY_MIB}" >= "${RAMDISK_SIZE_MIB}" )); then
   # Mount volatile RAMdisk.
   # Note: `tmpfs` can use swap space when the device's physical memory is under
   # pressure. Alternatively, we could use `ramfs` which doesn't use swap space,


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1461

Based on `man free` it is more appropriate to use the metric for available memory instead of free memory, when deciding whether to use the RAMdisk for TinyPilot installation/update.

>   free   Unused memory (MemFree and SwapFree in /proc/meminfo)
> ...
> available: Estimation of how much memory is available for starting new applications, without swapping. Unlike the data provided by the cache or free fields, this field  takes  into account  page cache and also that not all reclaimable memory slabs will be reclaimed due to items being in use (MemAvailable in /proc/meminfo, available on kernels 3.14, emulated on kernels 2.6.27+, otherwise the same as free)

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1463"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>