### PR TITLE
Clarify placeholder usage and width for input fields

### DIFF
--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -262,8 +262,10 @@
           format. The placeholder text should be a made-up but semantically
           correct value. The placeholder should make it obvious to the reader
           that it’s just an example value by containing words like “example” or
-          artificial sequences like “1234”. Omit prefixes such as
-          “<span class="monospace">e.g., </span>”.<br />
+          artificial sequences like “1234”. Omit prefixes such as “<span
+            class="monospace"
+            >e.g., </span
+          >”.<br />
           A placeholder is not needed for input fields that expect free text, or
           when the validation rules are too trivial to allow for expressive or
           meaningful demo usage.


### PR DESCRIPTION
I stumbled across this while working on https://github.com/tiny-pilot/tinypilot/issues/897.

This PR clarifies the rules for input fields in regards to placeholder usage, and setting the width. We mostly follow the rules already (with one exception in Pro), but they haven’t been documented yet:

- [Hostname dialog](https://github.com/tiny-pilot/tinypilot/assets/83721279/cbe06798-6606-4e31-a4dd-2d6fc2d803e4)
  - The width seems reasonable for a real-life hostname.
  - I think no placeholder is needed, since (a) the input field is prefilled anyway, and (b) I think that a placeholder such as `example` or `tinypilot` wouldn’t add much value or clarity.
- Security dialog ([user/password form](https://github.com/tiny-pilot/tinypilot/assets/83721279/6e72802d-d4d2-46ee-8d0d-2380904e94d3))
  - Sensible width.
  - No placeholder needed, since “username” is more or less free text, and usage should be clear enough by itself.
- [Wake-on-LAN](https://github.com/tiny-pilot/tinypilot/assets/83721279/67bac827-232d-40b7-bfe1-563b34168d1e)
  - Good width, since it allows for 12 characters plus delimiters plus some extra padding.
  - We don’t have a placeholder here currently, but I think we should add one to demonstrate the expected format. → https://github.com/tiny-pilot/tinypilot-pro/pull/1005
- Virtual Media ([Upload disk image from URL](https://github.com/tiny-pilot/tinypilot/assets/83721279/26ca8e22-d132-4adb-b207-a9b36e8b6ef9))
  - Widths seems okay, and it accounts for long URLs too, which are expected here.
  - We already have a good placeholder here.

Since we have more text in the style guide section now, and an additional demo input field, I tidied up the sub-section on font usage, to make it look more concise overall.

<img width="709" alt="Screenshot 2023-07-27 at 10 33 16" src="https://github.com/tiny-pilot/tinypilot/assets/83721279/c4589ad7-b8df-419e-b5dc-07ef029a2516">

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1536"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>