### PR TITLE
Delete ustreamer_debian_package_path Ansible variable

### DIFF
--- a/ansible-role-ustreamer/tasks/main.yml
+++ b/ansible-role-ustreamer/tasks/main.yml
@@ -72,7 +72,7 @@
 
 - name: install uStreamer Debian package
   apt:
-    deb: "{{ ustreamer_debian_package_path }}"
+    deb: https://github.com/tiny-pilot/ustreamer-debian/releases/download/5.38-20230620124412/ustreamer_5.38-20230620124412_armhf.deb
 
 - name: fix uStreamer folder permissions
   file:

--- a/ansible-role-ustreamer/vars/main.yml
+++ b/ansible-role-ustreamer/vars/main.yml
@@ -1,7 +1,3 @@
-# Specifies the filesystem path or URL of a Debian package that installs
-# uStreamer.
-ustreamer_debian_package_path: https://github.com/tiny-pilot/ustreamer-debian/releases/download/5.38-20230620124412/ustreamer_5.38-20230620124412_armhf.deb
-
 # The user/group must match the one created by the uStreamer Debian package.
 ustreamer_group: ustreamer
 ustreamer_user: ustreamer

--- a/ansible-role/molecule/default/molecule.yml
+++ b/ansible-role/molecule/default/molecule.yml
@@ -21,12 +21,6 @@ provisioner:
         vars:
           ansible_user: root
           tinypilot_debian_package_path: /opt/debian-pkgs/${TINYPILOT_DEBIAN_PACKAGE}
-  options:
-    # This variable expects a string, just like `--extra-vars` command-line
-    # parameter. See
-    # https://github.com/ansible-community/molecule/issues/3065#issuecomment-835897461
-    extra-vars: >
-      ustreamer_debian_package_path=https://github.com/tiny-pilot/ustreamer-debian/releases/download/5.38-20230620124412/ustreamer_5.38-20230620124412_amd64.deb
 verifier:
   name: ansible
 scenario:


### PR DESCRIPTION
We only use it in one place, so we can hardcode it in that place for simplicity.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1478"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>