### PR TITLE
Hint to STUN in H.264 status bar warning

### DIFF
--- a/app/templates/custom-elements/video-stream-indicator.html
+++ b/app/templates/custom-elements/video-stream-indicator.html
@@ -63,6 +63,9 @@
   <span class="label-mjpeg">MJPEG</span>
   <span class="label-h264">H.264</span>
   <div class="status-bar-tooltip">
+    <!-- For menu breadcrumbs (e.g., `“System” > “Logs”`) in the tooltip
+         message, make it so that line breaks always occur after the `>` token.
+         -->
     <div class="tooltip-text-info">
       <p>
         TinyPilot is currently using
@@ -71,8 +74,8 @@
         compression to stream the video output of your target device.
       </p>
       <p>
-        You can configure the streaming mode in the
-        “System”&nbsp;&gt;&nbsp;“Video&nbsp;Settings” dialog.
+        You can configure the streaming mode in the “System”&nbsp;&gt;
+        “Video&nbsp;Settings” dialog.
       </p>
     </div>
     <div class="tooltip-text-h264-failure">
@@ -82,10 +85,10 @@
       </p>
       <p>
         You may be able to resolve this issue by using a STUN server. Go to
-        “System”&nbsp;&gt;&nbsp;“Video Settings”&nbsp;&gt; “Advanced Settings”
-        to enable this option.
+        “System”&nbsp;&gt; “Video&nbsp;Settings”&nbsp;&gt;
+        “Show&nbsp;Advanced&nbsp;Settings” to enable this option.
       </p>
-      <p>See “System”&nbsp;&gt;&nbsp;“Logs” for diagnostic details.</p>
+      <p>See “System”&nbsp;&gt; “Logs” for diagnostic details.</p>
     </div>
   </div>
   <img src="/img/warning-icon.svg" class="warning-icon" alt="Warning" />


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1651.

<img width="652" alt="Screenshot 2023-10-31 at 15 15 04" src="https://github.com/tiny-pilot/tinypilot/assets/83721279/eb33a9b5-dcc5-499a-bfc0-a3e5ef5dba09">

I deliberately omitted the `&nbsp;` before the `“Advanced Settings”`, because otherwise the line break would split the `“Advanced Settings”` label in half.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1669"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>