### PR TITLE
Log message when update is complete

### DIFF
--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -245,6 +245,8 @@
           return shutdown(/*restart=*/ true)
             .then(() => {
               this._state = this.states.RESTARTING;
+              this.elements.updateLogs.textContent +=
+                "Restarting to complete update...\n";
             })
             .catch((error) => {
               this.dispatchEvent(
@@ -265,6 +267,8 @@
           })
             .then(() => {
               this._state = this.states.UPDATE_FINISHED;
+              this.elements.updateLogs.textContent +=
+                "Update is now complete.\n";
             })
             .catch((error) => {
               this.dispatchEvent(
@@ -325,8 +329,6 @@
 
           try {
             await this._waitForUpdateToFinish();
-            this.elements.updateLogs.textContent +=
-              "Restarting to complete update...\n";
             await this._performRestart();
             // Wait at least 10 seconds to ensure reboot has started before
             // checking whether the system is back up.
@@ -346,7 +348,6 @@
             return;
           }
           updateLogsStreamer.stop();
-          this.elements.updateLogs.textContent += "Update is now complete.\n";
         }
       }
     );

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -325,6 +325,7 @@
 
           try {
             await this._waitForUpdateToFinish();
+            this.elements.updateLogs.textContent += "Restarting to complete update...\n";
             await this._performRestart();
             // Wait at least 10 seconds to ensure reboot has started before
             // checking whether the system is back up.
@@ -344,6 +345,7 @@
             return;
           }
           updateLogsStreamer.stop();
+          this.elements.updateLogs.textContent += "Update is now complete.\n";
         }
       }
     );

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -325,7 +325,8 @@
 
           try {
             await this._waitForUpdateToFinish();
-            this.elements.updateLogs.textContent += "Restarting to complete update...\n";
+            this.elements.updateLogs.textContent +=
+              "Restarting to complete update...\n";
             await this._performRestart();
             // Wait at least 10 seconds to ensure reboot has started before
             // checking whether the system is back up.


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1466

When updating TinyPilot via the web UI, if you're watching the detailed update logs it's easy to miss when the update has actually completed.

This PR adds the following messages to the update-dialog's update logs:
> Restarting to complete update...
> Update is now complete.

Demo video:

https://github.com/tiny-pilot/tinypilot/assets/6730025/378c0a23-f02e-4bae-a2d7-1113a12891c1

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1627"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>