### PR TITLE
Move Hostname menu-item to Networking submenu

### DIFF
--- a/app/templates/custom-elements/menu-bar.html
+++ b/app/templates/custom-elements/menu-bar.html
@@ -193,12 +193,17 @@
             >Update</a
           >
         </li>
-        <li class="item" role="presentation">
-          <a
-            data-onclick-event="change-hostname-dialog-requested"
-            role="menuitem"
-            >Hostname</a
-          >
+        <li class="item subgroup" role="presentation">
+          <a role="menuitem">Networking</a>
+          <ul class="items" role="group">
+            <li class="item" role="presentation">
+              <a
+                data-onclick-event="change-hostname-dialog-requested"
+                role="menuitem"
+                >Hostname</a
+              >
+            </li>
+          </ul>
         </li>
         <li class="item" role="presentation">
           <a


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1641
Related https://github.com/tiny-pilot/tinypilot-pro/issues/1067

Menu bar:
<img width="555" alt="Screen Shot 2023-10-27 at 17 23 50" src="https://github.com/tiny-pilot/tinypilot/assets/6730025/2b755694-b7fb-41ee-8b19-86ec8d663157">

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1664"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>