### PR TITLE
Set npm package name to `tinypilot`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "app",
+  "name": "tinypilot",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "tinypilot",
       "devDependencies": {
         "@playwright/test": "1.35.1",
         "eslint": "8.44.0",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "tinypilot",
   "type": "module",
   "devDependencies": {
     "@playwright/test": "1.35.1",


### PR DESCRIPTION
This is a follow-up fix for [our recent NodeJS / npm upgrade](https://github.com/tiny-pilot/tinypilot/issues/1395).

Apparently, in lock-file version 3, the `name` property is now mandatory. If the name of the package wasn’t declared explicitly in `package.json`, then npm will infer (or rather: guess) the package name from the name of the enclosing folder.

In my case, I’m running my dev environment in a Docker container, and I’m mounting everything to the `/app` working directory. Therefore, npm had set the `name` property in `package-lock.json` to be `app`. If someone else runs `npm install` on their machine, and their repo folder name is different, then npm will change the `package-lock.json` file again.

In order to stay independent of this (in my book rather questionable) behaviour, I suggest we just declare a `name` property in `package.json`, then npm should yield the same `package-lock.json` result regardless of the local folder name. Since we don’t publish our “package” to any registry, we could even consider to keep `tinypilot` as name for Pro (instead of adjusting to `tinypilot-pro`) – just for simplicity.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1483"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>