### PR TITLE
Update uStreamer package to v5.43

### DIFF
--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -73,7 +73,7 @@ wget \
 # Download uStreamer Debian package.
 wget \
   --directory-prefix="${BUNDLE_DIR}" \
-  https://github.com/tiny-pilot/ustreamer-debian/releases/download/ustreamer_5.38-20230802141939/ustreamer_5.38-20230802141939_armhf.deb
+  https://github.com/tiny-pilot/ustreamer-debian/releases/download/5.43-20231004144402/ustreamer_5.43-20231004144402_armhf.deb
 
 # Download yq binary
 wget \


### PR DESCRIPTION
Note that the change in the URL path outside the version + timestamp is due to a mistake in how we generated the release tag for the previous uStreamer Debian package: 

https://github.com/tiny-pilot/ustreamer-debian/tree/ustreamer_5.38-20230802141939

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1643"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>