### PR TITLE
Update collect-debug-logs script to include userland architecture

### DIFF
--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -71,7 +71,8 @@ cd /opt/tinypilot && \
 
 print_info "Checking uStreamer version..."
 cd /opt/ustreamer && \
-  printf "uStreamer version: %s\n\n" "$(/opt/ustreamer/ustreamer --version)" >> "${LOG_FILE}"
+  printf "uStreamer version: %s\n\n" "$(/opt/ustreamer/ustreamer --version)" \
+    >> "${LOG_FILE}"
 
 echo "System information" >> "${LOG_FILE}"
 
@@ -80,7 +81,7 @@ print_info "Checking system information..."
   printf "OS version: %s\n" "$(uname --all)"
   printf "Kernel architecture: %s\n" "$(uname --machine)"
   printf "Userland architecture: %s (%s)\n" "$(dpkg --print-architecture)" \
-    "$(getconf LONG_BIT)"
+    "$(getconf LONG_BIT)-bit"
   printf "Distribution name: %s\n" "$(lsb_release --id --short)"
   printf "Distribution version: %s\n" "$(lsb_release --release --short)"
   printf "\n"

--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -71,11 +71,16 @@ cd /opt/tinypilot && \
 
 print_info "Checking uStreamer version..."
 cd /opt/ustreamer && \
-  printf "uStreamer version: %s\n" "$(/opt/ustreamer/ustreamer --version)" >> "${LOG_FILE}"
+  printf "uStreamer version: %s\n\n" "$(/opt/ustreamer/ustreamer --version)" >> "${LOG_FILE}"
 
-print_info "Checking OS version..."
+echo "System information" >> "${LOG_FILE}"
+
+print_info "Checking system information..."
 {
   printf "OS version: %s\n" "$(uname --all)"
+  printf "Kernel architecture: %s\n" "$(uname --machine)"
+  printf "Userland architecture: %s (%s)\n" "$(dpkg --print-architecture)" \
+    "$(getconf LONG_BIT)"
   printf "Distribution name: %s\n" "$(lsb_release --id --short)"
   printf "Distribution version: %s\n" "$(lsb_release --release --short)"
   printf "\n"


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot-pro/issues/1030.

Raspberry Pi OS now updates the kernel on 32-bit installations to the 64-bit kernel while simultaneously keeping the userland as 32-bit, which means that it isn't possible to accurately determine if the user is running a 64-bit system based on the output of `uname --all`.

This change adds additional information to the `collect-debug-logs` script, allowing us to detect when a user is running TinyPilot on an unsupported architecture. It also slightly reformats the relevant section for readability.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1611"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>