### PR TITLE
Sort license/credits list by project name

### DIFF
--- a/app/templates/custom-elements/about-dialog.html
+++ b/app/templates/custom-elements/about-dialog.html
@@ -113,6 +113,9 @@
 
         _populateCredits() {
           getLicensingMetadata().then((metadata) => {
+            // Sort credits by project name.
+            metadata.sort((a, b) => a.name.localeCompare(b.name, "en"));
+
             const creditsDiv = this.shadowRoot.querySelector(".credits");
             for (const project of metadata) {
               // Skip displaying TinyPilot in the list of dependencies, since we


### PR DESCRIPTION
A quick convenience fix that aims to make it easier to parse and check the credits list in the `<about-dialog>` component.

Alternatively, we could also sort [server-side in the HTTP endpoint](https://github.com/tiny-pilot/tinypilot/blob/e845e1165b43143be341e00065cb0d62880da935/app/license_notice.py#L287-L295), but I thought that sorting is a presentational concern, and it also doesn’t make a difference in practice here (it’s one line of code one way or the other).

## After

<img width="890" alt="Screenshot 2023-07-27 at 08 36 49" src="https://github.com/tiny-pilot/tinypilot/assets/83721279/46b9f882-d5a5-42a3-98fe-768e10b70e2e">

## Before

<img width="883" alt="Screenshot 2023-07-27 at 08 38 37" src="https://github.com/tiny-pilot/tinypilot/assets/83721279/8088f65c-9bed-4dc9-808e-d77488ba888a">

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1535"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>