### PR TITLE
Proof of concept for popping out the remote screen

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -62,12 +62,6 @@ body {
 }
 
 .container {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  text-align: center;
-  margin: 0 auto;
-  padding-top: 55px; /* Account for menu bar plus some extra spacing */
 }
 
 .header-bar {

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -345,6 +345,14 @@ menuBar.addEventListener("change-hostname-dialog-requested", () => {
 menuBar.addEventListener("fullscreen-requested", () => {
   document.getElementById("remote-screen").fullscreen = true;
 });
+menuBar.addEventListener("popup-requested", () => {
+  const screenSize = document.getElementById("remote-screen").screenSize;
+  window.open(
+    "/?viewMode=standalone",
+    undefined,
+    `popup=true,width=${screenSize.width},height=${screenSize.height}`
+  );
+});
 menuBar.addEventListener("debug-logs-dialog-requested", () => {
   document.getElementById("debug-dialog").retrieveLogs();
   document.getElementById("debug-overlay").show();

--- a/app/templates/custom-elements/menu-bar.html
+++ b/app/templates/custom-elements/menu-bar.html
@@ -265,6 +265,11 @@
             >Full Screen</a
           >
         </li>
+        <li class="item" role="presentation">
+          <a data-onclick-event="popup-requested" role="menuitem"
+            >Popup Window</a
+          >
+        </li>
       </ul>
     </li>
 

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -2,34 +2,29 @@
   <style>
     @import "css/cursors.css";
 
+    :host {
+      --menu-bar-height: 45px;
+      --status-bar-height: 31px;
+      --bar-padding: 10px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding-top: calc(var(--menu-bar-height) + var(--bar-padding));
+    }
+
+    :host([no-margin=""]) {
+      --menu-bar-height: 0px;
+      --status-bar-height: 0px;
+      --bar-padding: 0px;
+    }
+
     .screen {
       max-width: 100%;
-      max-height: 70vh;
+      max-height: calc(
+        100vh - var(--menu-bar-height) - var(--status-bar-height) - 2 *
+          var(--bar-padding)
+      );
       object-fit: contain;
-    }
-
-    @media screen and (min-height: 450px) {
-      .screen {
-        max-height: 80vh;
-      }
-    }
-
-    @media screen and (min-height: 600px) {
-      .screen {
-        max-height: 85vh;
-      }
-    }
-
-    @media screen and (min-height: 900px) {
-      .screen {
-        max-height: 90vh;
-      }
-    }
-
-    @media screen and (min-height: 1180px) {
-      .screen {
-        max-height: 100vh;
-      }
     }
 
     :host([fullscreen="true"]) .screen-wrapper {
@@ -217,6 +212,11 @@
 
         set fullscreen(newValue) {
           this.setAttribute("fullscreen", newValue);
+        }
+
+        get screenSize() {
+          const screen = this._getCurrentScreenElement();
+          return { width: screen.clientWidth, height: screen.clientHeight };
         }
 
         get millisecondsBetweenMouseEvents() {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -18,14 +18,34 @@
     {% endfor %}
 
     <div id="app" tabindex="0">
-      <div class="header-bar">
+      <div
+        class="header-bar"
+        {%
+        if
+        is_standalone_mode
+        %}
+        style="display: none"
+        {%
+        endif
+        %}
+      >
         <menu-bar id="menu-bar"></menu-bar>
       </div>
-      <div class="footer-bar">
+      <div
+        class="footer-bar"
+        {%
+        if
+        is_standalone_mode
+        %}
+        style="display: none"
+        {%
+        endif
+        %}
+      >
         <status-bar id="status-bar"></status-bar>
       </div>
 
-      <div class="page-content container">
+      <div>
         <overlay-panel id="error-overlay" variant="danger">
           <error-dialog id="error-dialog"></error-dialog>
         </overlay-panel>
@@ -58,6 +78,14 @@
         <remote-screen
           id="remote-screen"
           milliseconds-between-mouse-events="600"
+          {%
+          if
+          is_standalone_mode
+          %}
+          no-margin
+          {%
+          endif
+          %}
         ></remote-screen>
 
         <on-screen-keyboard id="on-screen-keyboard"></on-screen-keyboard>

--- a/app/views.py
+++ b/app/views.py
@@ -19,6 +19,7 @@ def index_get():
         'index.html',
         use_webrtc_remote_screen=use_webrtc,
         page_title_prefix=_page_title_prefix(),
+        is_standalone_mode=_is_standalone_mode(),
         custom_elements_files=find_files.custom_elements_files())
 
 
@@ -47,3 +48,7 @@ def _page_title_prefix():
     if hostname.determine().lower() != _DEFAULT_HOSTNAME.lower():
         return f'{hostname.determine()} - '
     return ''
+
+
+def _is_standalone_mode():
+    return flask.request.args.get("viewMode") == "standalone"


### PR DESCRIPTION
Proof-of-concept implementation for https://github.com/tiny-pilot/tinypilot/issues/728. (Not meant for merging.)

@mtlynch could you briefly check out this branch, whether the functionality/behaviour matches what you had in mind? If so, I’d chop this up into 2–3 smaller PRs, and wrap up the implementation.

https://github.com/tiny-pilot/tinypilot/assets/83721279/a3a99b42-833a-4cc1-be4d-4bf9500df4a1

- We would add a new item to the “View” menu to open the popup window. Not sure about the menu item label, “Popup Window” certainly doesn’t sound great, but I also haven’t thought about good wording yet.
- For the popup window itself, we can strip all browser bars (bookmark, back/forward buttons, etc.) except for the address bar by means of the [`window.open` API](https://developer.mozilla.org/en-US/docs/Web/API/Window/open).
- The initial dimensions of the popup can be configured, e.g. to match the dimensions of the current remote screen. (The user can adjust the size in any event anyways, though.) This POC demonstrates this initial auto-sizing, it comes at roughly 10 LOC. We could also leave this feature out, however, as it’s a mere convenience (e.g. for when the user had manually “optimized” their browser window size previously). Without initial sizing parameters, the browser just uses its regular dimensions for new windows.
- In order to strip off the menu bar and status bar inside the popup window, I’d find it most simple to use a query parameter (here: `?viewMode=standalone`) and facilitate the control flow via a template parameter in `views.py`/`index.html`. That also would allow for the iframe use-case described in https://github.com/tiny-pilot/tinypilot/issues/523. A potential alternative might be to communicate internally via JavaScript with the popup window from the main window, but that would prohibit the iframe use-case. It would also probably be more complicated code-wise.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1574"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>