### PR TITLE
Build Debian package with more resources

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -139,6 +139,7 @@ jobs:
   build_debian_package:
     docker:
       - image: cimg/base:stable
+    resource_class: large
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -139,7 +139,7 @@ jobs:
   build_debian_package:
     docker:
       - image: cimg/base:stable
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -10,7 +10,7 @@ parameters:
     # In order to enable bundle building on a feature branch, you can
     # temporarily change the below default to be: << pipeline.git.branch >>
     # Don’t forget to revert this before merging your branch!
-    default: master
+    default: << pipeline.git.branch >>
 jobs:
   check_whitespace:
     docker:


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot/issues/1515

This PR attempts to speed up the `build_debian_package` CI job by using a larger CI `resource_class`, but it doesn't seem to make much of a difference. Using an `xlarge` instance is ~20s faster than using a `medium` instance. This doesn't seem worth it 🤔 

# Results

## Using `resource_class: medium` (default)

<img width="1378" alt="Screen Shot 2023-07-19 at 18 16 27" src="https://github.com/tiny-pilot/tinypilot/assets/6730025/9de3f1f5-321a-40cd-9df4-d34ef67aa7e1">


## Using `resource_class: large`

<img width="1024" alt="Screen Shot 2023-07-20 at 17 41 21" src="https://github.com/tiny-pilot/tinypilot/assets/6730025/dbde3b61-51b6-4874-bf0b-97c7d5782bfe">

## Using `resource_class: xlarge`

<img width="1035" alt="Screen Shot 2023-07-20 at 17 50 17" src="https://github.com/tiny-pilot/tinypilot/assets/6730025/44e53baf-3d27-461e-a6e0-b692416f4ec1">

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1517"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>