### PR TITLE
Drop Ubuntu support for uStreamer

### DIFF
--- a/ansible-role-ustreamer/meta/main.yml
+++ b/ansible-role-ustreamer/meta/main.yml
@@ -11,9 +11,6 @@ galaxy_info:
     - name: Debian
       versions:
         - bullseye
-    - name: Ubuntu
-      versions:
-        - jammy
 
   galaxy_tags:
     - raspberrypi

--- a/ansible-role-ustreamer/tasks/install_janus.yml
+++ b/ansible-role-ustreamer/tasks/install_janus.yml
@@ -7,13 +7,11 @@
   apt_key:
     url: https://ftp-master.debian.org/keys/archive-key-{{ ansible_distribution_major_version }}.asc
     state: present
-  when: ustreamer_is_os_raspbian or ustreamer_is_os_debian
 
 - name: enable Janus apt suite
   apt_repository:
     repo: deb http://deb.debian.org/debian {{ ustreamer_janus_apt_suite }} main
     state: present
-  when: ustreamer_is_os_raspbian or ustreamer_is_os_debian
 
 - name: install Janus package
   apt:

--- a/ansible-role-ustreamer/tasks/main.yml
+++ b/ansible-role-ustreamer/tasks/main.yml
@@ -55,11 +55,6 @@
     ustreamer_packages: "{{ ustreamer_packages }} + ['libjpeg62-turbo-dev']"
   when: ustreamer_is_os_debian
 
-- name: collect Ubuntu-specific required apt packages
-  set_fact:
-    ustreamer_packages: "{{ ustreamer_packages }} + ['gcc', 'libjpeg8', 'libjpeg-dev', 'libjpeg-turbo8', 'libuuid1', 'libbsd0', 'make']"
-  when: ansible_distribution == 'Ubuntu'
-
 - name: collect Janus WebRTC plugin specific required apt packages
   set_fact:
     ustreamer_packages: "{{ ustreamer_packages }} + ['libglib2.0-dev', 'libjansson-dev']"

--- a/ansible-role-ustreamer/tasks/main.yml
+++ b/ansible-role-ustreamer/tasks/main.yml
@@ -1,7 +1,4 @@
 ---
-- name: include distribution-specific vars
-  include_vars: "{{ ansible_distribution }}.yml"
-
 - name: check that the H264 variables are in a consistent state
   fail:
     msg: >-

--- a/ansible-role-ustreamer/vars/Debian.yml
+++ b/ansible-role-ustreamer/vars/Debian.yml
@@ -1,2 +1,0 @@
----
-ustreamer_janus_apt_suite: "{{ ansible_distribution_release }}-backports"

--- a/ansible-role-ustreamer/vars/Ubuntu.yml
+++ b/ansible-role-ustreamer/vars/Ubuntu.yml
@@ -1,2 +1,0 @@
----
-ustreamer_janus_apt_suite: "{{ ansible_distribution_release }}"

--- a/ansible-role-ustreamer/vars/main.yml
+++ b/ansible-role-ustreamer/vars/main.yml
@@ -11,6 +11,8 @@ ustreamer_dir: /opt/ustreamer
 # runs.
 ustreamer_settings_file: /home/{{ ustreamer_user }}/config.yml
 
+ustreamer_janus_apt_suite: "{{ ansible_distribution_release }}-backports"
+
 # These variables are only used within this role.
 ustreamer_janus_configs_dir: /etc/janus
 


### PR DESCRIPTION
We no longer support installing to Ubuntu, so we can drop Ubuntu-specific logic.

I tested this at the same time as #1477 by building a Pro bundle and installing it on a Voyager 2a.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1476"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>