### PR TITLE
Paste text asynchronously

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -347,7 +347,11 @@ def paste_post():
     # Convert text to bytes.
     buffer = bytearray()
     for char in text:
-        hid_modifier, hid_keycode = text_to_hid.convert(char, language)
+        try:
+            hid_modifier, hid_keycode = text_to_hid.convert(char, language)
+        except text_to_hid.UnsupportedCharacterError as e:
+            logger.warning(e)
+            continue
         buffer += fake_keyboard.keystroke_to_buffer(hid_modifier, hid_keycode)
     # Write bytes to HID keyboard asynchronous.
     keyboard_path = flask.current_app.config.get('KEYBOARD_PATH')

--- a/app/hid/keyboard.py
+++ b/app/hid/keyboard.py
@@ -1,11 +1,12 @@
 from hid import write as hid_write
 
+RELEASE_KEYS_BUFFER = bytes([0] * 8)
 
-def send_keystroke(keyboard_path, control_keys, hid_keycode):
-    buf = [0] * 8
+
+def keystroke_to_buffer(control_keys, hid_keycode):
+    buf = bytearray(RELEASE_KEYS_BUFFER)
     buf[0] = control_keys
     buf[2] = hid_keycode
-    hid_write.write_to_hid_interface(keyboard_path, buf)
 
     # If it's a normal keycode (i.e. not a standalone modifier key), add a
     # message indicating that the key should be released after it is sent. We do
@@ -15,8 +16,15 @@ def send_keystroke(keyboard_path, control_keys, hid_keycode):
     # genuinely long key presses (see
     # https://github.com/tiny-pilot/tinypilot/issues/1093).
     if hid_keycode:
-        release_keys(keyboard_path)
+        buf += RELEASE_KEYS_BUFFER
+
+    return buf
+
+
+def send_keystroke(keyboard_path, control_keys, hid_keycode):
+    buf = keystroke_to_buffer(control_keys, hid_keycode)
+    hid_write.write_to_hid_interface(keyboard_path, buf)
 
 
 def release_keys(keyboard_path):
-    hid_write.write_to_hid_interface(keyboard_path, [0] * 8)
+    hid_write.write_to_hid_interface(keyboard_path, RELEASE_KEYS_BUFFER)

--- a/app/hid/write.py
+++ b/app/hid/write.py
@@ -59,7 +59,7 @@ class ProcessWithResult(multiprocessing.Process):
         return self.parent_conn.recv() if self.parent_conn.poll() else None
 
 
-def _write_to_hid_interface_immediately(hid_path, buffer):
+def write_to_hid_interface_immediately(hid_path, buffer):
     try:
         with open(hid_path, 'ab+') as hid_handle:
             hid_handle.write(bytearray(buffer))
@@ -78,10 +78,9 @@ def write_to_hid_interface(hid_path, buffer):
     # Writes can hang, for example, when TinyPilot is attempting to write to the
     # mouse interface, but the target system has no GUI. To avoid locking up the
     # main server process, perform the HID interface I/O in a separate process.
-    write_process = ProcessWithResult(
-        target=_write_to_hid_interface_immediately,
-        args=(hid_path, buffer),
-        daemon=True)
+    write_process = ProcessWithResult(target=write_to_hid_interface_immediately,
+                                      args=(hid_path, buffer),
+                                      daemon=True)
     write_process.start()
     write_process.join(timeout=0.5)
     if write_process.is_alive():


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1026
Dependent on https://github.com/tiny-pilot/tinypilot/pull/1557

Writing individual keystrokes to the HID interface is slow, resulting in API requests to paste large amounts of text to timeout. This PR writes multiple keystrokes to the HID interface at once, and does so asynchronously.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1558"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>