### PR TITLE
Drop tinypilot_port Ansible variable

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -10,7 +10,7 @@ parameters:
     # In order to enable bundle building on a feature branch, you can
     # temporarily change the below default to be: << pipeline.git.branch >>
     # Don’t forget to revert this before merging your branch!
-    default: << pipeline.git.branch >>
+    default: master
 jobs:
   check_whitespace:
     docker:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -10,7 +10,7 @@ parameters:
     # In order to enable bundle building on a feature branch, you can
     # temporarily change the below default to be: << pipeline.git.branch >>
     # Don’t forget to revert this before merging your branch!
-    default: master
+    default: << pipeline.git.branch >>
 jobs:
   check_whitespace:
     docker:

--- a/ansible-role/README.md
+++ b/ansible-role/README.md
@@ -5,7 +5,6 @@
 Available variables are listed below, along with default values (see [defaults/main.yml](defaults/main.yml)):
 
 ```yaml
-tinypilot_interface: "127.0.0.1"
 tinypilot_port: 8000
 # The client is responsible for specifying the path/URL to the TinyPilot Debian
 # package

--- a/ansible-role/README.md
+++ b/ansible-role/README.md
@@ -5,7 +5,6 @@
 Available variables are listed below, along with default values (see [defaults/main.yml](defaults/main.yml)):
 
 ```yaml
-tinypilot_port: 8000
 # The client is responsible for specifying the path/URL to the TinyPilot Debian
 # package
 tinypilot_debian_package_path: null

--- a/ansible-role/tasks/nginx.yml
+++ b/ansible-role/tasks/nginx.yml
@@ -6,7 +6,7 @@
     nginx_upstreams:
       - name: tinypilot
         servers:
-          - "{{ tinypilot_interface }}:{{ tinypilot_port }} fail_timeout=1s max_fails=600"
+          - "127.0.0.1:{{ tinypilot_port }} fail_timeout=1s max_fails=600"
       - name: ustreamer
         servers:
           - "{{ ustreamer_interface }}:{{ ustreamer_port }} fail_timeout=1s max_fails=600"

--- a/ansible-role/tasks/nginx.yml
+++ b/ansible-role/tasks/nginx.yml
@@ -6,7 +6,7 @@
     nginx_upstreams:
       - name: tinypilot
         servers:
-          - "127.0.0.1:{{ tinypilot_port }} fail_timeout=1s max_fails=600"
+          - "127.0.0.1:8000 fail_timeout=1s max_fails=600"
       - name: ustreamer
         servers:
           - "{{ ustreamer_interface }}:{{ ustreamer_port }} fail_timeout=1s max_fails=600"

--- a/ansible-role/templates/tinypilot.systemd.j2
+++ b/ansible-role/templates/tinypilot.systemd.j2
@@ -8,7 +8,6 @@ Type=simple
 User={{ tinypilot_user }}
 WorkingDirectory={{ tinypilot_dir }}
 ExecStart={{ tinypilot_dir }}/venv/bin/python app/main.py
-Environment=HOST={{ tinypilot_interface }}
 Environment=PORT={{ tinypilot_port }}
 Environment=APP_SETTINGS_FILE=/home/tinypilot/app_settings.cfg
 {% if tinypilot_enable_debug_logging %}

--- a/ansible-role/templates/tinypilot.systemd.j2
+++ b/ansible-role/templates/tinypilot.systemd.j2
@@ -8,7 +8,6 @@ Type=simple
 User={{ tinypilot_user }}
 WorkingDirectory={{ tinypilot_dir }}
 ExecStart={{ tinypilot_dir }}/venv/bin/python app/main.py
-Environment=PORT={{ tinypilot_port }}
 Environment=APP_SETTINGS_FILE=/home/tinypilot/app_settings.cfg
 {% if tinypilot_enable_debug_logging %}
 Environment=DEBUG=1

--- a/ansible-role/vars/main.yml
+++ b/ansible-role/vars/main.yml
@@ -8,9 +8,6 @@ tinypilot_group: tinypilot
 tinypilot_dir: /opt/tinypilot
 tinypilot_privileged_dir: /opt/tinypilot-privileged
 
-# Port on which TinyPilot's backend listens (accessible only from 127.0.0.1).
-tinypilot_port: 8000
-
 # uStreamer variables are placed here, instead of in `defaults/main.yml`,
 # in order to elevate their variable precedence. These variables will now
 # override the default variables in the uStreamer role.

--- a/ansible-role/vars/main.yml
+++ b/ansible-role/vars/main.yml
@@ -8,9 +8,7 @@ tinypilot_group: tinypilot
 tinypilot_dir: /opt/tinypilot
 tinypilot_privileged_dir: /opt/tinypilot-privileged
 
-tinypilot_interface: "127.0.0.1"
-# Port on which TinyPilot's backend listens (accessible only from
-# tinypilot_interface).
+# Port on which TinyPilot's backend listens (accessible only from 127.0.0.1).
 tinypilot_port: 8000
 
 # uStreamer variables are placed here, instead of in `defaults/main.yml`,


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot/issues/1429

Similar to https://github.com/tiny-pilot/tinypilot/pull/1498, this PR removes the `tinypilot_port` Ansible variable and inlines its value (i.e., `8000`).

As suggested by https://github.com/tiny-pilot/tinypilot-pro/issues/972, `tinypilot_port` is considered a junk unsupported variable:
> We can either delete them because they're unused, or we can trivially inline their values because they're only used in one place.

You can test this PR and https://github.com/tiny-pilot/tinypilot/pull/1498 by running the following command on device:
```bash
sudo /opt/tinypilot/scripts/install-bundle \
  https://output.circle-artifacts.com/output/job/2e7b1af1-8c3b-4c04-8c26-bf52e82819e7/artifacts/0/bundler/dist/tinypilot-community-20230710T1448Z-1.9.0-18+e4ff7d9.tgz
```

Notes:
1. This PR was triggered based on [our discussion](https://codeapprove.com/pr/tiny-pilot/tinypilot/1469#thread-03723286-15ac-4bb6-b466-86223f9b94c0) about user-configurable variables.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1499"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>