### PR TITLE
Rate-limit keystroke events to the backend

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -5,7 +5,7 @@ import {
   requiresShiftKey,
 } from "./keycodes.js";
 import { KeyboardState } from "./keyboardstate.js";
-import { sendKeystroke } from "./keystrokes.js";
+import { RateLimitedKeyboard } from "./keystrokes.js";
 import { isPasteOverlayShowing, showPasteOverlay } from "./paste.js";
 import * as settings from "./settings.js";
 import { OverlayTracker } from "./overlays.js";
@@ -18,6 +18,7 @@ import { OverlayTracker } from "./overlays.js";
 const socket = io();
 let connectedToServer = false;
 
+const keyboard = new RateLimitedKeyboard(socket);
 const keyboardState = new KeyboardState();
 
 // Keep track of overlays, in order to properly deactivate keypress forwarding.
@@ -82,8 +83,8 @@ function processKeystroke(keystroke) {
     return;
   }
   const keystrokeHistoryEvent = keystrokeHistory.push(keystroke.key);
-  const result = sendKeystroke(socket, keystroke);
-  result
+  keyboard
+    .sendKeystroke(keystroke)
     .then(() => {
       keystrokeHistoryEvent.status = "succeeded";
     })

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -5,7 +5,7 @@ import {
   requiresShiftKey,
 } from "./keycodes.js";
 import { KeyboardState } from "./keyboardstate.js";
-import { RateLimitedKeyboard } from "./keystrokes.js";
+import { RateLimitedKeystrokes } from "./keystrokes.js";
 import { isPasteOverlayShowing, showPasteOverlay } from "./paste.js";
 import * as settings from "./settings.js";
 import { OverlayTracker } from "./overlays.js";
@@ -18,7 +18,7 @@ import { OverlayTracker } from "./overlays.js";
 const socket = io();
 let connectedToServer = false;
 
-const keyboard = new RateLimitedKeyboard(socket);
+const keystrokes = new RateLimitedKeystrokes(socket);
 const keyboardState = new KeyboardState();
 
 // Keep track of overlays, in order to properly deactivate keypress forwarding.
@@ -83,7 +83,7 @@ function processKeystroke(keystroke) {
     return;
   }
   const keystrokeHistoryEvent = keystrokeHistory.push(keystroke.key);
-  keyboard
+  keystrokes
     .sendKeystroke(keystroke)
     .then(() => {
       keystrokeHistoryEvent.status = "succeeded";

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -218,7 +218,7 @@ function onKeyUp(evt) {
   }
 
   if (isModifierCode(canonicalCode)) {
-    socket.emit("keyRelease");
+    keystrokes.sendKeyRelease();
   }
 }
 

--- a/app/static/js/keystrokes.js
+++ b/app/static/js/keystrokes.js
@@ -13,6 +13,10 @@ export class RateLimitedKeyboard {
     eventFunc();
   }
 
+  _queueEvent(eventFunc) {
+    this._eventQueue.push(eventFunc);
+  }
+
   _handleKeystroke(keystroke, resolve, reject) {
     this._socket.emit("keystroke", keystroke, (result) => {
       if ("success" in result && result.success) {
@@ -26,9 +30,7 @@ export class RateLimitedKeyboard {
   // Enqueue a keystroke message to be sent to the backend.
   sendKeystroke(keystroke) {
     return new Promise((resolve, reject) => {
-      this._eventQueue.push(() =>
-        this._handleKeystroke(keystroke, resolve, reject)
-      );
+      this._queueEvent(() => this._handleKeystroke(keystroke, resolve, reject));
     });
   }
 }

--- a/app/static/js/keystrokes.js
+++ b/app/static/js/keystrokes.js
@@ -1,12 +1,34 @@
-// Send a keystroke message to the backend.
-export function sendKeystroke(socket, keystroke) {
-  return new Promise((resolve, reject) => {
-    socket.emit("keystroke", keystroke, (result) => {
+export class RateLimitedKeyboard {
+  constructor(socket) {
+    this._socket = socket;
+    this._eventQueue = [];
+    setInterval(this._runEvent.bind(this), 50 /* 20 events per second */);
+  }
+
+  _runEvent() {
+    const eventFunc = this._eventQueue.shift();
+    if (eventFunc === undefined) {
+      return;
+    }
+    eventFunc();
+  }
+
+  _handleKeystroke(keystroke, resolve, reject) {
+    this._socket.emit("keystroke", keystroke, (result) => {
       if ("success" in result && result.success) {
         resolve({});
       } else {
         reject(new Error("Failed to forward keystroke"));
       }
     });
-  });
+  }
+
+  // Enqueue a keystroke message to be sent to the backend.
+  sendKeystroke(keystroke) {
+    return new Promise((resolve, reject) => {
+      this._eventQueue.push(() =>
+        this._handleKeystroke(keystroke, resolve, reject)
+      );
+    });
+  }
 }

--- a/app/static/js/keystrokes.js
+++ b/app/static/js/keystrokes.js
@@ -2,7 +2,7 @@
  * A mechanism to rate-limit the keystrokes messages sent to backend so that
  * they don't flood the SocketIO server's message queue and starve the server of
  * PING/PONG messages, needed to keep the client-server connection alive.
- * 
+ *
  * The current rate-limiting implementation maintains an array of anonymous
  * functions that get executed in a first in, first out (FIFO) ordering at a
  * fixed rate of 20 functions per second (i.e., a function gets executed once
@@ -11,7 +11,7 @@
  */
 export class RateLimitedKeystrokes {
   /**
-   * @param {Socket} socket - https://socket.io/docs/v4/client-api/#socket 
+   * @param {Socket} socket - https://socket.io/docs/v4/client-api/#socket
    */
   constructor(socket) {
     this._socket = socket;

--- a/app/static/js/keystrokes.js
+++ b/app/static/js/keystrokes.js
@@ -1,4 +1,4 @@
-export class RateLimitedKeyboard {
+export class RateLimitedKeystrokes {
   constructor(socket) {
     this._socket = socket;
     this._eventQueue = [];

--- a/app/static/js/keystrokes.js
+++ b/app/static/js/keystrokes.js
@@ -1,4 +1,18 @@
+/**
+ * A mechanism to rate-limit the keystrokes messages sent to backend so that
+ * they don't flood the SocketIO server's message queue and starve the server of
+ * PING/PONG messages, needed to keep the client-server connection alive.
+ * 
+ * The current rate-limiting implementation maintains an array of anonymous
+ * functions that get executed in a first in, first out (FIFO) ordering at a
+ * fixed rate of 20 functions per second (i.e., a function gets executed once
+ * every 50ms). Once a function has been executed, it is removed from the array.
+ * Each enqueue function is responsible for it's own success/error handling.
+ */
 export class RateLimitedKeystrokes {
+  /**
+   * @param {Socket} socket - https://socket.io/docs/v4/client-api/#socket 
+   */
   constructor(socket) {
     this._socket = socket;
     this._eventQueue = [];
@@ -27,12 +41,22 @@ export class RateLimitedKeystrokes {
     });
   }
 
-  // Enqueue a keystroke message to be sent to the backend.
+  /**
+   * Enqueue a keystroke message to be sent to the backend.
+   * @param {Object} keystroke - An object as returned by `processKeystroke`
+   * @returns {Promise<Object>}
+   *     Success case:  the Promise resolves with an empty object.
+   *     Error case:    the Promise rejects with an `Error`.
+   */
   sendKeystroke(keystroke) {
     return new Promise((resolve, reject) => {
       this._queueEvent(() => this._handleKeystroke(keystroke, resolve, reject));
     });
   }
+
+  /**
+   * Enqueue a keyRelease message to be sent to the backend.
+   */
   sendKeyRelease() {
     this._queueEvent(() => this._socket.emit("keyRelease"));
   }

--- a/app/static/js/keystrokes.js
+++ b/app/static/js/keystrokes.js
@@ -33,4 +33,7 @@ export class RateLimitedKeystrokes {
       this._queueEvent(() => this._handleKeystroke(keystroke, resolve, reject));
     });
   }
+  sendKeyRelease() {
+    this._queueEvent(() => this._socket.emit("keyRelease"));
+  }
 }


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1026

This PR rate-limits the speed at which the fontend sends `keystroke` WebSocket messages to the backend (currently at a fixed rate of 20 messages per second). This change is necessary to avoid clogging up SocketIO's message queue with custom `keystroke` messages that previously starved the server of `PONG` messages (needed to keep the WebSocket connection alive) before the `ping_timeout` (i.e., `5s`) was reached.

This change seems to fix the large paste bug without the client being disconnected 🙌 . As for the fast typers, I doubt anyone can (comfortably) type at 20 characters per second so no one should even notice this change.

Notes
* One interesting side effect is that the browser seems to rate limit `setInterval` events at one per minute when the browser tab is inactive. So if someone does paste a large amount of text into TinyPilot and continues in another tab, the keystokes only get sent to the backend at 1/min. 
    * To avoid browser rate-limiting, someone suggests using web workers
        * https://stackoverflow.com/a/6032591/3769045
* Testing steps: Paste a large amount of text (>2k characters) onto the target machine via the TinyPilot web-UI:

    1. Install this branch's bundle onto a device
    2. On your machine, copy a large amount of text (pick a chapter from [Moby Dick](https://www.gutenberg.org/files/2701/2701-h/2701-h.htm))
    3. In your browser, navigate to the TinyPilot web-UI
    4. On the target machine, open a text editor
    5. In the TinyPilot Web-UI, click "Actions" > "Paste"
    6. On your keyboard, press `cmd-v` or `ctrl-v`

    All the text should be pasted, uninterrupted (i.e., without the client being disconnected from the server).


<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1601"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>