### PR TITLE
Improve error messaging when updates fail due to an incorrectly set clock

### DIFF
--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -220,6 +220,23 @@
               }
             })
             .catch((error) => {
+              if (error.code === "CERTIFICATE_NOT_YET_VALID") {
+                this.dispatchEvent(
+                  new DialogFailedEvent({
+                    title: "Unable to Connect to TinyPilot Update Server",
+                    message:
+                      "Your TinyPilot device's date differs signifcantly " +
+                      "from the date on the TinyPilot update server. This " +
+                      "can happen if your TinyPilot device does not have " +
+                      "Internet access or your network blocks access to " +
+                      "time servers (NTP servers).\n\nWait for up to five " +
+                      "minutes to give your TinyPilot device time to " +
+                      "synchronize its clock, and then try updating again.",
+                    details: error,
+                  })
+                );
+                return;
+              }
               this.dispatchEvent(
                 new DialogFailedEvent({
                   title: "Failed to Retrieve Version Information",

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -225,13 +225,17 @@
                   new DialogFailedEvent({
                     title: "Unable to Connect to TinyPilot Update Server",
                     message:
-                      "Your TinyPilot device's date differs signifcantly " +
-                      "from the date on the TinyPilot update server. This " +
-                      "can happen if your TinyPilot device does not have " +
-                      "Internet access or your network blocks access to " +
-                      "time servers (NTP servers).\n\nWait for up to five " +
-                      "minutes to give your TinyPilot device time to " +
-                      "synchronize its clock, and then try updating again.",
+                      "Your TinyPilot device couldn't establish a secure " +
+                      "connection to the update server, as the date on your " +
+                      "TinyPilot device and the date on the server are too " +
+                      "far apart. Your TinyPilot device might not know the " +
+                      "correct date if it hasn't been able to synchronize " +
+                      "with a network time server (NTP server).\n\nWait a " +
+                      "few minutes for your TinyPilot device to synchronize " +
+                      "its clock, then try again. If the error persists, " +
+                      "SSH in to your TinyPilot device to set the date " +
+                      "manually or check that your network allows " +
+                      "connections to NTP servers.",
                     details: error,
                   })
                 );

--- a/app/version.py
+++ b/app/version.py
@@ -80,6 +80,11 @@ def latest_version():
                 timeout=10) as response:
             response_bytes = response.read()
     except urllib.error.URLError as e:
+        if (hasattr(e.reason, 'reason') and
+                e.reason.reason == 'CERTIFICATE_VERIFY_FAILED' and
+                e.reason.verify_message == 'certificate is not yet valid'):
+            raise VersionRequestError(
+                f'Is the date shown in System > Logs correct? {e}') from e
         raise VersionRequestError(
             f'Failed to request latest available version: {e}') from e
 

--- a/app/version.py
+++ b/app/version.py
@@ -1,6 +1,7 @@
 import dataclasses
 import json
 import urllib.request
+from datetime import date
 
 import flask
 
@@ -11,6 +12,10 @@ class Error(Exception):
 
 class VersionFileError(Error):
     pass
+
+
+class CertificateNotYetValidError(Error):
+    code = 'CERTIFICATE_NOT_YET_VALID'
 
 
 class VersionRequestError(Error):
@@ -83,8 +88,10 @@ def latest_version():
         if (hasattr(e.reason, 'reason') and
                 e.reason.reason == 'CERTIFICATE_VERIFY_FAILED' and
                 e.reason.verify_message == 'certificate is not yet valid'):
-            raise VersionRequestError(
-                f'Is the date shown in System > Logs correct? {e}') from e
+            raise CertificateNotYetValidError(
+                'Server\'s certificate start date is ahead of TinyPilot\'s'
+                f' system date of {date.today():%Y-%m-%d}. Check the system'
+                f' date to ensure that it is accurate. {e}') from e
         raise VersionRequestError(
             f'Failed to request latest available version: {e}') from e
 

--- a/app/version.py
+++ b/app/version.py
@@ -1,5 +1,6 @@
 import dataclasses
 import json
+import ssl
 import urllib.request
 from datetime import date
 
@@ -85,8 +86,7 @@ def latest_version():
                 timeout=10) as response:
             response_bytes = response.read()
     except urllib.error.URLError as e:
-        if (hasattr(e.reason, 'reason') and
-                e.reason.reason == 'CERTIFICATE_VERIFY_FAILED' and
+        if (isinstance(e.reason, ssl.SSLCertVerificationError) and
                 e.reason.verify_message == 'certificate is not yet valid'):
             raise CertificateNotYetValidError(
                 'Server\'s certificate start date is ahead of TinyPilot\'s'


### PR DESCRIPTION
Resolves #1503.

This change adds code to intercept `CERTIFICATE_VERIFY_FAILED` errors that have a reason of "certificate is not yet valid" when checking for updates so the app can show a more actionable error message. Any other type of certificate or URL error is unaffected.

You can test the change by turning off the network time service and then setting the date back by a few years:

```bash
sudo systemctl stop systemd-timesyncd
sudo date --set='-2 years'
```
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1653"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>