### PR TITLE
Maintain h.264 video stream when target machine is switched off

### DIFF
--- a/app/static/js/webrtc-video.js
+++ b/app/static/js/webrtc-video.js
@@ -181,9 +181,7 @@ function attachToJanusPlugin() {
 
       if (added) {
         await remoteScreen.addWebrtcStreamTrack(track);
-        if (!remoteScreen.webrtcEnabled) {
-          await remoteScreen.enableWebrtc();
-        }
+        await remoteScreen.enableWebrtc();
       } else {
         await remoteScreen.removeWebrtcStreamTrack(track);
       }

--- a/app/static/js/webrtc-video.js
+++ b/app/static/js/webrtc-video.js
@@ -174,15 +174,18 @@ function attachToJanusPlugin() {
      * @param {string} mid - The Media-ID.
      * @param {boolean} added - Whether the track was added or removed.
      */
-    onremotetrack: function (track, mid, added) {
+    onremotetrack: async function (track, mid, added) {
       console.debug(
         `Remote ${track.kind} track "${mid}" ${added ? "added" : "removed"}.`
       );
 
       if (added) {
-        remoteScreen.enableWebrtcStreamTrack(track);
+        await remoteScreen.addWebrtcStreamTrack(track);
+        if (!remoteScreen.webrtcEnabled) {
+          await remoteScreen.enableWebrtc();
+        }
       } else {
-        remoteScreen.disableWebrtcStreamTrack(track);
+        await remoteScreen.removeWebrtcStreamTrack(track);
       }
     },
   });

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -322,6 +322,25 @@
           }
         }
 
+        async enableWebrtc() {
+          // We optimistically unmute before we start the playback, because we
+          // cannot tell ahead of time whether audio is blocked by the
+          // UserAgent.
+          this.elements.video.muted = false;
+          // It’s important that we hold off on displaying the WebRTC stream
+          // until the video playback has started, to ensure a smooth visual
+          // transition of the remote screen without any flickering or 
+          // interruption.
+          try {
+            await this._playWebrtcVideo();
+          } catch {
+            return;
+          }
+          this.webrtcEnabled = true;
+          this.elements.image.removeAttribute("src");
+          this.dispatchEvent(new VideoStreamingModeChangedEvent("H264"));
+        }
+
         /**
          * Adds a track to the WebRTC media stream. If there any video tracks in
          * the stream, the WebRTC stream is displayed and the MJPEG stream is
@@ -338,7 +357,7 @@
          *
          * @param {MediaStreamTrack} mediaStreamTrack - https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack
          */
-        async enableWebrtcStreamTrack(mediaStreamTrack) {
+        async addWebrtcStreamTrack(mediaStreamTrack) {
           const video = this.elements.video;
           if (!video.srcObject) {
             // Lazy-initialize the media stream. (See comment in
@@ -364,28 +383,6 @@
           // the addTrack method has no effect.
           // https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/addTrack
           stream.addTrack(mediaStreamTrack);
-
-          // We only proceed switching to WebRTC if we have at least a video
-          // track. We don’t want to switch yet if the only thing we have is an
-          // audio track.
-          // It’s also important that we hold off on displaying the WebRTC
-          // stream until the video playback has started, to ensure a smooth
-          // visual transition of the remote screen without any flickering or
-          // interruption.
-          if (mediaStreamTrack.kind === "video") {
-            // We optimistically unmute before we start the playback, because we
-            // cannot tell ahead of time whether audio is blocked by the
-            // UserAgent.
-            video.muted = false;
-            try {
-              await this._playWebrtcVideo();
-            } catch {
-              return;
-            }
-            this.webrtcEnabled = true;
-            this.elements.image.removeAttribute("src");
-            this.dispatchEvent(new VideoStreamingModeChangedEvent("H264"));
-          }
         }
 
         /**
@@ -397,17 +394,13 @@
          *
          * @param {MediaStreamTrack} mediaStreamTrack - https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack
          */
-        disableWebrtcStreamTrack(mediaStreamTrack) {
+        removeWebrtcStreamTrack(mediaStreamTrack) {
           const video = this.elements.video;
           if (!video.srcObject) {
             return;
           }
           const stream = video.srcObject;
           stream.removeTrack(mediaStreamTrack);
-          if (stream.getVideoTracks().length === 0) {
-            video.pause();
-            this.enableMjpeg();
-          }
         }
 
         /**

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -325,6 +325,9 @@
         /**
          * Displays the WebRTC stream while hiding the MJPEG stream.
          *
+         * Enabling WebRTC only succeeds if there is a "video" stream track
+         * available. Otherwise, calling this method is a no-op.
+         * 
          * Autoplay of WebRTC media tracks might be restricted by the UserAgent,
          * either through explicit user settings, or due to automatic detection
          * mechanisms, such as whether the user had interacted with the website

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -325,18 +325,29 @@
         /**
          * Displays the WebRTC stream while hiding the MJPEG stream.
          *
-         * Autoplay of the WebRTC stream might be restricted by the UserAgent,
+         * Autoplay of WebRTC media tracks might be restricted by the UserAgent,
          * either through explicit user settings, or due to automatic detection
          * mechanisms, such as whether the user had interacted with the website
          * prior to the playback (i.e., by clicking somewhere). Our strategy is:
-         * - If the audio is blocked, then we will display video, and try to
+         * - If both video and audio are blocked, we stay on MJPEG.
+         * - If only audio is blocked, then we will display video, and try to
          *   unmute the audio track. (Which might not succeed, though.)
          */
         async enableWebrtc() {
+          const video = this.elements.video;
+          const stream = video.srcObject;
+          
+          // We only proceed enabling WebRTC if we have at least one video
+          // track. We don’t want to switch yet if the only thing we have is an
+          // audio track.
+          if (stream !== null && stream.getVideoTracks().length > 0) {
+            return;
+          }
+
           // We optimistically unmute before we start the playback, because we
           // cannot tell ahead of time whether audio is blocked by the
           // UserAgent.
-          this.elements.video.muted = false;
+          video.muted = false;
           // It’s important that we hold off on displaying the WebRTC stream
           // until the video playback has started, to ensure a smooth visual
           // transition of the remote screen without any flickering or

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -327,7 +327,7 @@
          *
          * Enabling WebRTC only succeeds if there is a "video" stream track
          * available. Otherwise, calling this method is a no-op.
-         * 
+         *
          * Autoplay of WebRTC media tracks might be restricted by the UserAgent,
          * either through explicit user settings, or due to automatic detection
          * mechanisms, such as whether the user had interacted with the website

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -343,7 +343,7 @@
           // track. We don’t want to switch yet if the only thing we have is an
           // audio track.
           const stream = video.srcObject;
-          if (stream.getVideoTracks().length > 0) {
+          if (stream.getVideoTracks().length === 0) {
             return;
           }
 

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -322,6 +322,16 @@
           }
         }
 
+        /**
+         * Displays the WebRTC stream while hiding the MJPEG stream.
+         *
+         * Autoplay of the WebRTC stream might be restricted by the UserAgent,
+         * either through explicit user settings, or due to automatic detection
+         * mechanisms, such as whether the user had interacted with the website
+         * prior to the playback (i.e., by clicking somewhere). Our strategy is:
+         * - If the audio is blocked, then we will display video, and try to
+         *   unmute the audio track. (Which might not succeed, though.)
+         */
         async enableWebrtc() {
           // We optimistically unmute before we start the playback, because we
           // cannot tell ahead of time whether audio is blocked by the
@@ -342,18 +352,7 @@
         }
 
         /**
-         * Adds a track to the WebRTC media stream. If there any video tracks in
-         * the stream, the WebRTC stream is displayed and the MJPEG stream is
-         * hidden. However, if there are only audio tracks in the stream, the
-         * MJPEG stream will continue to be displayed.
-         *
-         * Autoplay of WebRTC media tracks might be restricted by the UserAgent,
-         * either through explicit user settings, or due to automatic detection
-         * mechanisms, such as whether the user had interacted with the website
-         * prior to the playback (i.e., by clicking somewhere). Our strategy is:
-         * - If both video and audio are blocked, we stay on MJPEG.
-         * - If only audio is blocked, then we will display video, and try to
-         *   unmute the audio track. (Which might not succeed, though.)
+         * Adds a track to the WebRTC media stream.
          *
          * @param {MediaStreamTrack} mediaStreamTrack - https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack
          */
@@ -386,11 +385,7 @@
         }
 
         /**
-         * Removes a track from the WebRTC media stream. If there are no more
-         * video tracks in the stream, the MJPEG stream is displayed and the
-         * WebRTC stream is hidden. However, if there are no more audio tracks
-         * in the stream, the WebRTC stream will continue to be displayed
-         * because it's still better than the MJPEG stream.
+         * Removes a track from the WebRTC media stream.
          *
          * @param {MediaStreamTrack} mediaStreamTrack - https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack
          */

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -338,7 +338,7 @@
           if (!video.srcObject) {
             return;
           }
-          
+
           // We only proceed enabling WebRTC if we have at least one video
           // track. We don’t want to switch yet if the only thing we have is an
           // audio track.

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -329,7 +329,7 @@
           this.elements.video.muted = false;
           // It’s important that we hold off on displaying the WebRTC stream
           // until the video playback has started, to ensure a smooth visual
-          // transition of the remote screen without any flickering or 
+          // transition of the remote screen without any flickering or
           // interruption.
           try {
             await this._playWebrtcVideo();

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -335,12 +335,15 @@
          */
         async enableWebrtc() {
           const video = this.elements.video;
-          const stream = video.srcObject;
+          if (!video.srcObject) {
+            return;
+          }
           
           // We only proceed enabling WebRTC if we have at least one video
           // track. We don’t want to switch yet if the only thing we have is an
           // audio track.
-          if (stream !== null && stream.getVideoTracks().length > 0) {
+          const stream = video.srcObject;
+          if (stream.getVideoTracks().length > 0) {
             return;
           }
 


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1487

This PR refactors our remote-screen WebRTC API to allow media tracks to be added/removed without automatically enabling/disabling the WebRTC streaming mode. This gives more responsibility to the (function) caller, but also gives more control in deciding when to change streaming modes.

Demo video:

https://github.com/tiny-pilot/tinypilot/assets/6730025/d891fbcb-1cea-41fe-b775-948b5a9879e6

Notes
1. We've renamed `enableWebrtcStreamTrack` -> `addWebrtcStreamTrack`
    * This method no longer enables WebRTC mode (i.e., shows the video element)
1. We've renamed `disableWebrtcStreamTrack` -> `removeWebrtcStreamTrack`
    * This method no longer disables WebRTC mode (i.e., hides the video element)
1. WebRTC mode can now both be enabled and have zero media tracks
    * This was the cause of the original bug
1. The remote-screen will still failover to MJPEG when the connection to Janus fails, but will not try to reconnect until a full page refresh

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1619"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>