### PR TITLE
Disable call-to-action button when hostname is empty

### DIFF
--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -212,7 +212,6 @@
         _onInputChanged() {
           const isEqualToInitialValue =
             this.elements.hostnameInput.value === this.initialHostname;
-          this.elements.changeAndRestart.disabled = isEqualToInitialValue;
           const isEmpty = this.elements.hostnameInput.value === "";
           this.elements.changeAndRestart.disabled =
             isEmpty || isEqualToInitialValue;


### PR DESCRIPTION
I noticed a tiny UI glitch, where we are inconsistent with our style guide: [call-to-action buttons should be disabled, if the corresponding input field is empty](https://github.com/tiny-pilot/tinypilot/blob/1354e914f364c5e1de5d922ea0a68fc7e976f3df/app/templates/styleguide.html#L168-L171). This PR fixes this issue for the hostname dialog.

https://github.com/tiny-pilot/tinypilot/assets/83721279/a06eeeea-5bb2-45f5-8f48-9ac2aa639ff9


<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1538"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>