### PR TITLE
Override Janus systemd config

### DIFF
--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -63,6 +63,9 @@ readonly TINYPILOT_VARIANT='community'
 readonly BUNDLE_FILENAME="tinypilot-${TINYPILOT_VARIANT}-${TIMESTAMP}-${TINYPILOT_VERSION}.tgz"
 
 # Download Janus Bullseye Backports Debian package.
+# Note: before bumping the Janus package version, be sure to compare our Janus
+# systemd config file (debian-pkg/usr/share/tinypilot/janus.service) to that of
+# upstream and verify that the diff is the same as before.
 wget \
   --directory-prefix="${BUNDLE_DIR}" \
   http://ftp.us.debian.org/debian/pool/main/j/janus/janus_1.0.1-1~bpo11+1_armhf.deb

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -215,6 +215,11 @@ cp \
   /usr/share/tinypilot/janus.transport.websockets.jcfg \
   /etc/janus/janus.transport.websockets.jcfg
 
+# Override Janus systemd config.
+cp \
+  /usr/share/tinypilot/janus.service \
+  /etc/systemd/system/janus.service
+
 # Restart Janus to pick up the new config files.
 deb-systemd-invoke restart janus
 

--- a/debian-pkg/usr/share/tinypilot/janus.service
+++ b/debian-pkg/usr/share/tinypilot/janus.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Janus WebRTC gateway
+After=network.target
+Documentation=https://janus.conf.meetecho.com/docs/index.html
+# Give up if we restart on failure 20 times within 5 minutes (300 seconds).
+StartLimitIntervalSec=300
+StartLimitBurst=20
+
+[Service]
+Type=forking
+ExecStart=/usr/bin/janus --disable-colors --daemon --log-stdout
+Restart=on-failure
+RestartSec=1
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1578

This PR overrides the default Janus systemd config in order set additional systemd settings. Specifically:
```diff
 [Unit]
 Description=Janus WebRTC gateway
 After=network.target
 Documentation=https://janus.conf.meetecho.com/docs/index.html
+# Give up if we restart on failure 20 times within 5 minutes (300 seconds).
+StartLimitIntervalSec=300
+StartLimitBurst=20

 [Service]
 Type=forking
 ExecStart=/usr/bin/janus --disable-colors --daemon --log-stdout
 Restart=on-failure
+RestartSec=1
 LimitNOFILE=65536

 [Install]
 WantedBy=multi-user.target
```

Janus with STUN requires the network to be online, otherwise `janus` fails to start. Theses additional settings are needed to allow Janus with STUN settings a better chance of starting up successfully, by giving it more chances to restart on failure. Seeing as STUN is an optional setting, we didn't want Janus to always require an online network because it might unnecessarily delay TinyPilot's H.264 video stream.

### Testing

To enable STUN, append the following block to `/etc/janus/janus.jcfg`:

```
nat: {
  stun_server = "stun.gmx.de"
  stun_port = 3478
}
```

Now if you restart your device, the `janus` service should start successfully on boot. On my device `janus` restarted 8 times in 12 seconds before successfully running.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1622"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>