### PR TITLE
Replace pyflakes with ruff

### DIFF
--- a/app/update/status_test.py
+++ b/app/update/status_test.py
@@ -30,7 +30,7 @@ root        51  0.0  0.0 103152 21264 ?        Ss   Apr03   0:00 /lib/dummy-b
 USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
 root         1  0.0  0.0 224928  8612 ?        Ss   Apr03   0:01 /sbin/dummy-a
 root        51  0.0  0.0 103152 21264 ?        Ss   Apr03   0:00 /opt/tinypilot-privileged/scripts/update
-""".lstrip().encode('utf-8')
+""".lstrip().encode('utf-8')  # noqa: E501
         mock_read_update_result.return_value = None
 
         status_actual, error_actual = update.status.get()
@@ -47,7 +47,7 @@ root        51  0.0  0.0 103152 21264 ?        Ss   Apr03   0:00 /opt/tinypilot-
 USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
 root         1  0.0  0.0 224928  8612 ?        Ss   Apr03   0:01 /sbin/dummy-a
 root        51  0.0  0.0 103152 21264 ?        Ss   Apr03   0:00 /opt/tinypilot-privileged/scripts/update
-""".lstrip().encode('utf-8')
+""".lstrip().encode('utf-8')  # noqa: E501
         # get should ignore this result because an update process
         # is currently running, which takes priority over the previous result.
         mock_read_update_result.return_value = update.result.Result(

--- a/dev-scripts/build-python
+++ b/dev-scripts/build-python
@@ -52,7 +52,9 @@ isort \
   --skip-glob=venv/*
 
 # Run static analysis for Python bugs/cruft.
-pyflakes "${SOURCE_DIR}/" "${ADDITIONAL_PY_SCRIPTS[@]}"
+ruff check \
+  "${SOURCE_DIR}/" \
+  "${ADDITIONAL_PY_SCRIPTS[@]}"
 
 # Check for other style violations.
 PYTHONPATH="${SOURCE_DIR}" \

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,6 @@
 coverage==7.2.7
 isort[requirements]==4.3.21
-pyflakes==3.0.1
+ruff==0.0.290
 pylint==2.14.2
 pylint-quotes==0.2.3
 sqlfluff==1.3.2


### PR DESCRIPTION
ruff applies the same checks as pyflakes, but it has additional customizations and supports a wider range of rules.

For now, we're just replacing pyflakes, which doesn't give us much of a speedup, but in subsequent changes, we can replace `isort`, which saves us about 2s on every execution of `build-python`.