### PR TITLE
Fix blank popup window bug on Firefox

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -342,7 +342,11 @@ menuBar.addEventListener("dedicated-window-requested", () => {
   window.open(
     "/?viewMode=standalone",
     undefined,
-    `popup=true,width=${width},height=${height}`
+    // We need to add noopener to prevent a bug on Firefox where tearing down
+    // the existing page causes the browser to garbage collect resources that
+    // the popup tries to access.
+    // https://github.com/tiny-pilot/tinypilot/issues/1609
+    `popup=true,noopener,width=${width},height=${height}`
   );
 
   // Redirect the user to a placeholder page. We can’t keep the main window


### PR DESCRIPTION
Resolves #1609

There's a bug that affects (at least) Firefox on Win10 where if the user tries View > Dedicated Window, the window comes up blank and the JS console has errors about "can't access dead object".

The issue seems like a bug in Firefox. What seems to be happening is that the popup is trying to share resources with the main window, but the browser's garbage seems to not be aware of the additional reference. So the popup starts loading, we redirect the original window, which causes the browser to tear down its resources, and then the popup continues loading, but the shared resources it was trying to access have been garbage collected in redirecting the original window.

Adding `noopener` seems to fix the issue, as it prevents the two windows from sharing resources:

>`noopener`
>
>If this feature is set, the new window will not have access to the originating window via Window.opener and returns null.
>
>When `noopener` is used, non-empty target names, other than _top, _self, and _parent, are treated like _blank in terms of deciding whether to open a new browsing context.

https://developer.mozilla.org/en-US/docs/Web/API/Window/open#parameters