### PR TITLE
Refactor non-configurable default Ansible variables

### DIFF
--- a/ansible-role/README.md
+++ b/ansible-role/README.md
@@ -5,8 +5,6 @@
 Available variables are listed below, along with default values (see [defaults/main.yml](defaults/main.yml)):
 
 ```yaml
-tinypilot_interface: "127.0.0.1"
-tinypilot_port: 8000
 # The client is responsible for specifying the path/URL to the TinyPilot Debian
 # package
 tinypilot_debian_package_path: null

--- a/ansible-role/defaults/main.yml
+++ b/ansible-role/defaults/main.yml
@@ -2,11 +2,4 @@
 # Specifies the filesystem path or URL of a Debian package that installs
 # TinyPilot.
 tinypilot_debian_package_path: null
-# Port on which TinyPilot frontend listens (accessible from other hosts on the
-# network).
-tinypilot_external_port: 80
-tinypilot_interface: "127.0.0.1"
-# Port on which TinyPilot's backend listens (accessible only from
-# tinypilot_interface).
-tinypilot_port: 8000
 tinypilot_enable_debug_logging: no

--- a/ansible-role/vars/main.yml
+++ b/ansible-role/vars/main.yml
@@ -1,4 +1,11 @@
 ---
+# Port on which TinyPilot frontend listens (accessible from other hosts on the
+# network).
+tinypilot_external_port: 80
+tinypilot_interface: "127.0.0.1"
+# Port on which TinyPilot's backend listens (accessible only from
+# tinypilot_interface).
+tinypilot_port: 8000
 # TinyPilot's get-tinypilot.sh script (which it uses for installation and
 # updates) relies on the tinypilot user being named "tinypilot" so changing this
 # value will break updates.

--- a/app/update/settings.py
+++ b/app/update/settings.py
@@ -25,12 +25,11 @@ _SETTINGS_FILE_PATH = os.path.expanduser('~/settings.yml')
 _DEFAULTS = {
     'tinypilot_keyboard_interface': '/dev/hidg0',
     'tinypilot_mouse_interface': '/dev/hidg1',
-    'tinypilot_dir':
-        '/opt/tinypilot',  # Must match ansible-role/defaults/main.yml.
-    'tinypilot_external_port': 80,  # Must match ansible-role/defaults/main.yml.
+    'tinypilot_dir': '/opt/tinypilot',  # Must match ansible-role/vars/main.yml.
+    'tinypilot_external_port': 80,  # Must match ansible-role/vars/main.yml.
     'tinypilot_interface':
-        '127.0.0.1',  # Must match ansible-role/defaults/main.yml.
-    'tinypilot_port': 8000,  # Must match ansible-role/defaults/main.yml.
+        '127.0.0.1',  # Must match ansible-role/vars/main.yml.
+    'tinypilot_port': 8000,  # Must match ansible-role/vars/main.yml.
     'ustreamer_interface':
         '127.0.0.1',  # Must match ansible-role/vars/main.yml.
     'ustreamer_port': 8001,  # Must match ansible-role/vars/main.yml.


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot/issues/1429

This is a non-functional change. This PR moves the following non-configurable default Ansible values from `ansible-role/defaults/main.yml` to `ansible-role/vars/main.yml`:
- `tinypilot_external_port`
- `tinypilot_interface`
- `tinypilot_port`

This is mostly a stylistic change that implies that variables in `ansible-role/vars/main.yml` shouldn't be changed.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1484"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>