### PR TITLE
Include network interface details in debug logs

### DIFF
--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -116,7 +116,7 @@ print_info "Checking network interfaces..."
   readonly INTERFACES_ROOT="/sys/class/net"
   for interface_path in "${INTERFACES_ROOT}"/* ; do
     ifname="${interface_path##*/}"
-    echo "  ${ifname} ($(cat ${INTERFACES_ROOT}/"${ifname/}"/operstate))"
+    echo "  ${ifname} ($(cat ${INTERFACES_ROOT}/"${ifname}"/operstate))"
   done
 } >> "${LOG_FILE}"
 

--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -113,10 +113,10 @@ print_info "Checking if SSH is enabled..."
 print_info "Checking network interfaces..."
 {
   echo "Network interfaces:"
-  readonly INTERFACES="/sys/class/net"
-  for interface in "${INTERFACES}"/* ; do
-    ifname="${interface##*/}"
-    echo "  ${ifname} ($(cat ${INTERFACES}/"${ifname/}"/operstate))"
+  readonly INTERFACES_ROOT="/sys/class/net"
+  for interface_path in "${INTERFACES_ROOT}"/* ; do
+    ifname="${interface_path##*/}"
+    echo "  ${ifname} ($(cat ${INTERFACES_ROOT}/"${ifname/}"/operstate))"
   done
 } >> "${LOG_FILE}"
 

--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -110,6 +110,16 @@ print_info "Checking if SSH is enabled..."
   echo "SSH access: ${SSH_STATUS}"
 } >> "${LOG_FILE}"
 
+print_info "Checking network interfaces..."
+{
+  echo "Network interfaces:"
+  readonly INTERFACES="/sys/class/net"
+  for interface in "${INTERFACES}"/* ; do
+    ifname="${interface##*/}"
+    echo "  ${ifname} ($(cat ${INTERFACES}/"${ifname/}"/operstate))"
+  done
+} >> "${LOG_FILE}"
+
 print_info "Checking temperature..."
 printf "%s\n" "$(vcgencmd measure_temp)" >> "${LOG_FILE}"
 


### PR DESCRIPTION
Resolves #1432.

This change adds a new section to the debug logs listing all available network interfaces, including popular VPNs, virtual network devices, USB adapters, and so on, and their current active state:

```
Network interfaces:
  eth0 (down)
  lo0 (unknown)
  wlan0 (up)
  tailscale0 (up)
  wg0 (down)
```

This addition will be helpful for support purposes, as we can see at a glance whether the user is connecting over something other than the onboard Ethernet.

### Why not dump the output of `ip` or `ifconfig`?

Users may consider details of their network configuration to be sensitive. This conservative approach provides the most helpful information while ensuring we don't accidentally leak sensitive information.

### Why not parse the output of `ip` or `ifconfig`?

I opted to use `/sys/class/net` rather than directly parsing the output of `ip` or `ifconfig`. The rationale for this decision is that `ifconfig` is deprecated, and the output of `ip link show` is not guaranteed. The `/sys/class/net` structure should be more resilient.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1471"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>