### PR TITLE
Remove circular dependency on uStreamer user when provisioning tc358743 chip

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -7,7 +7,7 @@ parameters:
   # because it's slow building ARMv7 binaries from a CircleCI AMD64 instance.
   bundle_build_branch:
     type: string
-    default: master
+    default: << pipeline.git.branch >>
 jobs:
   check_whitespace:
     docker:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -7,7 +7,7 @@ parameters:
   # because it's slow building ARMv7 binaries from a CircleCI AMD64 instance.
   bundle_build_branch:
     type: string
-    default: << pipeline.git.branch >>
+    default: master
 jobs:
   check_whitespace:
     docker:

--- a/ansible-role-ustreamer/tasks/main.yml
+++ b/ansible-role-ustreamer/tasks/main.yml
@@ -101,14 +101,6 @@
     name: ustreamer
     enabled: yes
 
-- name: save uStreamer settings file
-  template:
-    src: config.yml.j2
-    dest: "{{ ustreamer_settings_file }}"
-    owner: "{{ ustreamer_user }}"
-    group: "{{ ustreamer_group }}"
-    mode: "0644"
-
 - name: create uStreamer Janus plugin config
   template:
     src: janus.plugin.ustreamer.jcfg.j2
@@ -142,6 +134,14 @@
 - name: uninstall TC358743 settings if they're not in use
   import_tasks: remove_tc358743.yml
   when: ustreamer_capture_device != 'tc358743'
+
+- name: save uStreamer settings file
+  template:
+    src: config.yml.j2
+    dest: "{{ ustreamer_settings_file }}"
+    owner: "{{ ustreamer_user }}"
+    group: "{{ ustreamer_group }}"
+    mode: "0644"
 
 - name: install uStreamer launcher
   import_tasks: install_launcher.yml

--- a/ansible-role-ustreamer/tasks/main.yml
+++ b/ansible-role-ustreamer/tasks/main.yml
@@ -31,32 +31,6 @@
   include_tasks: install_janus.yml
   when: ustreamer_install_janus
 
-- name: check for a boot config file
-  stat:
-    path: /boot/config.txt
-  register: boot_config_result
-
-- name: save whether boot config file exists
-  set_fact:
-    boot_config_exists: "{{ boot_config_result.stat.exists }}"
-
-- name: check whether this machine has a uStreamer settings file
-  stat:
-    path: "{{ ustreamer_settings_file }}"
-  register: ustreamer_settings_file_result
-
-- name: read saved settings
-  import_tasks: check_saved_settings.yml
-  when: ustreamer_settings_file_result.stat.exists | bool
-
-- name: configure TC358743 HDMI capture chip
-  import_tasks: provision_tc358743.yml
-  when: ustreamer_capture_device == 'tc358743'
-
-- name: uninstall TC358743 settings if they're not in use
-  import_tasks: remove_tc358743.yml
-  when: ustreamer_capture_device != 'tc358743'
-
 - name: collect universal required apt packages
   set_fact:
     ustreamer_packages:
@@ -142,6 +116,32 @@
   notify:
     - restart Janus
   when: ustreamer_install_janus
+
+- name: check for a boot config file
+  stat:
+    path: /boot/config.txt
+  register: boot_config_result
+
+- name: save whether boot config file exists
+  set_fact:
+    boot_config_exists: "{{ boot_config_result.stat.exists }}"
+
+- name: check whether this machine has a uStreamer settings file
+  stat:
+    path: "{{ ustreamer_settings_file }}"
+  register: ustreamer_settings_file_result
+
+- name: read saved settings
+  import_tasks: check_saved_settings.yml
+  when: ustreamer_settings_file_result.stat.exists | bool
+
+- name: configure TC358743 HDMI capture chip
+  import_tasks: provision_tc358743.yml
+  when: ustreamer_capture_device == 'tc358743'
+
+- name: uninstall TC358743 settings if they're not in use
+  import_tasks: remove_tc358743.yml
+  when: ustreamer_capture_device != 'tc358743'
 
 - name: install uStreamer launcher
   import_tasks: install_launcher.yml


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot-pro/issues/956
Related https://github.com/tiny-pilot/ustreamer-debian/issues/11
Related https://github.com/tiny-pilot/tinypilot/pull/1459

I accidently broke TinyPilot Pro image builder via https://github.com/tiny-pilot/tinypilot-pro/pull/955#issuecomment-1611870272

This PR is non-functional change that moves the provisioning of `tc358743` chip only until after the uStreamer Debian package is installed (and only after the `ustreamer` user has been created).

Notes:
1. I've [moved the TC358743 provisioning closer down to the uStreamer launcher tasks](https://github.com/tiny-pilot/tinypilot/blob/05f256fc6cac24ac62ec8a41a28e52cb9b2e5d15/ansible-role-ustreamer/tasks/main.yml#L112-L136) because the [TC358743 provisioning sets a bunch of ustreamer variables](https://github.com/tiny-pilot/tinypilot/blob/9cbfe6418767a92385718482d04d91f63d62528e/ansible-role-ustreamer/tasks/provision_tc358743.yml#L61-L68) which is only put into effect by the uStreamer launcher.

I've tested this PR on a Voyager device using:
```bash
sudo -i
apt-get remove tinypilot ustreamer -y
deluser --remove-home ustreamer
mkdir -p /home/ustreamer
cat > /home/ustreamer/config.yml <<EOF
capture_device: "tc358743"
EOF
curl \
  --location \
  --silent \
  --show-error \
  https://raw.githubusercontent.com/tiny-pilot/tinypilot/master/scripts/install-bundle | \
  bash -s -- https://output.circle-artifacts.com/output/job/4fbbc644-59be-47b3-9a55-3af3402023b9/artifacts/0/bundler/dist/tinypilot-community-20230628T1859Z-1.9.0-6+05f256f.tgz
```

**CodeApprove: https://codeapprove.com/pr/tiny-pilot/tinypilot/1470**