### PR TITLE
Migrate uStreamer directory permissions to the uStreamer Debian package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ parameters:
     # For one-off builds, you can also specify this parameter when manually
     # triggering the build pipeline on CircleCI; in this case, the parameter
     # value needs to be the (literal) branch name.
-    default: << pipeline.git.branch >>
+    default: master
 workflows:
   build_pipeline:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,5 +26,6 @@ workflows:
           name: build_pipeline_params
           mapping: |
             ansible-role-ustreamer/.* ansible_role_changed true
-          base-revision: master
+          # testing
+          base-revision: << pipeline.git.branch >>
           config-path: .circleci/continue_config.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ parameters:
     # For one-off builds, you can also specify this parameter when manually
     # triggering the build pipeline on CircleCI; in this case, the parameter
     # value needs to be the (literal) branch name.
-    default: master
+    default: << pipeline.git.branch >>
 workflows:
   build_pipeline:
     jobs:
@@ -26,6 +26,5 @@ workflows:
           name: build_pipeline_params
           mapping: |
             ansible-role-ustreamer/.* ansible_role_changed true
-          # testing
-          base-revision: << pipeline.git.branch >>
+          base-revision: master
           config-path: .circleci/continue_config.yml

--- a/ansible-role-ustreamer/molecule/default/molecule.yml
+++ b/ansible-role-ustreamer/molecule/default/molecule.yml
@@ -24,7 +24,7 @@ provisioner:
     # parameter. See
     # https://github.com/ansible-community/molecule/issues/3065#issuecomment-835897461
     extra-vars: >
-      ustreamer_debian_package_path=https://github.com/tiny-pilot/ustreamer-debian/releases/download/5.38-20230620124412/ustreamer_5.38-20230620124412_amd64.deb
+      ustreamer_debian_package_path=https://github.com/tiny-pilot/ustreamer-debian/releases/download/ustreamer_5.38-20230802141939/ustreamer_5.38-20230802141939_amd64.deb
 verifier:
   name: ansible
 scenario:

--- a/ansible-role-ustreamer/tasks/main.yml
+++ b/ansible-role-ustreamer/tasks/main.yml
@@ -27,16 +27,6 @@
   apt:
     deb: "{{ ustreamer_debian_package_path }}"
 
-- name: fix uStreamer folder permissions
-  file:
-    path: "{{ ustreamer_dir }}"
-    state: directory
-    owner: "{{ ustreamer_user }}"
-    group: "{{ ustreamer_group }}"
-    recurse: yes
-  tags:
-    - molecule-idempotence-notest
-
 - name: install uStreamer as a service
   template:
     src: ustreamer.systemd.j2

--- a/ansible-role-ustreamer/vars/main.yml
+++ b/ansible-role-ustreamer/vars/main.yml
@@ -1,6 +1,7 @@
 # Specifies the filesystem path or URL of a Debian package that installs
 # uStreamer.
-ustreamer_debian_package_path: https://github.com/tiny-pilot/ustreamer-debian/releases/download/5.38-20230620124412/ustreamer_5.38-20230620124412_armhf.deb
+# Temporary testing
+ustreamer_debian_package_path: https://output.circle-artifacts.com/output/job/2015849b-b46f-49d0-b686-de0a12b3083e/artifacts/0/build/linux_arm_v7/ustreamer_5.38-20230801160853_armhf.deb
 
 # The user/group must match the one created by the uStreamer Debian package.
 ustreamer_group: ustreamer

--- a/ansible-role-ustreamer/vars/main.yml
+++ b/ansible-role-ustreamer/vars/main.yml
@@ -1,6 +1,5 @@
 # Specifies the filesystem path or URL of a Debian package that installs
 # uStreamer.
-# Temporary testing
 ustreamer_debian_package_path: https://github.com/tiny-pilot/ustreamer-debian/releases/download/ustreamer_5.38-20230802141939/ustreamer_5.38-20230802141939_armhf.deb
 
 # The user/group must match the one created by the uStreamer Debian package.

--- a/ansible-role-ustreamer/vars/main.yml
+++ b/ansible-role-ustreamer/vars/main.yml
@@ -1,7 +1,7 @@
 # Specifies the filesystem path or URL of a Debian package that installs
 # uStreamer.
 # Temporary testing
-ustreamer_debian_package_path: https://output.circle-artifacts.com/output/job/2015849b-b46f-49d0-b686-de0a12b3083e/artifacts/0/build/linux_arm_v7/ustreamer_5.38-20230801160853_armhf.deb
+ustreamer_debian_package_path: https://github.com/tiny-pilot/ustreamer-debian/releases/download/ustreamer_5.38-20230802141939/ustreamer_5.38-20230802141939_armhf.deb
 
 # The user/group must match the one created by the uStreamer Debian package.
 ustreamer_group: ustreamer


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1467

This change sets the correct permissions of the uStreamer directory (i.e., /opt/ustreamer) using the uStreamer Debian package, instead of using Ansible.

To test this bundle, run:

```bash
curl \
  --silent \
  --show-error \
  --location \
  https://raw.githubusercontent.com/tiny-pilot/tinypilot/master/scripts/install-bundle | \
  sudo bash -s -- \
    https://output.circle-artifacts.com/output/job/e81ad09e-33d3-4703-a812-59bb58f415c2/artifacts/0/bundler/dist/tinypilot-community-20230802T1810Z-1.9.0-43+0d9bfb3.tgz
```

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1546"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>