### PR TITLE
Proof of concept: Process pasted keystrokes asynchronously in background thread

### DIFF
--- a/app/hid/write.py
+++ b/app/hid/write.py
@@ -13,6 +13,9 @@ class Error(Exception):
 class WriteError(Error):
     pass
 
+class TimeoutError(Error):
+    pass
+
 
 @dataclasses.dataclass
 class ProcessResult:
@@ -60,6 +63,9 @@ class ProcessWithResult(multiprocessing.Process):
 
 
 def _write_to_hid_interface_immediately(hid_path, buffer):
+    # Force timeout.
+    for _ in range(pow(10, 100)):
+        pass
     try:
         with open(hid_path, 'ab+') as hid_handle:
             hid_handle.write(bytearray(buffer))
@@ -70,11 +76,6 @@ def _write_to_hid_interface_immediately(hid_path, buffer):
 
 
 def write_to_hid_interface(hid_path, buffer):
-    # Avoid an unnecessary string formatting call in a write that requires low
-    # latency.
-    if logger.getEffectiveLevel() == logging.DEBUG:
-        logger.debug_sensitive('writing to HID interface %s: %s', hid_path,
-                               ' '.join([f'{x:#04x}' for x in buffer]))
     # Writes can hang, for example, when TinyPilot is attempting to write to the
     # mouse interface, but the target system has no GUI. To avoid locking up the
     # main server process, perform the HID interface I/O in a separate process.
@@ -90,7 +91,7 @@ def write_to_hid_interface(hid_path, buffer):
     result = write_process.result()
     # If the result is None, it means the write failed to complete in time.
     if result is None or not result.was_successful():
-        raise WriteError(f'Failed to write to HID interface: {hid_path}. '
+        raise TimeoutError(f'Failed to write to HID interface: {hid_path}. '
                          'Is USB cable connected?')
 
 

--- a/app/hid/write.py
+++ b/app/hid/write.py
@@ -84,7 +84,7 @@ def write_to_hid_interface(hid_path, buffer):
         args=(hid_path, buffer),
         daemon=True)
     write_process.start()
-    write_process.join(timeout=0.5)
+    write_process.join(timeout=0.1)
     if write_process.is_alive():
         write_process.kill()
         _wait_for_process_exit(write_process)

--- a/app/hid/write.py
+++ b/app/hid/write.py
@@ -2,6 +2,7 @@ import dataclasses
 import logging
 import multiprocessing
 import typing
+import functools
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +63,30 @@ class ProcessWithResult(multiprocessing.Process):
         return self.parent_conn.recv() if self.parent_conn.poll() else None
 
 
-def _write_to_hid_interface_immediately(hid_path, buffer):
+def timeout(function):
+    @functools.wraps(function)
+    def wrapper(*args, **kwargs):
+        # Writes can hang, for example, when TinyPilot is attempting to write to the
+        # mouse interface, but the target system has no GUI. To avoid locking up the
+        # main server process, perform the HID interface I/O in a separate process.
+        write_process = ProcessWithResult(
+            target=function,
+            args=args,
+            kwargs=kwargs,
+            daemon=True)
+        write_process.start()
+        write_process.join(timeout=0.1)
+        if write_process.is_alive():
+            write_process.kill()
+            _wait_for_process_exit(write_process)
+        result = write_process.result()
+        # If the result is None, it means the write failed to complete in time.
+        if result is None or not result.was_successful():
+            raise TimeoutError
+    return wrapper
+
+
+def _write_to_hid_interface(hid_path, buffer):
     # Force timeout.
     for _ in range(pow(10, 100)):
         pass
@@ -74,26 +98,13 @@ def _write_to_hid_interface_immediately(hid_path, buffer):
             'Failed to write to HID interface: %s. Is USB cable connected?',
             hid_path)
 
-
-def write_to_hid_interface(hid_path, buffer):
-    # Writes can hang, for example, when TinyPilot is attempting to write to the
-    # mouse interface, but the target system has no GUI. To avoid locking up the
-    # main server process, perform the HID interface I/O in a separate process.
-    write_process = ProcessWithResult(
-        target=_write_to_hid_interface_immediately,
-        args=(hid_path, buffer),
-        daemon=True)
-    write_process.start()
-    write_process.join(timeout=0.1)
-    if write_process.is_alive():
-        write_process.kill()
-        _wait_for_process_exit(write_process)
-    result = write_process.result()
-    # If the result is None, it means the write failed to complete in time.
-    if result is None or not result.was_successful():
-        raise TimeoutError(f'Failed to write to HID interface: {hid_path}. '
-                         'Is USB cable connected?')
-
+# Workaround to allow decorated functions to be executed in a thread.
+# For example:
+#     @timeout
+#     def write_to_hid_interface(hid_path, buffer):
+#         ...
+# Raises _pickle.PicklingError: Can't pickle
+write_to_hid_interface = timeout(_write_to_hid_interface)
 
 def _wait_for_process_exit(target_process):
     max_attempts = 3

--- a/app/socket_api.py
+++ b/app/socket_api.py
@@ -13,37 +13,51 @@ from request_parsers import mouse_event as mouse_event_request
 
 logger = logging.getLogger(__name__)
 
-socketio = flask_socketio.SocketIO()
+socketio = flask_socketio.SocketIO(logger=True, engineio_logger=True, ping_interval=(1, 5), ping_timeout=30)
 socketio.on_namespace(update_logs.Namespace('/updateLogs'))
 
 
 @socketio.on('keystroke')
 def on_keystroke(message):
-    logger.debug_sensitive('received keystroke message: %s', message)
     try:
         keystroke = keystroke_request.parse_keystroke(message)
     except keystroke_request.Error as e:
-        logger.error_sensitive('Failed to parse keystroke request: %s', e)
         return {'success': False}
     hid_keycode = None
     try:
         control_keys, hid_keycode = js_to_hid.convert(keystroke)
     except js_to_hid.UnrecognizedKeyCodeError:
-        logger.warning_sensitive('Unrecognized key: %s (keycode=%s)',
-                                 keystroke.key, keystroke.code)
         return {'success': False}
     if hid_keycode is None:
-        logger.info_sensitive('Ignoring %s key (keycode=%s)', keystroke.key,
-                              keystroke.code)
         return {'success': False}
     keyboard_path = flask.current_app.config.get('KEYBOARD_PATH')
     try:
         fake_keyboard.send_keystroke(keyboard_path, control_keys, hid_keycode)
     except hid_write.WriteError as e:
-        logger.error_sensitive('Failed to write key: %s (keycode=%s). %s',
-                               keystroke.key, keystroke.code, e)
         return {'success': False}
+    except hid_write.TimeoutError as e:
+        return {'success': False, "timeout": True}
     return {'success': True}
+
+
+from api import api_blueprint
+from flask import request
+import json_response
+import time
+@api_blueprint.route('/keystrokes', methods=['POST'])
+def paste_post():
+    keystrokes = request.json["keystrokes"]
+    print("Received", len(keystrokes), "keystrokes")
+    def process_keystrokes(keystrokes, app):
+        with app.app_context():
+            for i, keystroke in enumerate(keystrokes):
+                tick = time.time()
+                result = on_keystroke(keystroke)
+                tock = time.time()
+                print("Keystoke", i, "timed-out" if "timeout" in result else "done", "after", tock-tick, "seconds")
+                socketio.sleep()
+    socketio.start_background_task(process_keystrokes, keystrokes, flask.current_app._get_current_object())
+    return json_response.success()
 
 
 @socketio.on('mouse-event')
@@ -51,7 +65,6 @@ def on_mouse_event(message):
     try:
         mouse_move_event = mouse_event_request.parse_mouse_event(message)
     except mouse_event_request.Error as e:
-        logger.error_sensitive('Failed to parse mouse event request: %s', e)
         return {'success': False}
     mouse_path = flask.current_app.config.get('MOUSE_PATH')
     try:
@@ -61,7 +74,6 @@ def on_mouse_event(message):
                                     mouse_move_event.vertical_wheel_delta,
                                     mouse_move_event.horizontal_wheel_delta)
     except hid_write.WriteError as e:
-        logger.error_sensitive('Failed to forward mouse event: %s', e)
         return {'success': False}
     return {'success': True}
 

--- a/app/static/js/controllers.js
+++ b/app/static/js/controllers.js
@@ -323,3 +323,17 @@ export async function isMjpegStreamAvailable() {
     .then((response) => response.ok)
     .catch(() => false);
 }
+
+export async function sendKeystrokes(keystrokes) {
+  return fetch("/api/keystrokes", {
+    method: "POST",
+    mode: "same-origin",
+    cache: "no-cache",
+    redirect: "error",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRFToken": getCsrfToken(),
+    },
+    body: JSON.stringify({keystrokes}),
+  }).then(processJsonResponse);
+}


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot/issues/1026

This (dirty) PR demonstrates the following:
1. Processing a large amount of keystrokes in a green thread:
https://github.com/tiny-pilot/tinypilot/blob/f6b71015b1642855db946218a56fd1308916343b/app/socket_api.py#L59
3. Maintaining the order of keystrokes as they are written:
https://github.com/tiny-pilot/tinypilot/blob/f6b71015b1642855db946218a56fd1308916343b/app/socket_api.py#L51-L58
5. Limiting the execution time of each keystroke written by using processes:
https://github.com/tiny-pilot/tinypilot/blob/f6b71015b1642855db946218a56fd1308916343b/app/hid/write.py#L87

This PR was trigger by the [following comment](https://github.com/tiny-pilot/tinysocket/pull/5#issuecomment-1705497417):
> It seems like even if the work is happening in start_background_task, it still locks up the main Flask thread.
>
> It's possible that we could solve this if we use our home-rolled replacement for eventlet.Timeout using multiprocess.Process (like we already do in hid/write.py).

Demo:

https://github.com/tiny-pilot/tinypilot/assets/6730025/c7be4c57-a1f8-4a54-9f35-110c238eb9cc

The demo video shows the following:
1. With our `ping_interval` set to 1 second, the PING/PONG messages do still drift slightly beyond 1 second. This might be due to the overhead of starting and stopping processes.
2. In the terminal, we can see that the execution time of each process is constantly being limited to 0.1s even when the process is performing heavy processing:
https://github.com/tiny-pilot/tinypilot/blob/f6b71015b1642855db946218a56fd1308916343b/app/hid/write.py#L65-L68

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1618"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>