### PR TITLE
Add video streaming mode to TinyPilot logs

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -12,7 +12,7 @@ def streaming_mode():
     """Prints TinyPilot's preferred video streaming mode, either H264 or MJPEG.
 
     Note: this doesn't represent the currently active video streaming mode
-    because H264 can fail and fallback to MJPEG.
+    because H264 can fail and fall back to MJPEG.
 
     Example of invocation:
         flask cli streaming-mode

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,0 +1,20 @@
+from flask import Blueprint
+
+import db.settings
+
+# For invoking the commands on the CLI you need to specify the FLASK_APP env
+# variable containing the path to the main file. E.g.: FLASK_APP=app/main.py
+cli_blueprint = Blueprint('cli', __name__)
+
+
+@cli_blueprint.cli.command('streaming-mode')
+def streaming_mode():
+    """Prints TinyPilot's preferred video streaming mode, either H264 or MJPEG.
+
+    Note: this doesn't represent the currently active video streaming mode
+    because H264 can fail and fallback to MJPEG.
+
+    Example of invocation:
+        flask cli streaming-mode
+    """
+    print(db.settings.Settings().get_streaming_mode().value)

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from werkzeug import exceptions
 # app-wide logger class before any other module loads it.
 import log
 import api
+import cli
 import json_response
 import license_notice
 import secret_key
@@ -49,6 +50,7 @@ csrf = flask_wtf.csrf.CSRFProtect(app)
 app.register_blueprint(api.api_blueprint)
 app.register_blueprint(license_notice.blueprint)
 app.register_blueprint(views.views_blueprint)
+app.register_blueprint(cli.cli_blueprint)
 
 
 @app.errorhandler(flask_wtf.csrf.CSRFError)

--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -168,7 +168,8 @@ print_info "Checking TinyPilot streaming mode..."
   echo "Streaming mode"
   echo "Selected mode: $(/opt/tinypilot/scripts/streaming-mode)"
   printf "Current mode: "
-  if LAST_JANUS_VIDEO_LINE="$(journalctl --unit janus.service --quiet --reverse --lines 1 --grep 'ustreamer/video')" && [[ "${LAST_JANUS_VIDEO_LINE}" =~ 'Memsink opened; reading frames' ]]; then
+  if LAST_JANUS_VIDEO_LINE="$(journalctl --unit janus.service --quiet --reverse --lines 1 --grep 'ustreamer/video')" &&
+      [[ "${LAST_JANUS_VIDEO_LINE}" =~ 'Memsink opened; reading frames' ]]; then
     printf "H264"
   else
     printf "MJPEG"

--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -166,10 +166,10 @@ print_info "Checking for voltage issues..."
 print_info "Checking TinyPilot streaming mode..."
 {
   echo "Streaming mode"
-  echo "Selected mode: H.264"
+  echo "Selected mode: $(/opt/tinypilot/scripts/streaming-mode)"
   printf "Current mode: "
   if LAST_JANUS_VIDEO_LINE="$(journalctl --unit janus.service --quiet --reverse --lines 1 --grep 'ustreamer/video')" && [[ "${LAST_JANUS_VIDEO_LINE}" =~ 'Memsink opened; reading frames' ]]; then
-    printf "H.264"
+    printf "H264"
   else
     printf "MJPEG"
   fi

--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -163,6 +163,19 @@ print_info "Checking for voltage issues..."
   printf "\n\n"
 } >> "${LOG_FILE}"
 
+print_info "Checking TinyPilot streaming mode..."
+{
+  echo "Streaming mode"
+  echo "Selected mode: H.264"
+  printf "Current mode: "
+  if LAST_JANUS_VIDEO_LINE="$(journalctl --unit janus.service --quiet --reverse --lines 1 --grep 'ustreamer/video')" && [[ "${LAST_JANUS_VIDEO_LINE}" =~ 'Memsink opened; reading frames' ]]; then
+    printf "H.264"
+  else
+    printf "MJPEG"
+  fi
+  printf "\n\n"
+} >> "${LOG_FILE}"
+
 print_info "Checking TinyPilot settings..."
 {
   printf "TinyPilot settings.yml\n"

--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -168,6 +168,9 @@ print_info "Checking TinyPilot streaming mode..."
   echo "Streaming mode"
   echo "Selected mode: $(/opt/tinypilot/scripts/streaming-mode)"
   printf "Current mode: "
+  # H264 mode is considered active when the last Janus video log line contains
+  # "Memsink opened; reading frames".
+  # https://github.com/tiny-pilot/ustreamer/blob/89fd83bfc187ed592e9582be077fa1a005098532/janus/src/plugin.c#L148
   if LAST_JANUS_VIDEO_LINE="$(journalctl --unit janus.service --quiet --reverse --lines 1 --grep 'ustreamer/video')" &&
       [[ "${LAST_JANUS_VIDEO_LINE}" =~ 'Memsink opened; reading frames' ]]; then
     printf "H264"

--- a/scripts/streaming-mode
+++ b/scripts/streaming-mode
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Prints TinyPilot's preferred video streaming mode, either H264 or MJPEG.
+
+# Exit on first failure.
+set -e
+
+# Exit on unset variable.
+set -u
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+readonly SCRIPT_DIR
+cd "${SCRIPT_DIR}/.."
+. ./venv/bin/activate
+
+TINYPILOT_HOME_DIR="$(realpath ~)"
+readonly TINYPILOT_HOME_DIR
+export TINYPILOT_HOME_DIR
+
+# Create a dummy app settings file. The flask app needs a settings file to
+# start, but it's not necessary for this simple script, so we use a blank,
+# dummy version.
+APP_SETTINGS_FILE="$(mktemp)"
+readonly APP_SETTINGS_FILE
+export APP_SETTINGS_FILE
+
+export FLASK_APP='app/main.py'
+flask cli streaming-mode

--- a/scripts/streaming-mode
+++ b/scripts/streaming-mode
@@ -13,10 +13,6 @@ readonly SCRIPT_DIR
 cd "${SCRIPT_DIR}/.."
 . ./venv/bin/activate
 
-TINYPILOT_HOME_DIR="$(realpath ~)"
-readonly TINYPILOT_HOME_DIR
-export TINYPILOT_HOME_DIR
-
 # Create a dummy app settings file. The flask app needs a settings file to
 # start, but it's not necessary for this simple script, so we use a blank,
 # dummy version.


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1490

Video demo:

https://github.com/tiny-pilot/tinypilot/assets/6730025/0165c85d-f9fa-4389-b98d-44de90843f5a

### Notes

1. When there are active WebRTC consumers, I see this in the Janus logs:
    ```
    Oct 30 15:27:57 tinypilot janus[1790]: Creating new session: 3545622190134115; 0xed914e28
    Oct 30 15:27:57 tinypilot janus[1790]: Creating new handle in session 3545622190134115: 8464226001965214; 0xed914e28 0xefb019c8
    Oct 30 15:27:57 tinypilot janus[1790]: == ustreamer/main      -- Creating session 0xefb01650 ...
    Oct 30 15:27:57 tinypilot janus[1790]: == ustreamer/video     -- Memsink opened; reading frames ...
    Oct 30 15:27:57 tinypilot janus[1790]: [8464226001965214] Creating ICE agent (ICE Full mode, controlling)
    Oct 30 15:27:57 tinypilot janus[1790]: == ustreamer/audio     -- Detected host audio
    Oct 30 15:27:57 tinypilot janus[1790]: == ustreamer/audio     -- Pipeline configured on 48000Hz; capturing ...
    Oct 30 15:27:58 tinypilot janus[1790]: [8464226001965214] The DTLS handshake has been completed
    ```
    
    When there are no active WebRTC consumers, I see this in the Janus logs:
    ```
    Oct 30 15:30:15 tinypilot janus[1790]: [WSS-0xed9005f8] Destroying WebSocket client
    Oct 30 15:30:15 tinypilot janus[1790]: Destroying session 3545622190134115; 0xed914e28
    Oct 30 15:30:15 tinypilot janus[1790]: Detaching handle from ustreamer; 0xefb019c8 0xefb01650 0xefb019c8 (nil)
    Oct 30 15:30:15 tinypilot janus[1790]: [8464226001965214] WebRTC resources freed; 0xefb019c8 0xed914e28
    Oct 30 15:30:15 tinypilot janus[1790]: == ustreamer/main      -- Removing session 0xefb01650 ...
    Oct 30 15:30:15 tinypilot janus[1790]: == ustreamer/audio     -- Pipeline closed
    Oct 30 15:30:15 tinypilot janus[1790]: == ustreamer/video     -- Memsink closed
    Oct 30 15:30:16 tinypilot janus[1790]: == ustreamer/video     -- No active watchers, memsink disconnected
    ```
    
    So based on the above log examples, [H264 mode is active](https://github.com/tiny-pilot/tinypilot/blob/dda4d8b161eaac91db7f05a4e6bc14510b99f415/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs#L171-L173) when the last Janus log that contains `ustreamer/video`,  also contains `Memsink opened; reading frames`. For example:

    ```
    Oct 30 15:27:57 tinypilot janus[1790]: == ustreamer/video     -- Memsink opened; reading frames ...
    ```
    
    Otherwise, it is assumed that MJPEG is active.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1666"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>