### PR TITLE
Delete dead ustreamer_port var

### DIFF
--- a/ansible-role-ustreamer/defaults/main.yml
+++ b/ansible-role-ustreamer/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-# Port to listen for connections.
-ustreamer_port: null
-
 # Path to video device, such as /dev/video1.
 ustreamer_video_path: null
 


### PR DESCRIPTION
As of 710ed072e9b048c1c2c953052c07656c9d58a24d, we no longer honor this variable, so we can safely delete it.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1569"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>