### PR TITLE
Delete duplicate playwright npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
         "eslint": "8.44.0",
         "eslint-plugin-html": "7.1.0",
         "mocha": "10.2.0",
-        "playwright": "1.35.1",
         "prettier": "2.8.8"
       }
     },
@@ -1453,22 +1452,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.35.1.tgz",
-      "integrity": "sha512-NbwBeGJLu5m7VGM0+xtlmLAH9VUfWwYOhUi/lSEDyGg46r1CA9RWlvoc5yywxR9AzQb0mOCm7bWtOXV7/w43ZA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "playwright-core": "1.35.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/playwright-core": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "eslint": "8.44.0",
     "eslint-plugin-html": "7.1.0",
     "mocha": "10.2.0",
-    "playwright": "1.35.1",
     "prettier": "2.8.8"
   }
 }


### PR DESCRIPTION
We somehow ended up with two playwright packages, but @playwright/test is the correct one, so we can drop the duplicate.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1636"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>