### PR TITLE
Upgrade flask-socketio to version 5.3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 eventlet==0.31.0
 Flask==1.1.1
-Flask-SocketIO==5.0.1
+Flask-SocketIO==5.3.4
 Flask-WTF==0.14.3
 pyyaml==6.0.1
 
@@ -15,8 +15,8 @@ itsdangerous==1.1.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1
 monotonic==1.5
-python-engineio==4.0.1
-python-socketio==5.1.0
+python-engineio==4.5.1
+python-socketio==5.8.0
 six==1.15.0
 Werkzeug==1.0.1
 WTForms==2.3.3


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot/issues/1026#issuecomment-1650368355

> Might as well be on latest and greatest.

This PR upgrades [`flask-socketio`](https://github.com/miguelgrinberg/Flask-SocketIO/tree/v5.3.4) to the latest version (5.3.4).

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1526"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>