### PR TITLE
Upgrade circleci/path-filtering to version 1.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@
 version: 2.1
 setup: true
 orbs:
-  path-filtering: circleci/path-filtering@0.1.4
+  path-filtering: circleci/path-filtering@1.0.0
 parameters:
   # Creating the bundle assumes an ARMv7 build, so we only do this on master,
   # because it's slow building ARMv7 binaries from a CircleCI AMD64 instance.


### PR DESCRIPTION
This was supposed to resolve this https://github.com/tiny-pilot/tinypilot/issues/1559, but it wasn't actually related.

Might as well upgrade `circleci/path-filtering` while we're here.





<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1560"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>