### PR TITLE
Skip installing git in build_bundle CI step

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -13,7 +13,7 @@ parameters:
     # For one-off builds, you can also specify this parameter when manually
     # triggering the build pipeline on CircleCI; in this case, the parameter
     # value needs to be the (literal) branch name.
-    default: master
+    default: << pipeline.git.branch >>
 jobs:
   check_whitespace:
     docker:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -253,9 +253,6 @@ jobs:
       - attach_workspace:
           at: ./bundler/bundle/
       - run:
-          name: Install dependencies
-          command: sudo apt-get update && sudo apt-get install -y git
-      - run:
           name: Create the bundle
           command: ./bundler/create-bundle
       - store_artifacts:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -13,7 +13,7 @@ parameters:
     # For one-off builds, you can also specify this parameter when manually
     # triggering the build pipeline on CircleCI; in this case, the parameter
     # value needs to be the (literal) branch name.
-    default: << pipeline.git.branch >>
+    default: master
 jobs:
   check_whitespace:
     docker:


### PR DESCRIPTION
`create-bundle` [used to depend on git](https://github.com/tiny-pilot/tinypilot/blob/1.8.0/bundler/create-bundle), as it downloaded external roles using git and used `git` to pull version information about the local repo.

We've since simplified the bundle build process, so we no longer require git, and we can delete the CI step when we install git into the container. This saves us about 5s on every bundle build in CI.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1564"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>