### PR TITLE
Fix instructions on how to manually trigger a bundle build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,4 +28,3 @@ workflows:
             ansible-role-ustreamer/.* ansible_role_changed true
           base-revision: master
           config-path: .circleci/continue_config.yml
-          bundle_build_branch: << pipeline.git.branch >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,3 +28,4 @@ workflows:
             ansible-role-ustreamer/.* ansible_role_changed true
           base-revision: master
           config-path: .circleci/continue_config.yml
+          bundle_build_branch: << pipeline.git.branch >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,16 +8,8 @@ setup: true
 orbs:
   path-filtering: circleci/path-filtering@0.1.4
 parameters:
-  # Creating the bundle assumes an ARMv7 build, so we only do this on master,
-  # because it's slow building ARMv7 binaries from a CircleCI AMD64 instance.
   bundle_build_branch:
     type: string
-    # In order to enable bundle building on a feature branch, you can
-    # temporarily change the below default to be: << pipeline.git.branch >>
-    # Don’t forget to revert this before merging your branch!
-    # For one-off builds, you can also specify this parameter when manually
-    # triggering the build pipeline on CircleCI; in this case, the parameter
-    # value needs to be the (literal) branch name.
     default: master
 workflows:
   build_pipeline:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -8,7 +8,7 @@ parameters:
   bundle_build_branch:
     type: string
     # In order to enable bundle building on a feature branch, you can
-    # temporarily change the below default to be: << pipeline.git.branch >>
+    # temporarily change the below `default` to be: << pipeline.git.branch >>
     # Don’t forget to revert this before merging your branch!
     # For one-off builds, you can also specify this parameter when manually
     # triggering the build pipeline on CircleCI; in this case, the parameter

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -13,7 +13,7 @@ parameters:
     # For one-off builds, you can also specify this parameter when manually
     # triggering the build pipeline on CircleCI; in this case, the parameter
     # value needs to be the (literal) branch name.
-    default: master
+    default: << pipeline.git.branch >>
 jobs:
   check_whitespace:
     docker:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -3,8 +3,16 @@ parameters:
   ansible_role_changed:
     type: boolean
     default: false
+  # Creating the bundle assumes an ARMv7 build, so we only do this on master,
+  # because it's slow building ARMv7 binaries from a CircleCI AMD64 instance.
   bundle_build_branch:
     type: string
+    # In order to enable bundle building on a feature branch, you can
+    # temporarily change the below default to be: << pipeline.git.branch >>
+    # Don’t forget to revert this before merging your branch!
+    # For one-off builds, you can also specify this parameter when manually
+    # triggering the build pipeline on CircleCI; in this case, the parameter
+    # value needs to be the (literal) branch name.
     default: master
 jobs:
   check_whitespace:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -13,7 +13,7 @@ parameters:
     # For one-off builds, you can also specify this parameter when manually
     # triggering the build pipeline on CircleCI; in this case, the parameter
     # value needs to be the (literal) branch name.
-    default: << pipeline.git.branch >>
+    default: master
 jobs:
   check_whitespace:
     docker:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -5,7 +5,7 @@ parameters:
     default: false
   bundle_build_branch:
     type: string
-    default: master
+    default: << pipeline.git.branch >>
 jobs:
   check_whitespace:
     docker:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -5,7 +5,7 @@ parameters:
     default: false
   bundle_build_branch:
     type: string
-    default: << pipeline.git.branch >>
+    default: master
 jobs:
   check_whitespace:
     docker:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ echo 'ustreamer_capture_device: tc358743' >> ~/settings.yml
 The canonical way to build bundles is on CircleCI. By default, bundles are only built off the `master` branch. There are two methods available to build a bundle off a feature branch:
 
 1. Temporarily enable bundle builds for all commits on a feature branch:
-   1. In [the CircleCI configuration](/.circleci/config.yml), change the `bundle_build_branch` parameter’s default value from `master` to `<< pipeline.git.branch >>`.
+   1. In [the CircleCI configuration](/.circleci/continue_config.yml), change the `bundle_build_branch` parameter’s `default` value from `master` to `<< pipeline.git.branch >>`.
    1. Push your changes as branch to GitHub. CircleCI will now automatically build bundles for all subsequent commits of that branch.
    1. Before eventually merging your feature branch, remember to revert the `bundle_build_branch` parameter to the original value (i.e., `master`).
 1. Manually trigger a bundle build as one-off:


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1548

This PR moves the comments that explains how to trigger a code-based bundle build from `.circleci/config.yml` to `.circleci/continue_config.yml` and updates the contributing docs to reference the correct CircleCI config file.

So the correct ways to [manually trigger a bundle build](https://github.com/tiny-pilot/tinypilot/blob/1ea663b0ee6679e0ab73e59f57de94e4b8e8a708/CONTRIBUTING.md#installing-a-nightly-bundle) is either the:
1. Code-based way
    > 1. In [the CircleCI configuration](/.circleci/continue_config.yml), change the `bundle_build_branch` parameter’s `default` value from `master` to `<< pipeline.git.branch >>`.
    > 1. Push your changes as branch to GitHub. CircleCI will now automatically build bundles for all subsequent commits of that branch.
    > 1. Before eventually merging your feature branch, remember to revert the `bundle_build_branch` parameter to the original value (i.e., `master`)
3. CircleCI web UI way
    > 1. On CircleCI’s overview page for the respective branch, click the “Trigger Pipeline” button.
    > 1. In the dialog, enter `bundle_build_branch` as parameter name, and the (exact) name of the branch as parameter value.
    > 1. Click the “Trigger Pipeline” button in the dialog. CircleCI will now build a bundle for the latest commit of that branch.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1561"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>