### PR TITLE
Make bundle filename similar to image filename

### DIFF
--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -50,17 +50,17 @@ print_tinypilot_version() {
 # Compose bundle file name, which consists of these hyphen-separated parts:
 # 1. `tinypilot`
 # 2. The TinyPilot variant: `community` or `pro`
-# 3. A timestamp (which allows lexical sorting of bundles by their file names).
-# 4. The SemVer-compliant TinyPilot version.
+# 3. The SemVer-compliant TinyPilot version.
+# 4. A timestamp (which allows lexical sorting of bundles by their file names).
 # Examples for bundle names:
-# - `tinypilot-pro-20220620T1713Z-2.4.1.tgz` (Pro)
-# - `tinypilot-community-20220620T1611Z-1.8.0-23+649a6b2.tgz` (Community)
-TIMESTAMP="$(date --iso-8601=minutes | sed 's/[:-]//g' | sed 's/+0000/Z/g')"
+# - `tinypilot-pro-2.4.1-2022-06-20T1713Z.tgz` (Pro)
+# - `tinypilot-community-1.8.0-23+649a6b2-2022-06-20T1611Z.tgz` (Community)
+TIMESTAMP="$(date --iso-8601=minutes | sed 's/://g' | sed 's/+0000/Z/g')"
 readonly TIMESTAMP
 TINYPILOT_VERSION="$(print_tinypilot_version)"
 readonly TINYPILOT_VERSION
 readonly TINYPILOT_VARIANT='community'
-readonly BUNDLE_FILENAME="tinypilot-${TINYPILOT_VARIANT}-${TIMESTAMP}-${TINYPILOT_VERSION}.tgz"
+readonly BUNDLE_FILENAME="tinypilot-${TINYPILOT_VARIANT}-${TINYPILOT_VERSION}-${TIMESTAMP}.tgz"
 
 # Download Janus Bullseye Backports Debian package.
 # Note: before bumping the Janus package version, be sure to compare our Janus


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilotkvm.com/issues/1040

This PR changes the TinyPilot bundle filename schema to match that of the [TinyPilot Pro image filename schema](https://github.com/tiny-pilot/tinypilot-pro/blob/737abefc54d7cd3869d23468bc04d322557ce26c/packer/tinypilot.pkr.hcl#L49):
```
tinypilot-${var.variant}-${var.version}-${var.build_id}.img
```

This change is needed to be able to [infer the image filename from the bundle filename](https://github.com/tiny-pilot/tinypilotkvm.com/issues/1040#issuecomment-1751287865).

We're basically switching the position of the `${TIMESTAMP}` with the position of the `${TINYPILOT_VERSION}`, in the bundle filename.

#### Before

```
tinypilot-community-20231012T1853Z-1.9.1-22+0bde143.tgz
```

#### After

```
tinypilot-community-1.9.1-22+0bde143-2023-10-12T1853Z.tgz
```

### Notes

1. I was originally worried about adding hyphens back into the `${TIMESTAMP}` portion of the filename because the `${TINYPILOT_VERSION}` portion can also contain hyphens, especially in the community variant (e.g., `1.8.0-23+649a6b2`). So this would mean we couldn't easily split the filename into its different portions, using something like `filename.split("-")`. <s>However, we never needed to split the bundle filename back into its separate portions. So I think it's A-OK.</s>

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1658"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>