### PR TITLE
Add TinyPilot's external port as a default TinyPilot setting

### DIFF
--- a/app/update/settings.py
+++ b/app/update/settings.py
@@ -34,6 +34,7 @@ _CONSTANTS = {
 _DEFAULTS = {
     'tinypilot_keyboard_interface': '/dev/hidg0',
     'tinypilot_mouse_interface': '/dev/hidg1',
+    'tinypilot_external_port': 80,  # Must match ansible-role/defaults/main.yml.
     'ustreamer_desired_fps': video_service.DEFAULT_FRAME_RATE,
     'ustreamer_quality': video_service.DEFAULT_MJPEG_QUALITY,
     'ustreamer_h264_bitrate': video_service.DEFAULT_H264_BITRATE,

--- a/app/update/settings_test.py
+++ b/app/update/settings_test.py
@@ -44,7 +44,7 @@ class UpdateSettingsTest(unittest.TestCase):
         self.assertEqual('/dev/hidg0',
                          settings_dict['tinypilot_keyboard_interface'])
         # Count constant and default values.
-        self.assertEqual(7, len(settings_dict))
+        self.assertEqual(8, len(settings_dict))
 
     def test_populates_empty_file_with_blank_settings(self):
         self.make_mock_settings_file('')


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot/issues/1429

This PR adds `tinypilot_external_port` to our dictionary of default TinyPilot settings. This is needed in order to use `tinypilot_external_port` in TinyPilot's NGINX config template via https://github.com/tiny-pilot/tinypilot/pull/1469

Notes:
1. This PR was triggered based on [our discussion](https://codeapprove.com/pr/tiny-pilot/tinypilot/1469#thread-03723286-15ac-4bb6-b466-86223f9b94c0) about user-configurable variables.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1497"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>