### PR TITLE
Populate uStreamer Janus plugin config after reading capture device

### DIFF
--- a/ansible-role-ustreamer/tasks/main.yml
+++ b/ansible-role-ustreamer/tasks/main.yml
@@ -44,14 +44,6 @@
     name: ustreamer
     enabled: yes
 
-- name: create uStreamer Janus plugin config
-  template:
-    src: janus.plugin.ustreamer.jcfg.j2
-    dest: "{{ ustreamer_janus_configs_dir }}/janus.plugin.ustreamer.jcfg"
-  notify:
-    - restart Janus
-  when: ustreamer_install_janus
-
 - name: check for a boot config file
   stat:
     path: /boot/config.txt
@@ -84,3 +76,11 @@
 
 - name: install uStreamer launcher
   import_tasks: install_launcher.yml
+
+- name: create uStreamer Janus plugin config
+  template:
+    src: janus.plugin.ustreamer.jcfg.j2
+    dest: "{{ ustreamer_janus_configs_dir }}/janus.plugin.ustreamer.jcfg"
+  notify:
+    - restart Janus
+  when: ustreamer_install_janus


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1567

WebRTC audio streaming stopped working since https://github.com/tiny-pilot/tinypilot/pull/1470. The problem was that the uStreamer Janus plugin config file was being written before populating the `ustreamer_capture_device` variable, which resulted in no Janus audio config:
https://github.com/tiny-pilot/tinypilot/blob/b379ac26ea87a99e6126b3d616648b905013cb2f/ansible-role-ustreamer/templates/janus.plugin.ustreamer.jcfg.j2#L5-L10

The `ustreamer_capture_device` variable is populated when reading the `/home/ustreamer/config.yml` file:
https://github.com/tiny-pilot/tinypilot/blob/b379ac26ea87a99e6126b3d616648b905013cb2f/ansible-role-ustreamer/tasks/check_saved_settings.yml#L11-L14

Back in https://github.com/tiny-pilot/tinypilot/pull/1470, I specifically mentioned that I was shifting where the TC358743 chip was being provisioned, but I incorrectly assumed that only the uStreamer launcher cared about the uStreamer config file:
> I've [moved the TC358743 provisioning closer down to the uStreamer launcher tasks](https://github.com/tiny-pilot/tinypilot/blob/05f256fc6cac24ac62ec8a41a28e52cb9b2e5d15/ansible-role-ustreamer/tasks/main.yml#L112-L136) because the [TC358743 provisioning sets a bunch of ustreamer variables](https://github.com/tiny-pilot/tinypilot/blob/9cbfe6418767a92385718482d04d91f63d62528e/ansible-role-ustreamer/tasks/provision_tc358743.yml#L61-L68) which is only put into effect by the uStreamer launcher.

This PR only writes the uStreamer Janus plugin config file after we have determined the uStreamer capture device.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1568"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>