### PR TITLE
Revise installation section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,18 +69,11 @@ curl \
   sudo reboot
 ```
 
-The installation process:
-
-- Creates a service account for TinyPilot with limited priviliges.
-- Installs TinyPilot as a systemd service so it runs automatically on every boot.
-- Installs and configures TinyPilot's dependencies:
-  - nginx, which listens on 0.0.0.0:80
-  - uStreamer, which listens on 127.0.0.1:8001
-- Installs TinyPilot to the `/opt/tinypilot` directory.
-
 When your Pi reboots, you should be able to access TinyPilot by visiting your Pi hostname in the browser. For example, if your device is named `raspberrypi`:
 
 - [http://raspberrypi/](http://raspberrypi/)
+
+If you're using an HDMI to CSI capture chip (such as with a TinyPilot Voyager series device), see [the additional configuration steps](https://github.com/tiny-pilot/tinypilot/wiki/Installation-Options#example-tc358743-hdmi-to-csi-capture-chip) required for video capture.
 
 ## Developer installation
 


### PR DESCRIPTION
Our install instructions assume an HDMI to USB dongle, so users with an HDMI to CSI chip try to install, they tend not to know that they need to perform extra steps.

This change revises the install section of the README to remove implementation details about what TinyPilot installs and make it more obvious how to find instructions for installing with an HDMI to CSI chip.