### PR TITLE
Enforce consistent string quoting rules

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -11,6 +11,10 @@ jobs=0
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
 
+string-quote=single
+triple-quote=double
+docstring-quote=double
+
 [MESSAGES CONTROL]
 
 # Disable the message, report, category or checker with the given id(s). You

--- a/.pylintrc
+++ b/.pylintrc
@@ -11,6 +11,7 @@ jobs=0
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
 
+# Enforce consistent string quoting rules with the pylint-quotes plugin.
 string-quote=single
 triple-quote=double
 docstring-quote=double

--- a/app/request_parsers/errors.py
+++ b/app/request_parsers/errors.py
@@ -11,7 +11,7 @@ class MissingFieldError(Error):
 
 
 class InvalidHostnameError(Error):
-    code = "INVALID_HOSTNAME"
+    code = 'INVALID_HOSTNAME'
 
 
 class InvalidVideoSettingError(Error):

--- a/app/update/settings.py
+++ b/app/update/settings.py
@@ -34,7 +34,7 @@ _SETTINGS_FILE_PATH = env.abs_path_in_home_dir('settings.yml')
 #  2. Save the EDID to set correct bytes in the "Display Range Limits" block
 #  3. Re-open the EDID in "AW EDID Editor v.02.00.13" and re-set
 #     the screen size dimensions to 0 (both vertical and horizontal)
-_DEFAULT_TC358743_EDID = '''
+_DEFAULT_TC358743_EDID = """
 00ffffffffffff005262769800888888
 2d1e0103800000781aee91a3544c9926
 0f50547fef8081c08140810081809500
@@ -51,7 +51,7 @@ a9c081406140271f80f07138164038c0
 00000000000000000000000000000000
 00000000000000000000000000000000
 0000000000000000000000000000008e
-'''.strip()
+""".strip()
 
 # Define default values for user-configurable TinyPilot settings. The YAML data
 # in _SETTINGS_FILE_PATH take precedence over these defaults.

--- a/app/update_logs_test.py
+++ b/app/update_logs_test.py
@@ -7,24 +7,24 @@ class UpdateLogsTest(unittest.TestCase):
 
     def test_get_new_logs_with_more_next_logs(self):
         self.assertEqual(
-            "56789",
-            update_logs.get_new_logs(prev_logs="01234", next_logs="0123456789"))
+            '56789',
+            update_logs.get_new_logs(prev_logs='01234', next_logs='0123456789'))
 
     def test_get_new_logs_with_more_prev_logs(self):
         self.assertEqual(
-            "",
-            update_logs.get_new_logs(prev_logs="0123456789", next_logs="01234"))
+            '',
+            update_logs.get_new_logs(prev_logs='0123456789', next_logs='01234'))
 
     def test_get_new_logs_with_no_common_logs(self):
         self.assertEqual(
-            "56789",
-            update_logs.get_new_logs(prev_logs="01234", next_logs="56789"))
+            '56789',
+            update_logs.get_new_logs(prev_logs='01234', next_logs='56789'))
 
     def test_get_new_logs_with_no_prev_logs(self):
         self.assertEqual(
-            "0123456789",
-            update_logs.get_new_logs(prev_logs="", next_logs="0123456789"))
+            '0123456789',
+            update_logs.get_new_logs(prev_logs='', next_logs='0123456789'))
 
     def test_get_new_logs_with_no_next_logs(self):
         self.assertEqual(
-            "", update_logs.get_new_logs(prev_logs="01234", next_logs=""))
+            '', update_logs.get_new_logs(prev_logs='01234', next_logs=''))

--- a/dev-scripts/build-python
+++ b/dev-scripts/build-python
@@ -55,4 +55,7 @@ isort \
 pyflakes "${SOURCE_DIR}/" "${ADDITIONAL_PY_SCRIPTS[@]}"
 
 # Check for other style violations.
-PYTHONPATH="${SOURCE_DIR}" pylint "${SOURCE_DIR}" "${ADDITIONAL_PY_SCRIPTS[@]}"
+PYTHONPATH="${SOURCE_DIR}" \
+  pylint \
+  --load-plugins pylint_quotes \
+  "${SOURCE_DIR}" "${ADDITIONAL_PY_SCRIPTS[@]}"

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,5 +2,6 @@ coverage==7.2.7
 isort[requirements]==4.3.21
 pyflakes==3.0.1
 pylint==2.14.2
+pylint-quotes==0.2.3
 sqlfluff==1.3.2
 yapf==0.40.1


### PR DESCRIPTION
Add the pylint-quotes pylint plugin to the build to ensure we use consistent string quoting conventions throughout our Python code.

We had a few stray instances of inconsistent strings, so I fixed them in this change as well.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1628"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>