### PR TITLE
Use a fresh database on each e2e test run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
           command: sudo ./dev-scripts/enable-passwordless-sudo
       - run:
           name: Run playwright tests
-          command: npx playwright test
+          command: ./dev-scripts/run-e2e-tests
       - store_artifacts:
           path: playwright-report
       - store_artifacts:

--- a/dev-scripts/run-e2e-tests
+++ b/dev-scripts/run-e2e-tests
@@ -47,6 +47,12 @@ if [[ $# -gt 0 && "$1" =~ ^http ]]; then
   export E2E_BASE_URL="$1"
   readonly E2E_BASE_URL
   shift
+else
+  # When running against a local dev server, use a fresh home directory on each
+  # test run so that database state in one run doesn't affect subsequent runs.
+  TINYPILOT_HOME_DIR="$(mktemp --directory)"
+  export TINYPILOT_HOME_DIR
+  readonly TINYPILOT_HOME_DIR
 fi
 
 npx playwright test

--- a/dev-scripts/serve-dev
+++ b/dev-scripts/serve-dev
@@ -15,5 +15,5 @@ HOST=0.0.0.0 \
   DEBUG=1 \
   USE_RELOADER=1 \
   APP_SETTINGS_FILE=../dev_app_settings.cfg \
-  TINYPILOT_HOME_DIR="$(realpath ~)" \
+  TINYPILOT_HOME_DIR="${TINYPILOT_HOME_DIR:-$(realpath ~)}" \
   ./app/main.py


### PR DESCRIPTION
Currently, the end-to-end test reuses the dev database in `~/tinypilot.db`. But that means that a DB corruption in one test run will affect subsequent runs, which we don't want.

To fix this, we can adjust the `run-e2e-test` script to use a temporary directory as TinyPilot's home directory for storing the TinyPilot SQLite database.

We also adjust the CI code so that it more closely matches the dev workflow.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1637"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>