### PR TITLE
Add HID Keystroke class

### DIFF
--- a/app/hid/keyboard.py
+++ b/app/hid/keyboard.py
@@ -1,10 +1,10 @@
 from hid import write as hid_write
 
 
-def send_keystroke(keyboard_path, control_keys, hid_keycode):
+def send_keystroke(keyboard_path, keystroke):
     buf = [0] * 8
-    buf[0] = control_keys
-    buf[2] = hid_keycode
+    buf[0] = keystroke.modifier
+    buf[2] = keystroke.keycode
     hid_write.write_to_hid_interface(keyboard_path, buf)
 
     # If it's a normal keycode (i.e. not a standalone modifier key), add a
@@ -14,7 +14,7 @@ def send_keystroke(keyboard_path, control_keys, hid_keycode):
     # events. However, auto-releasing has the disadvantage of preventing
     # genuinely long key presses (see
     # https://github.com/tiny-pilot/tinypilot/issues/1093).
-    if hid_keycode:
+    if keystroke.keycode:
         release_keys(keyboard_path)
 
 

--- a/app/hid/keyboard_test.py
+++ b/app/hid/keyboard_test.py
@@ -2,7 +2,7 @@ import tempfile
 import unittest
 
 from hid import keyboard
-from hid import keycodes
+from hid import keycodes as hid
 
 
 class KeyboardTest(unittest.TestCase):
@@ -11,8 +11,7 @@ class KeyboardTest(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as input_file:
             keyboard.send_keystroke(
                 keyboard_path=input_file.name,
-                control_keys=keycodes.KEYCODE_NONE,
-                hid_keycode=keycodes.KEYCODE_A,
+                keystroke=hid.Keystroke(keycode=hid.KEYCODE_A),
             )
             input_file.seek(0)
             # Press the key then release the key.
@@ -24,8 +23,8 @@ class KeyboardTest(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as input_file:
             keyboard.send_keystroke(
                 keyboard_path=input_file.name,
-                control_keys=keycodes.MODIFIER_LEFT_SHIFT,
-                hid_keycode=keycodes.KEYCODE_NONE,
+                keystroke=hid.Keystroke(keycode=hid.KEYCODE_NONE,
+                                        modifier=hid.MODIFIER_LEFT_SHIFT),
             )
             input_file.seek(0)
             # Press the key, but do not release the key. This is to allow for
@@ -37,8 +36,8 @@ class KeyboardTest(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as input_file:
             keyboard.send_keystroke(
                 keyboard_path=input_file.name,
-                control_keys=keycodes.MODIFIER_LEFT_SHIFT,
-                hid_keycode=keycodes.KEYCODE_A,
+                keystroke=hid.Keystroke(keycode=hid.KEYCODE_A,
+                                        modifier=hid.MODIFIER_LEFT_SHIFT),
             )
             input_file.seek(0)
             # Press the key then release the key.

--- a/app/hid/keycodes.py
+++ b/app/hid/keycodes.py
@@ -1,3 +1,5 @@
+import dataclasses
+
 # USB Usage ID values for the keycodes that TinyPilot can emit to the target
 # computer through the USB keyboard interface.
 #
@@ -141,3 +143,9 @@ KEYCODE_RIGHT_ALT = 0xe6
 KEYCODE_RIGHT_META = 0xe7
 KEYCODE_MEDIA_PLAY_PAUSE = 0xe8
 KEYCODE_REFRESH = 0xfa
+
+
+@dataclasses.dataclass
+class Keystroke:
+    keycode: int
+    modifier: int = KEYCODE_NONE

--- a/app/js_to_hid.py
+++ b/app/js_to_hid.py
@@ -152,12 +152,12 @@ def convert(keystroke):
         keystroke: A JavaScript-esque Keystroke object, as defined in
             `app/request_parsers/keystroke.py`
 
+    Returns:
+        A HID Keystroke object.
+
     Raises:
         UnrecognizedKeyCodeError: If the JavaScript-esque Keystroke's keycode is
             unrecognized.
-
-    Returns:
-        A HID Keystroke object.
     """
     return hid.Keystroke(keycode=_map_keycode(keystroke),
                          modifier=_map_modifier_keys(keystroke))

--- a/app/js_to_hid.py
+++ b/app/js_to_hid.py
@@ -146,7 +146,8 @@ _MAPPING = {
 
 
 def convert(keystroke):
-    return _map_modifier_keys(keystroke), _map_keycode(keystroke)
+    return hid.Keystroke(keycode=_map_keycode(keystroke),
+                         modifier=_map_modifier_keys(keystroke))
 
 
 def _map_modifier_keys(keystroke):

--- a/app/js_to_hid.py
+++ b/app/js_to_hid.py
@@ -146,6 +146,19 @@ _MAPPING = {
 
 
 def convert(keystroke):
+    """Converts a JavaScript-esque Keystroke object into a HID Keystroke object.
+
+    Args:
+        keystroke: A JavaScript-esque Keystroke object, as defined in
+            `app/request_parsers/keystroke.py`
+
+    Raises:
+        UnrecognizedKeyCodeError: If the JavaScript-esque Keystroke's keycode is
+            unrecognized.
+
+    Returns:
+        A HID Keystroke object.
+    """
     return hid.Keystroke(keycode=_map_keycode(keystroke),
                          modifier=_map_modifier_keys(keystroke))
 

--- a/app/js_to_hid_test.py
+++ b/app/js_to_hid_test.py
@@ -8,7 +8,7 @@ from request_parsers import keystroke
 class ConvertJsToHIDTest(unittest.TestCase):
 
     def test_converts_simple_keystroke(self):
-        modifier_bitmask, hid_keycode = js_to_hid.convert(
+        hid_keystroke = js_to_hid.convert(
             keystroke.Keystroke(left_meta_modifier=False,
                                 right_meta_modifier=False,
                                 left_alt_modifier=False,
@@ -19,11 +19,10 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 right_ctrl_modifier=False,
                                 key='a',
                                 code='KeyA'))
-        self.assertEqual(0, modifier_bitmask)
-        self.assertEqual(hid.KEYCODE_A, hid_keycode)
+        self.assertEqual(hid.Keystroke(keycode=hid.KEYCODE_A), hid_keystroke)
 
     def test_converts_shifted_keystroke(self):
-        modifier_bitmask, hid_keycode = js_to_hid.convert(
+        hid_keystroke = js_to_hid.convert(
             keystroke.Keystroke(left_meta_modifier=False,
                                 right_meta_modifier=False,
                                 left_alt_modifier=False,
@@ -34,11 +33,12 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 right_ctrl_modifier=False,
                                 key='A',
                                 code='KeyA'))
-        self.assertEqual(hid.MODIFIER_LEFT_SHIFT, modifier_bitmask)
-        self.assertEqual(hid.KEYCODE_A, hid_keycode)
+        self.assertEqual(
+            hid.Keystroke(keycode=hid.KEYCODE_A,
+                          modifier=hid.MODIFIER_LEFT_SHIFT), hid_keystroke)
 
     def test_converts_keystroke_with_all_modifiers_pressed(self):
-        modifier_bitmask, hid_keycode = js_to_hid.convert(
+        hid_keystroke = js_to_hid.convert(
             keystroke.Keystroke(left_meta_modifier=True,
                                 right_meta_modifier=True,
                                 left_alt_modifier=True,
@@ -50,14 +50,16 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 key='A',
                                 code='KeyA'))
         self.assertEqual(
-            hid.MODIFIER_LEFT_META | hid.MODIFIER_RIGHT_META |
-            hid.MODIFIER_LEFT_ALT | hid.MODIFIER_RIGHT_ALT |
-            hid.MODIFIER_LEFT_SHIFT | hid.MODIFIER_RIGHT_SHIFT |
-            hid.MODIFIER_LEFT_CTRL | hid.MODIFIER_RIGHT_CTRL, modifier_bitmask)
-        self.assertEqual(hid.KEYCODE_A, hid_keycode)
+            hid.Keystroke(
+                keycode=hid.KEYCODE_A,
+                modifier=(hid.MODIFIER_LEFT_META | hid.MODIFIER_RIGHT_META |
+                          hid.MODIFIER_LEFT_ALT | hid.MODIFIER_RIGHT_ALT |
+                          hid.MODIFIER_LEFT_SHIFT | hid.MODIFIER_RIGHT_SHIFT |
+                          hid.MODIFIER_LEFT_CTRL | hid.MODIFIER_RIGHT_CTRL)),
+            hid_keystroke)
 
     def test_converts_left_ctrl_keystroke(self):
-        modifier_bitmask, hid_keycode = js_to_hid.convert(
+        hid_keystroke = js_to_hid.convert(
             keystroke.Keystroke(left_meta_modifier=False,
                                 right_meta_modifier=False,
                                 left_alt_modifier=False,
@@ -68,11 +70,12 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 right_ctrl_modifier=False,
                                 key='Control',
                                 code='ControlLeft'))
-        self.assertEqual(hid.MODIFIER_LEFT_CTRL, modifier_bitmask)
-        self.assertEqual(hid.KEYCODE_NONE, hid_keycode)
+        self.assertEqual(
+            hid.Keystroke(keycode=hid.KEYCODE_NONE,
+                          modifier=hid.MODIFIER_LEFT_CTRL), hid_keystroke)
 
     def test_converts_right_ctrl_keystroke(self):
-        modifier_bitmask, hid_keycode = js_to_hid.convert(
+        hid_keystroke = js_to_hid.convert(
             keystroke.Keystroke(left_meta_modifier=False,
                                 right_meta_modifier=False,
                                 left_alt_modifier=False,
@@ -83,11 +86,12 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 right_ctrl_modifier=True,
                                 key='Control',
                                 code='ControlRight'))
-        self.assertEqual(hid.MODIFIER_RIGHT_CTRL, modifier_bitmask)
-        self.assertEqual(hid.KEYCODE_NONE, hid_keycode)
+        self.assertEqual(
+            hid.Keystroke(keycode=hid.KEYCODE_NONE,
+                          modifier=hid.MODIFIER_RIGHT_CTRL), hid_keystroke)
 
     def test_converts_left_ctrl_with_shift_left_keystroke(self):
-        modifier_bitmask, hid_keycode = js_to_hid.convert(
+        hid_keystroke = js_to_hid.convert(
             keystroke.Keystroke(left_meta_modifier=False,
                                 right_meta_modifier=False,
                                 left_alt_modifier=False,
@@ -98,9 +102,10 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 right_ctrl_modifier=False,
                                 key='Control',
                                 code='ControlLeft'))
-        self.assertEqual(hid.MODIFIER_LEFT_CTRL | hid.MODIFIER_LEFT_SHIFT,
-                         modifier_bitmask)
-        self.assertEqual(hid.KEYCODE_LEFT_CTRL, hid_keycode)
+        self.assertEqual(
+            hid.Keystroke(keycode=hid.KEYCODE_LEFT_CTRL,
+                          modifier=(hid.MODIFIER_LEFT_CTRL |
+                                    hid.MODIFIER_LEFT_SHIFT)), hid_keystroke)
 
     def test_raises_exception_on_unrecognized_code(self):
         with self.assertRaises(js_to_hid.UnrecognizedKeyCodeError):

--- a/app/socket_api.py
+++ b/app/socket_api.py
@@ -25,20 +25,19 @@ def on_keystroke(message):
     except keystroke_request.Error as e:
         logger.error_sensitive('Failed to parse keystroke request: %s', e)
         return {'success': False}
-    hid_keycode = None
     try:
-        control_keys, hid_keycode = js_to_hid.convert(keystroke)
+        hid_keystroke = js_to_hid.convert(keystroke)
     except js_to_hid.UnrecognizedKeyCodeError:
         logger.warning_sensitive('Unrecognized key: %s (keycode=%s)',
                                  keystroke.key, keystroke.code)
         return {'success': False}
-    if hid_keycode is None:
+    if hid_keystroke is None:
         logger.info_sensitive('Ignoring %s key (keycode=%s)', keystroke.key,
                               keystroke.code)
         return {'success': False}
     keyboard_path = flask.current_app.config.get('KEYBOARD_PATH')
     try:
-        fake_keyboard.send_keystroke(keyboard_path, control_keys, hid_keycode)
+        fake_keyboard.send_keystroke(keyboard_path, hid_keystroke)
     except hid_write.WriteError as e:
         logger.error_sensitive('Failed to write key: %s (keycode=%s). %s',
                                keystroke.key, keystroke.code, e)

--- a/app/socket_api.py
+++ b/app/socket_api.py
@@ -31,10 +31,6 @@ def on_keystroke(message):
         logger.warning_sensitive('Unrecognized key: %s (keycode=%s)',
                                  keystroke.key, keystroke.code)
         return {'success': False}
-    if hid_keystroke is None:
-        logger.info_sensitive('Ignoring %s key (keycode=%s)', keystroke.key,
-                              keystroke.code)
-        return {'success': False}
     keyboard_path = flask.current_app.config.get('KEYBOARD_PATH')
     try:
         fake_keyboard.send_keystroke(keyboard_path, hid_keystroke)


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot/issues/1026

This PR introduces the HID `Keystroke` class that represents a combination of HID keycode and HID modifier. This PR replaces the use of individual `keycode` and `modifier`/`control_keys` variables with a single `keystroke` variable.

This is a non-functional change that simplifies the way we represent HID Keystrokes in anticipation for parsing text to HID keystrokes via https://github.com/tiny-pilot/tinypilot/pull/1624

### Notes:
1. In https://github.com/tiny-pilot/tinypilot/pull/1625, we parse `text` + `language` directly to HID keystrokes in a [`request_parser`](https://github.com/tiny-pilot/tinypilot/blob/df246c830564eb164b9206d9ea9b0cfc6ae4e248/app/request_parsers/paste.py#L6-L44). Ideally, I'd like to do the same when [parsing JS keystroke WebSocket messages](https://github.com/tiny-pilot/tinypilot/blob/60fe150efe22bc5dfd6c328c841d109288a72274/app/request_parsers/keystroke.py#L40-L58) which are [polluting `socket_api.py` with JS-to-HID conversion logic](https://github.com/tiny-pilot/tinypilot/blob/60fe150efe22bc5dfd6c328c841d109288a72274/app/socket_api.py#L23-L33). This kind of change would cause some churn, so I did not implement that here.
2. I removed a piece of dead-code. From what I understand, this `if` statement can never be truthy.
    https://github.com/tiny-pilot/tinypilot/blob/c972446e5301b0720d518dd76963fc94ec1f00f8/app/socket_api.py#L35-L38

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1629"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>