### PR TITLE
Templatize Janus config to optionally allow using STUN

### DIFF
--- a/ansible-role-ustreamer/files/write-janus-config
+++ b/ansible-role-ustreamer/files/write-janus-config
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Writes the main Janus config file, rendered from the template in
+# /usr/share/ustreamer/templates/janus.jcfg.j2
+
+pushd /opt/tinypilot
+. venv/bin/activate && \
+  PYTHONPATH=/opt/tinypilot/app \
+    ./scripts/render-template \
+  < /usr/share/ustreamer/templates/janus.jcfg.j2 \
+  > /etc/janus/janus.jcfg && \
+  deactivate
+popd

--- a/ansible-role-ustreamer/handlers/main.yml
+++ b/ansible-role-ustreamer/handlers/main.yml
@@ -26,3 +26,6 @@
     name: janus
     state: restarted
   when: ustreamer_install_janus
+
+- name: write Janus configs
+  shell: {{ ustreamer_janus_dir }}/write-janus-config

--- a/ansible-role-ustreamer/tasks/install_janus.yml
+++ b/ansible-role-ustreamer/tasks/install_janus.yml
@@ -26,7 +26,16 @@
     group: root
     mode: "0644"
   loop:
-    - janus.jcfg
     - janus.transport.websockets.jcfg
   notify:
     - restart Janus
+
+- name: install Janus config writer
+  copy:
+    src: write-janus-config
+    dest: "{{ ustreamer_janus_dir }}/write-janus-config"
+    owner: "{{ ustreamer_user }}"
+    group: "{{ ustreamer_group }}"
+    mode: "0755"
+  notify:
+    - write Janus configs

--- a/ansible-role-ustreamer/templates/janus.jcfg.j2
+++ b/ansible-role-ustreamer/templates/janus.jcfg.j2
@@ -18,3 +18,10 @@ transports: {
 loggers: {
 	disable = "libjanus_jsonlog.so"
 }
+
+{% if ustreamer_janus_stun_server and ustreamer_janus_stun_port -%}
+nat: {
+  stun_server = {{ ustreamer_janus_stun_server }}
+  stun_port = {{ ustreamer_janus_stun_port }}
+}
+{% endif -%}

--- a/ansible-role-ustreamer/vars/main.yml
+++ b/ansible-role-ustreamer/vars/main.yml
@@ -21,4 +21,6 @@ ustreamer_yq_version: v4.30.6
 ustreamer_launcher_dir: /opt/ustreamer-launcher
 ustreamer_launcher_script: "{{ ustreamer_launcher_dir }}/launch"
 
+ustreamer_janus_dir: "/opt/ustreamer-janus"
+
 ustreamer_launcher_configs_dir: "{{ ustreamer_launcher_dir }}/configs.d"

--- a/app/update/settings.py
+++ b/app/update/settings.py
@@ -36,6 +36,8 @@ _DEFAULTS = {
     'ustreamer_desired_fps': video_service.DEFAULT_FRAME_RATE,
     'ustreamer_quality': video_service.DEFAULT_MJPEG_QUALITY,
     'ustreamer_h264_bitrate': video_service.DEFAULT_H264_BITRATE,
+    'ustreamer_janus_stun_server': None,  # Optional
+    'ustreamer_janus_stun_port': None,  # Optional
 }
 
 

--- a/app/update/settings_test.py
+++ b/app/update/settings_test.py
@@ -44,7 +44,7 @@ class UpdateSettingsTest(unittest.TestCase):
         self.assertEqual('/dev/hidg0',
                          settings_dict['tinypilot_keyboard_interface'])
         # Count constant and default values.
-        self.assertEqual(7, len(settings_dict))
+        self.assertEqual(9, len(settings_dict))
 
     def test_populates_empty_file_with_blank_settings(self):
         self.make_mock_settings_file('')


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot/issues/1460.

This PR is a demonstration for the internal logic that we would need in order to optionally allow specifying a STUN server in the Janus configuration. The PR is not meant for merging, but for discussing a few things design and code structure @mtlynch :

- The Ansible changes are a rough draft which I haven’t tested yet. I’m wondering, however, whether it would make sense to prioritize (up) https://github.com/tiny-pilot/tinypilot/issues/1496, to avoid changing Ansible logic that we’d soon have to migrate and delete anyway? I’m thinking that would be overall more efficient, even if it slightly delays the STUN feature.
  - I feel it would also make sense to address [the question who should be responsible for the Janus config](https://github.com/tiny-pilot/tinypilot/issues/1496#issuecomment-1645537095). To me, it would make sense to have this logic bundled with uStreamer rather than inside the TinyPilot Debian package, to make the uStreamer logic more self-contained.
- Assuming that the Janus config logic would stay with uStreamer, then generating the Janus config files cannot be done via a TinyPilot privileged script (as in [`/opt/tinypilot-privileged/scripts`](https://github.com/tiny-pilot/tinypilot/tree/master/debian-pkg/opt/tinypilot-privileged/scripts)). We’d need to write the configs already as part of the initial uStreamer+Janus installation, and that context is not aware (or shouldn’t depend) on TinyPilot.
  - So the uStreamer package must bring such a script by itself (e.g. `write-janus-config`), and the TinyPilot backend would invoke that directly.
  - Regarding the location for `write-janus-config`, we already have a `/opt/ustreamer-launcher` directory, but that doesn’t seem to be a fitting place – at least name-wise.
    - We could either consider introducing a new, separate directory, like `/opt/ustreamer-janus`. (As demonstrated in this PR.)
    - Or, we rename the folder to be `/opt/ustreamer`, so that it can legitimately house any uStreamer-related logic.
    - Or, we put it into `/opt/ustreamer-launcher` anyway (for simplicity), and defer (or even skip) the renaming. I’d have a slight preference for that option.
- In regards to division of concerns, I’d find it most sensible to restrict the config script to just generating the files, but then letting the caller be responsible for restarting the uStreamer or Janus services. Later, when we implement the backend logic in Python, we already have the [code for that in place](https://github.com/tiny-pilot/tinypilot/blob/34918d7ed87e401fb633c7697ab8702e9702b21d/app/video_service.py#L26-L59).

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1523"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>