### PR TITLE
Mark certain Ansible variables as not user-configurable

### DIFF
--- a/ansible-role/defaults/main.yml
+++ b/ansible-role/defaults/main.yml
@@ -5,8 +5,4 @@ tinypilot_debian_package_path: null
 # Port on which TinyPilot frontend listens (accessible from other hosts on the
 # network).
 tinypilot_external_port: 80
-tinypilot_interface: "127.0.0.1"
-# Port on which TinyPilot's backend listens (accessible only from
-# tinypilot_interface).
-tinypilot_port: 8000
 tinypilot_enable_debug_logging: no

--- a/ansible-role/vars/main.yml
+++ b/ansible-role/vars/main.yml
@@ -8,6 +8,11 @@ tinypilot_group: tinypilot
 tinypilot_dir: /opt/tinypilot
 tinypilot_privileged_dir: /opt/tinypilot-privileged
 
+tinypilot_interface: "127.0.0.1"
+# Port on which TinyPilot's backend listens (accessible only from
+# tinypilot_interface).
+tinypilot_port: 8000
+
 # uStreamer variables are placed here, instead of in `defaults/main.yml`,
 # in order to elevate their variable precedence. These variables will now
 # override the default variables in the uStreamer role.


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot/issues/1429

This is non-functional change. This PR moves the definition of `tinypilot_interface` and `tinypilot_port` from `ansible-role/defaults/main.yml` to `ansible-role/vars/main.yml` which indicates that these variables should not be overridden.

This change is based on [our discussion](https://github.com/tiny-pilot/tinypilot/pull/1484#issuecomment-1622011263) about user-configurable variables:
> Currently, our convention is:
> * `defaults/` - Maybe we support users overriding these variables.
> * `vars/` - We definitely don't support users overriding these variables.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1492"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>