### PR TITLE
Drop ustreamer_interface Ansible variable

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -10,7 +10,7 @@ parameters:
     # In order to enable bundle building on a feature branch, you can
     # temporarily change the below default to be: << pipeline.git.branch >>
     # Don’t forget to revert this before merging your branch!
-    default: << pipeline.git.branch >>
+    default: master
 jobs:
   check_whitespace:
     docker:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -10,7 +10,7 @@ parameters:
     # In order to enable bundle building on a feature branch, you can
     # temporarily change the below default to be: << pipeline.git.branch >>
     # Don’t forget to revert this before merging your branch!
-    default: master
+    default: << pipeline.git.branch >>
 jobs:
   check_whitespace:
     docker:

--- a/ansible-role-ustreamer/defaults/main.yml
+++ b/ansible-role-ustreamer/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-# Network interface to listen for connections.
-ustreamer_interface: null
-
 # Port to listen for connections.
 ustreamer_port: null
 

--- a/ansible-role-ustreamer/files/launch
+++ b/ansible-role-ustreamer/files/launch
@@ -86,7 +86,6 @@ append_arg_if_defined() {
 }
 
 append_arg_and_value_if_defined '.ustreamer_video_path'       '--device'
-append_arg_and_value_if_defined '.ustreamer_interface'        '--host'
 append_arg_and_value_if_defined '.ustreamer_port'             '--port'
 append_arg_and_value_if_defined '.ustreamer_encoder'          '--encoder'
 append_arg_and_value_if_defined '.ustreamer_format'           '--format'

--- a/ansible-role-ustreamer/tasks/install_launcher.yml
+++ b/ansible-role-ustreamer/tasks/install_launcher.yml
@@ -40,7 +40,6 @@
     ustreamer_runtime_vars: "{{ ustreamer_runtime_vars | combine({ item: lookup('ansible.builtin.vars', item) }) }}"
   when: lookup('ansible.builtin.vars', item) != None
   loop:
-    - ustreamer_interface
     - ustreamer_port
     - ustreamer_video_path
     - ustreamer_encoder

--- a/ansible-role/vars/main.yml
+++ b/ansible-role/vars/main.yml
@@ -2,7 +2,6 @@
 # uStreamer variables are placed here, instead of in `defaults/main.yml`,
 # in order to elevate their variable precedence. These variables will now
 # override the default variables in the uStreamer role.
-ustreamer_interface: "127.0.0.1" # Must match app/update/settings.py.
 ustreamer_port: 8001 # Must match app/update/settings.py.
 # Assigning `ustreamer_h264_sink` will make the uStreamer role install the Janus
 # server on the system, and thus enable H264 video streaming.

--- a/app/update/settings.py
+++ b/app/update/settings.py
@@ -24,8 +24,6 @@ _SETTINGS_FILE_PATH = os.path.expanduser('~/settings.yml')
 # precedence over the YAML data in _SETTINGS_FILE_PATH and _DEFAULTS. These
 # values are not user-configurable.
 _CONSTANTS = {
-    'ustreamer_interface':
-        '127.0.0.1',  # Must match ansible-role/vars/main.yml.
     'ustreamer_port': 8001,  # Must match ansible-role/vars/main.yml.
 }
 

--- a/app/update/settings_test.py
+++ b/app/update/settings_test.py
@@ -44,7 +44,7 @@ class UpdateSettingsTest(unittest.TestCase):
         self.assertEqual('/dev/hidg0',
                          settings_dict['tinypilot_keyboard_interface'])
         # Count constant and default values.
-        self.assertEqual(8, len(settings_dict))
+        self.assertEqual(7, len(settings_dict))
 
     def test_populates_empty_file_with_blank_settings(self):
         self.make_mock_settings_file('')

--- a/debian-pkg/usr/share/tinypilot/templates/tinypilot.conf.j2
+++ b/debian-pkg/usr/share/tinypilot/templates/tinypilot.conf.j2
@@ -2,7 +2,7 @@ upstream tinypilot {
     server 127.0.0.1:8000 fail_timeout=1s max_fails=600;
 }
 upstream ustreamer {
-    server {{ ustreamer_interface }}:{{ ustreamer_port }} fail_timeout=1s max_fails=600;
+    server 127.0.0.1:{{ ustreamer_port }} fail_timeout=1s max_fails=600;
 }
 upstream janus-ws {
     # The host and port must match the variables in


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot/issues/1431

In one of our dev meetings we mentioned that the `ustreamer_interface` Ansible variable can be dropped and the value inlined because uStreamer already serves on `127.0.0.1` by default.

Additionally, in https://github.com/tiny-pilot/tinypilot/issues/1431, we refactor `ustreamer_interface` from `ansible-role/vars/main.yml` to the end of `ansible-role-ustreamer/vars/main.yml`. To avoid doing this, we decided to drop `ustreamer_interface` instead.

In https://github.com/tiny-pilot/tinypilot-pro/issues/972, `ustreamer_interface` is considered an unsupported variable, which means:
> As we refactor to get rid of Ansible, we should make it impossible for users to override these values in `/home/tinypilot/settings.yml`

You can test this PR on a physical device using the following command:
```bash
curl \
  --silent \
  --show-error \
  --location \
  https://raw.githubusercontent.com/tiny-pilot/tinypilot/master/scripts/install-bundle | \
  sudo bash -s -- \
    https://output.circle-artifacts.com/output/job/ca37df56-d873-4f0c-a3df-05f9821908bb/artifacts/0/bundler/dist/tinypilot-community-20230721T1206Z-1.9.0-27+688d2ec.tgz
```
