### PR TITLE
Log whether the user is using the TinyPilot mouse jiggler

### DIFF
--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -110,6 +110,17 @@ print_info "Checking if SSH is enabled..."
   echo "SSH access: ${SSH_STATUS}"
 } >> "${LOG_FILE}"
 
+print_info "Checking if mouse jiggler is enabled..."
+{
+  MOUSE_JIGGLER_STATUS="disabled"
+  if [[ -e /etc/cron.d/tinypilot-mouse-jiggle ]]; then
+    MOUSE_JIGGLER_STATUS="enabled"
+  fi
+
+  readonly MOUSE_JIGGLER_STATUS
+  echo "Mouse jiggler: ${MOUSE_JIGGLER_STATUS}"
+} >> "${LOG_FILE}"
+
 print_info "Checking temperature..."
 printf "%s\n" "$(vcgencmd measure_temp)" >> "${LOG_FILE}"
 

--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -116,7 +116,6 @@ print_info "Checking if mouse jiggler is enabled..."
   if [[ -e /etc/cron.d/tinypilot-mouse-jiggle ]]; then
     MOUSE_JIGGLER_STATUS="enabled"
   fi
-
   readonly MOUSE_JIGGLER_STATUS
   echo "Mouse jiggler: ${MOUSE_JIGGLER_STATUS}"
 } >> "${LOG_FILE}"


### PR DESCRIPTION
This change adds the state of the TinyPilot mouse jiggler to the debug logs under the TinyPilot state section.

We had one instance in the past where a hanging mouse jiggler caused issues with the mouse, so logging the state of our own mouse jiggler may help with debugging issues in the future.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1475"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>