### PR TITLE
Replace pylint-quotes with ruff

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -11,11 +11,6 @@ jobs=0
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
 
-# Enforce consistent string quoting rules with the pylint-quotes plugin.
-string-quote=single
-triple-quote=double
-docstring-quote=double
-
 [MESSAGES CONTROL]
 
 # Disable the message, report, category or checker with the given id(s). You
@@ -115,7 +110,7 @@ no-docstring-rgx=^test_
 docstring-min-length=60
 
 [STRING]
-check-quote-consistency=yes
+check-quote-consistency=no
 
 [ELIF]
 

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -3,6 +3,7 @@ src = ["app"]
 select = [
   "F", # Enable pyflakes rules.
   "I", # Enable isort rules.
+  "Q", # Enable flake8-quotes rules.
   ]
 ignore = []
 
@@ -14,6 +15,14 @@ exclude = [
 
 # Assume Python 3.9
 target-version = "py39"
+
+[flake8-quotes]
+# Use consistent quotes regardless of whether it allows us to minimize escape
+# sequences.
+avoid-escape = false
+docstring-quotes = "double"
+inline-quotes = "single"
+multiline-quotes = "double"
 
 [isort]
 force-single-line = true

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -20,6 +20,7 @@ target-version = "py39"
 # Use consistent quotes regardless of whether it allows us to minimize escape
 # sequences.
 avoid-escape = false
+
 docstring-quotes = "double"
 inline-quotes = "single"
 multiline-quotes = "double"

--- a/dev-scripts/build-python
+++ b/dev-scripts/build-python
@@ -49,5 +49,4 @@ ruff check \
 # Check for other style violations.
 PYTHONPATH="${SOURCE_DIR}" \
   pylint \
-  --load-plugins pylint_quotes \
   "${SOURCE_DIR}" "${ADDITIONAL_PY_SCRIPTS[@]}"

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,5 @@
 coverage==7.2.7
 pylint==2.14.2
-pylint-quotes==0.2.3
 ruff==0.0.290
 sqlfluff==1.3.2
 yapf==0.40.1


### PR DESCRIPTION
ruff can replicate the same functionality as pylint-quotes but with faster performance and fewer extra tools, so this replaces pylint-quotes with ruff.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1635"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>