### PR TITLE
Prevent tinypilot.postinst from appending to Janus config

### DIFF
--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -116,7 +116,7 @@ memsink: {
 }
 EOF
 
-# Append audio settings if the TC358743 is enabled.
+# Append audio settings if TC358743 support is enabled.
 if "${tc358743_overlay_enabled}" ; then
   cat <<EOF >> "${JANUS_PLUGIN_USTREAMER_CONFIG}"
 audio: {

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -110,12 +110,13 @@ fi
 
 # Populate TinyPilot's Janus settings file.
 readonly JANUS_PLUGIN_USTREAMER_CONFIG='/etc/janus/janus.plugin.ustreamer.jcfg'
-cat <<EOF >> "${JANUS_PLUGIN_USTREAMER_CONFIG}"
+cat <<EOF > "${JANUS_PLUGIN_USTREAMER_CONFIG}"
 memsink: {
     object = "tinypilot::ustreamer::h264"
 }
 EOF
 
+# Append audio settings if the TC358743 is enabled.
 if "${tc358743_overlay_enabled}" ; then
   cat <<EOF >> "${JANUS_PLUGIN_USTREAMER_CONFIG}"
 audio: {


### PR DESCRIPTION
There was a bug in the tinypilot.postinst where we were appending to an existing janus.plugin.ustreamer.jcfg file instead of the intended behavior of recreating the file fresh on each install.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1615"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>