### PR TITLE
Drop tinypilot_interface Ansible variable

### DIFF
--- a/ansible-role/README.md
+++ b/ansible-role/README.md
@@ -5,7 +5,6 @@
 Available variables are listed below, along with default values (see [defaults/main.yml](defaults/main.yml)):
 
 ```yaml
-tinypilot_interface: "127.0.0.1"
 tinypilot_port: 8000
 # The client is responsible for specifying the path/URL to the TinyPilot Debian
 # package

--- a/ansible-role/tasks/nginx.yml
+++ b/ansible-role/tasks/nginx.yml
@@ -6,7 +6,7 @@
     nginx_upstreams:
       - name: tinypilot
         servers:
-          - "{{ tinypilot_interface }}:{{ tinypilot_port }} fail_timeout=1s max_fails=600"
+          - "127.0.0.1:{{ tinypilot_port }} fail_timeout=1s max_fails=600"
       - name: ustreamer
         servers:
           - "{{ ustreamer_interface }}:{{ ustreamer_port }} fail_timeout=1s max_fails=600"

--- a/ansible-role/templates/tinypilot.systemd.j2
+++ b/ansible-role/templates/tinypilot.systemd.j2
@@ -8,7 +8,6 @@ Type=simple
 User={{ tinypilot_user }}
 WorkingDirectory={{ tinypilot_dir }}
 ExecStart={{ tinypilot_dir }}/venv/bin/python app/main.py
-Environment=HOST={{ tinypilot_interface }}
 Environment=PORT={{ tinypilot_port }}
 Environment=APP_SETTINGS_FILE=/home/tinypilot/app_settings.cfg
 {% if tinypilot_enable_debug_logging %}

--- a/ansible-role/vars/main.yml
+++ b/ansible-role/vars/main.yml
@@ -8,9 +8,7 @@ tinypilot_group: tinypilot
 tinypilot_dir: /opt/tinypilot
 tinypilot_privileged_dir: /opt/tinypilot-privileged
 
-tinypilot_interface: "127.0.0.1"
-# Port on which TinyPilot's backend listens (accessible only from
-# tinypilot_interface).
+# Port on which TinyPilot's backend listens (accessible only from 127.0.0.1).
 tinypilot_port: 8000
 
 # uStreamer variables are placed here, instead of in `defaults/main.yml`,


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot/issues/1429

This PR removes the `tinypilot_interface` Ansible variable and inlines its value (i.e., `127.0.0.1`) because TinyPilot should always only serve local connections.

As suggested by https://github.com/tiny-pilot/tinypilot-pro/issues/972, `tinypilot_interface` is considered a junk unsupported variable:
> We can either delete them because they're unused, or we can trivially inline their values because they're only used in one place.

Notes:
1. This PR was triggered based on [our discussion](https://codeapprove.com/pr/tiny-pilot/tinypilot/1469#thread-03723286-15ac-4bb6-b466-86223f9b94c0) about user-configurable variables.
2. You can test this PR via https://github.com/tiny-pilot/tinypilot/pull/1499


<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1498"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>