### PR TITLE
Update apt package lists before install

### DIFF
--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -50,6 +50,7 @@ readonly USTREAMER_DEBIAN_PACKAGE
 TINYPILOT_DEBIAN_PACKAGE="$(ls tinypilot*.deb)"
 readonly TINYPILOT_DEBIAN_PACKAGE
 
+apt-get update
 apt-get install -y \
   "./${JANUS_DEBIAN_PACKAGE}" \
   "./${USTREAMER_DEBIAN_PACKAGE}" \


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot-pro/issues/1074

This PR runs `apt-get update` before installing our Debian packages to ensure that the APT package index is up-to-date.

I have tested this fix in TinyPilot Pro:
* https://github.com/tiny-pilot/tinypilot-pro/pull/1075

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1623"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>