### PR TITLE
Configure nginx to show helpful information instead of a HTTP 502 gateway error 

### DIFF
--- a/app/static/502.html
+++ b/app/static/502.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>TinyPilot is Not Running</title>
+  </head>
+  <body>
+    <h1>TinyPilot is Not Running</h1>
+    <p>
+      You have connected successfully to your TinyPilot device, but the
+      TinyPilot web application doesn't seem to be running.
+    </p>
+    <p>
+      Please try reloading the page. If you continue to see this message, please
+      <a
+        href="https://github.com/tiny-pilot/tinypilot/issues/new?assignees=&labels=bug&projects=&template=bug_report.md&title="
+        >file a bug on GitHub</a
+      >
+      to let us know.
+    </p>
+  </body>
+</html>

--- a/debian-pkg/usr/share/tinypilot/templates/tinypilot.conf.j2
+++ b/debian-pkg/usr/share/tinypilot/templates/tinypilot.conf.j2
@@ -24,6 +24,8 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_http_version 1.1;
 
+    error_page 502 /502.html;
+
     location /socket.io {
         proxy_pass http://tinypilot;
         proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
This adapts #1468 to this PR, as both PRs were changing the nginx config at the same time.

---

The TinyPilot web service may fail to start for a variety of reasons. If the TinyPilot web service isn't available, `nginx` will display a 502 error message. The default page isn't informative and does not indicate what the user should do.

This change adds a new directive to `nginx` to display a more helpful static HTML page instead of the default 502 error page. No proxy bypass is required as there is already an exception in place for static HTML pages.

<img width="808" alt="Screenshot 2023-06-28 at 02 43 36" src="https://github.com/tiny-pilot/tinypilot/assets/53837824/2807011d-df87-4147-81de-1ab4062dc7d7"> <a data-ca-tag
href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1468"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>