### PR TITLE
Upgrade to PyYAML 6.0.1

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -10,7 +10,7 @@ parameters:
     # In order to enable bundle building on a feature branch, you can
     # temporarily change the below default to be: << pipeline.git.branch >>
     # Don’t forget to revert this before merging your branch!
-    default: << pipeline.git.branch >>
+    default: master
 jobs:
   check_whitespace:
     docker:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -10,7 +10,7 @@ parameters:
     # In order to enable bundle building on a feature branch, you can
     # temporarily change the below default to be: << pipeline.git.branch >>
     # Don’t forget to revert this before merging your branch!
-    default: master
+    default: << pipeline.git.branch >>
 jobs:
   check_whitespace:
     docker:

--- a/ansible-role/molecule/requirements.txt
+++ b/ansible-role/molecule/requirements.txt
@@ -46,7 +46,7 @@ PyNaCl==1.5.0
 pyparsing==3.0.9
 python-dateutil==2.8.2
 python-slugify==6.1.2
-PyYAML==6.0
+PyYAML==5.3.1
 requests==2.28.1
 rich==12.5.1
 selinux==0.2.1

--- a/ansible-role/molecule/requirements.txt
+++ b/ansible-role/molecule/requirements.txt
@@ -46,7 +46,7 @@ PyNaCl==1.5.0
 pyparsing==3.0.9
 python-dateutil==2.8.2
 python-slugify==6.1.2
-PyYAML==5.4.1
+PyYAML==6.0.1
 requests==2.28.1
 rich==12.5.1
 selinux==0.2.1

--- a/ansible-role/molecule/requirements.txt
+++ b/ansible-role/molecule/requirements.txt
@@ -46,7 +46,7 @@ PyNaCl==1.5.0
 pyparsing==3.0.9
 python-dateutil==2.8.2
 python-slugify==6.1.2
-PyYAML==6.0.1
+PyYAML==6.0
 requests==2.28.1
 rich==12.5.1
 selinux==0.2.1

--- a/app/license_notice.py
+++ b/app/license_notice.py
@@ -94,7 +94,7 @@ _LICENSE_METADATA = [
         name='pyyaml',
         homepage_url='https://pyyaml.org',
         license_url=
-        'https://raw.githubusercontent.com/yaml/pyyaml/5.4.1/LICENSE',
+        'https://raw.githubusercontent.com/yaml/pyyaml/6.0.1/LICENSE',
     ),
     LicenseMetadata(
         name='bidict',

--- a/bundler/bundle/requirements.txt
+++ b/bundler/bundle/requirements.txt
@@ -13,4 +13,4 @@ MarkupSafe==2.1.1
 packaging==21.3
 pycparser==2.21
 pyparsing==3.0.9
-PyYAML==6.0.1
+PyYAML==6.0

--- a/bundler/bundle/requirements.txt
+++ b/bundler/bundle/requirements.txt
@@ -13,4 +13,4 @@ MarkupSafe==2.1.1
 packaging==21.3
 pycparser==2.21
 pyparsing==3.0.9
-PyYAML==6.0
+PyYAML==6.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ eventlet==0.31.0
 Flask==1.1.1
 Flask-SocketIO==5.0.1
 Flask-WTF==0.14.3
-pyyaml==5.4.1
+pyyaml==6.0.1
 
 # Indirect dependencies
 bidict==0.21.2


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1507

The release of [Cython `3` broke PyYAML `5.4`](https://github.com/yaml/pyyaml/issues/724). This PR upgrades to PyYAML `6.0.1` which pins `Cython < 3.0.0`. 

Notes
1. While bootstrapping the molecule testing environment, it was [complaining about the following dependency conflict](https://app.circleci.com/pipelines/github/tiny-pilot/tinypilot/3695/workflows/1e8382a7-5a08-4a64-a87a-a5af41916c70/jobs/22051?invite=true#step-105-155):
    ```bash
    The conflict is caused by:
        The user requested PyYAML==6.0.1
        molecule 3.2.3 depends on PyYAML<6 and >=5.1
    ```
    So based on [someone's suggestion from the original GitHub issue](https://github.com/yaml/pyyaml/issues/724#issuecomment-1639872845), I pinned `pyyaml` to version `5.3.1`. However, I only did this for the [molecule dependencies](https://github.com/tiny-pilot/tinypilot/pull/1508/files#diff-0852a7343763d1af5bb207aac9c7ac61e43aea1d676c9ab25ba6ae7503804578). 

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1508"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>