### PR TITLE
Hardcode h264 parameters

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -13,7 +13,7 @@ parameters:
     # For one-off builds, you can also specify this parameter when manually
     # triggering the build pipeline on CircleCI; in this case, the parameter
     # value needs to be the (literal) branch name.
-    default: master
+    default: << pipeline.git.branch >>
 jobs:
   check_whitespace:
     docker:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -13,7 +13,7 @@ parameters:
     # For one-off builds, you can also specify this parameter when manually
     # triggering the build pipeline on CircleCI; in this case, the parameter
     # value needs to be the (literal) branch name.
-    default: << pipeline.git.branch >>
+    default: master
 jobs:
   check_whitespace:
     docker:

--- a/ansible-role-ustreamer/defaults/main.yml
+++ b/ansible-role-ustreamer/defaults/main.yml
@@ -73,17 +73,6 @@ ustreamer_edid: |
 # Location to store EDID files.
 ustreamer_edids_dir: /home/{{ ustreamer_user }}/edids
 
-# Use the specified shared memory object to sink H264 frames encoded by MMAL
-# (e.g., tinypilot::ustreamer::h264). Disabled by default.
-ustreamer_h264_sink: null
-
-# Set permissions bitmask for H264 shared memory object (e.g., 777). Defaults
-# to 660 when not set.
-ustreamer_h264_sink_mode: null
-
-# Remove shared memory on stop (e.g., yes). Defaults to no when not set.
-ustreamer_h264_sink_rm: null
-
 # Set the bitrate in Kb/s for the H264 stream (e.g., 2000). The range of allowed
 # values is [25, 20000]. Defaults to 5000 when not set.
 ustreamer_h264_bitrate: null

--- a/ansible-role-ustreamer/files/launch
+++ b/ansible-role-ustreamer/files/launch
@@ -87,9 +87,9 @@ append_arg_if_defined() {
 
 # Apply hardcoded settings that are not configurable via YAML.
 USTREAMER_ARGS+=('--port' '48001')
-USTREAMER_ARGS+=('--ustreamer_h264_sink' 'tinypilot::ustreamer::h264')
-USTREAMER_ARGS+=('--ustreamer_h264_sink_mode' '777')
-USTREAMER_ARGS+=('--ustreamer_h264_sink_rm' 'yes')
+USTREAMER_ARGS+=('--h264-sink' 'tinypilot::ustreamer::h264')
+USTREAMER_ARGS+=('--h264-sink-mode' '777')
+USTREAMER_ARGS+=('--h264-sink-rm' 'yes')
 
 append_arg_and_value_if_defined '.ustreamer_video_path'       '--device'
 append_arg_and_value_if_defined '.ustreamer_encoder'          '--encoder'

--- a/ansible-role-ustreamer/files/launch
+++ b/ansible-role-ustreamer/files/launch
@@ -105,9 +105,6 @@ append_arg_and_value_if_defined '.ustreamer_brightness'       '--brightness'
 append_arg_if_defined           '.ustreamer_use_dv_timings'   '--dv-timings'
 append_arg_if_defined           '.ustreamer_tcp_nodelay'      '--tcp-nodelay'
 
-append_arg_and_value_if_defined '.ustreamer_h264_sink'        '--h264-sink'
-append_arg_and_value_if_defined '.ustreamer_h264_sink_mode'   '--h264-sink-mode'
-append_arg_if_defined           '.ustreamer_h264_sink_rm'     '--h264-sink-rm'
 append_arg_and_value_if_defined '.ustreamer_h264_bitrate'     '--h264-bitrate'
 
 # Echo commands to stdout.

--- a/ansible-role-ustreamer/files/launch
+++ b/ansible-role-ustreamer/files/launch
@@ -87,6 +87,7 @@ append_arg_if_defined() {
 
 # Apply hardcoded settings that are not configurable via YAML.
 USTREAMER_ARGS+=('--port' '48001')
+USTREAMER_ARGS+=('--persistent')
 USTREAMER_ARGS+=('--h264-sink' 'tinypilot::ustreamer::h264')
 USTREAMER_ARGS+=('--h264-sink-mode' '777')
 USTREAMER_ARGS+=('--h264-sink-rm' 'yes')

--- a/ansible-role-ustreamer/files/launch
+++ b/ansible-role-ustreamer/files/launch
@@ -87,7 +87,9 @@ append_arg_if_defined() {
 
 # Apply hardcoded settings that are not configurable via YAML.
 USTREAMER_ARGS+=('--port' '48001')
-USTREAMER_ARGS+=('--persistent')
+USTREAMER_ARGS+=('--ustreamer_h264_sink' 'tinypilot::ustreamer::h264')
+USTREAMER_ARGS+=('--ustreamer_h264_sink_mode' '777')
+USTREAMER_ARGS+=('--ustreamer_h264_sink_rm' 'yes')
 
 append_arg_and_value_if_defined '.ustreamer_video_path'       '--device'
 append_arg_and_value_if_defined '.ustreamer_encoder'          '--encoder'

--- a/ansible-role-ustreamer/files/launch
+++ b/ansible-role-ustreamer/files/launch
@@ -90,7 +90,7 @@ USTREAMER_ARGS+=('--port' '48001')
 USTREAMER_ARGS+=('--persistent')
 USTREAMER_ARGS+=('--h264-sink' 'tinypilot::ustreamer::h264')
 USTREAMER_ARGS+=('--h264-sink-mode' '777')
-USTREAMER_ARGS+=('--h264-sink-rm' 'yes')
+USTREAMER_ARGS+=('--h264-sink-rm')
 
 append_arg_and_value_if_defined '.ustreamer_video_path'       '--device'
 append_arg_and_value_if_defined '.ustreamer_encoder'          '--encoder'

--- a/ansible-role-ustreamer/handlers/main.yml
+++ b/ansible-role-ustreamer/handlers/main.yml
@@ -25,4 +25,3 @@
   service:
     name: janus
     state: restarted
-  when: ustreamer_install_janus

--- a/ansible-role-ustreamer/tasks/install_launcher.yml
+++ b/ansible-role-ustreamer/tasks/install_launcher.yml
@@ -51,9 +51,6 @@
     - ustreamer_use_dv_timings
     - ustreamer_drop_same_frames
     - ustreamer_tcp_nodelay
-    - ustreamer_h264_sink
-    - ustreamer_h264_sink_mode
-    - ustreamer_h264_sink_rm
     - ustreamer_h264_bitrate
 
 - name: print uStreamer runtime variables

--- a/ansible-role-ustreamer/tasks/main.yml
+++ b/ansible-role-ustreamer/tasks/main.yml
@@ -37,18 +37,8 @@
   debug:
     var: is_tc358743_enabled
 
-- name: determine whether to install Janus
-  set_fact:
-    ustreamer_install_janus: true
-
-- name: decide whether to support audio streaming
-  set_fact:
-    # Audio streaming requires Janus because MJPEG can't carry audio.
-    ustreamer_enable_audio_streaming: "{{ ustreamer_install_janus }}"
-
 - name: install Janus
   include_tasks: install_janus.yml
-  when: ustreamer_install_janus
 
 - name: install uStreamer Debian package
   apt:
@@ -93,4 +83,3 @@
     dest: "{{ ustreamer_janus_configs_dir }}/janus.plugin.ustreamer.jcfg"
   notify:
     - restart Janus
-  when: ustreamer_install_janus

--- a/ansible-role-ustreamer/tasks/main.yml
+++ b/ansible-role-ustreamer/tasks/main.yml
@@ -39,7 +39,7 @@
 
 - name: determine whether to install Janus
   set_fact:
-    ustreamer_install_janus: "{{ ustreamer_h264_sink != None }}"
+    ustreamer_install_janus: true
 
 - name: decide whether to support audio streaming
   set_fact:

--- a/ansible-role-ustreamer/tasks/main.yml
+++ b/ansible-role-ustreamer/tasks/main.yml
@@ -1,15 +1,4 @@
 ---
-- name: check that the H264 variables are in a consistent state
-  fail:
-    msg: >-
-      The H264 variables are in an inconsistent state. You must set the
-      ustreamer_h264_sink variable in order to set other H264 variables.
-  when: >-
-    ustreamer_h264_sink == None
-    and (ustreamer_h264_sink_mode != None
-         or ustreamer_h264_sink_rm != None
-         or ustreamer_h264_bitrate != None)
-
 - name: check for a boot config file
   stat:
     path: /boot/config.txt

--- a/ansible-role-ustreamer/tasks/provision_tc358743.yml
+++ b/ansible-role-ustreamer/tasks/provision_tc358743.yml
@@ -5,7 +5,7 @@
     path: /boot/config.txt
     line: "dtoverlay=tc358743-audio"
     insertafter: "^dtoverlay=tc358743$"
-  when: boot_config_exists and ustreamer_enable_audio_streaming
+  when: boot_config_exists
 
 - name: set GPU memory to 256MB in /boot/config.txt
   lineinfile:

--- a/ansible-role-ustreamer/templates/janus.plugin.ustreamer.jcfg.j2
+++ b/ansible-role-ustreamer/templates/janus.plugin.ustreamer.jcfg.j2
@@ -1,5 +1,5 @@
 memsink: {
-    object = "{{ ustreamer_h264_sink }}"
+    object = "tinypilot::ustreamer::h264"
 }
 
 {% if is_tc358743_enabled -%}

--- a/ansible-role-ustreamer/vars/main.yml
+++ b/ansible-role-ustreamer/vars/main.yml
@@ -18,9 +18,3 @@ ustreamer_launcher_dir: /opt/ustreamer-launcher
 ustreamer_launcher_script: "{{ ustreamer_launcher_dir }}/launch"
 
 ustreamer_launcher_configs_dir: "{{ ustreamer_launcher_dir }}/configs.d"
-
-# Assigning `ustreamer_h264_sink` will make the uStreamer role install the Janus
-# server on the system, and thus enable H264 video streaming.
-ustreamer_h264_sink: tinypilot::ustreamer::h264
-ustreamer_h264_sink_mode: 777
-ustreamer_h264_sink_rm: yes


### PR DESCRIPTION
Resolves #1570

This change removes uStreamer variables in the Ansible role and hardcodes them. We now also unconditionally install Janus.

To test this bundle, run:

```bash
curl \
  --silent \
  --show-error \
  --location \
  https://raw.githubusercontent.com/tiny-pilot/tinypilot/master/scripts/install-bundle | \
  sudo bash -s -- \
    https://output.circle-artifacts.com/output/job/8025923f-9ba2-4e45-aef0-952f0f12655b/artifacts/0/bundler/dist/tinypilot-community-20230824T1222Z-1.9.0-62+3908e48.tgz
```

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1585"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>