### PR TITLE
Bring back --allow-releaseinfo-change-suite

### DIFF
--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -50,7 +50,10 @@ readonly USTREAMER_DEBIAN_PACKAGE
 TINYPILOT_DEBIAN_PACKAGE="$(ls tinypilot*.deb)"
 readonly TINYPILOT_DEBIAN_PACKAGE
 
-apt-get update
+# Update apt packages, allowing the apt repos to change suite name.
+# See https://github.com/tiny-pilot/tinypilot/issues/764
+apt-get update --allow-releaseinfo-change-suite
+
 apt-get install -y \
   "./${JANUS_DEBIAN_PACKAGE}" \
   "./${USTREAMER_DEBIAN_PACKAGE}" \

--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -50,7 +50,7 @@ readonly USTREAMER_DEBIAN_PACKAGE
 TINYPILOT_DEBIAN_PACKAGE="$(ls tinypilot*.deb)"
 readonly TINYPILOT_DEBIAN_PACKAGE
 
-# Update apt packages, allowing the apt repos to change suite name.
+# Update apt package index files, allowing the apt repos to change suite name.
 # See https://github.com/tiny-pilot/tinypilot/issues/764
 apt-get update --allow-releaseinfo-change-suite
 


### PR DESCRIPTION
In #776, we added the `--allow-releaseinfo-change-suite` to avoid erroring out if the Raspbian apt repo changed suite names.

In #1604, we deleted the `apt update` command entirely, as it seemed unnecessary after deleting Ansible.

In #1623, we brought back the `apt update` command, but we left off the  flag we were previously using.

In recent installs, I'm seeing this warning:

```bash
4 packages can be upgraded. Run 'apt list --upgradable' to see them.
N: Repository 'http://raspbian.raspberrypi.org/raspbian bullseye InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
Reading package lists... Done
```

For the sake of preserving longstanging behavior, I think we should bring back the `--allow-releaseinfo-change-suite` flag.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1630"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>