### PR TITLE
Prevent installation on Bookworm

### DIFF
--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -30,6 +30,15 @@ if [[ "$(lsb_release --id --short)" == 'Raspbian' ]] \
   exit 1
 fi
 
+# Prevent installation on Raspberry Pi OS 12 "Bookworm".
+if [[ "$(lsb_release --id --short)" == 'Raspbian' ]] \
+    && (( "$(lsb_release --release --short)" > 11 )); then
+  echo "TinyPilot is not yet compatible with Raspberry Pi OS 12 \"Bookworm\"." >&2
+  echo "You can track our progress by visiting https://github.com/tiny-pilot/tinypilot/issues/1668." >&2
+  echo "To install TinyPilot, you'll need to downgrade your operating system to Raspberry Pi OS 11 \"Bullseye\"." >&2
+  exit 1
+fi
+
 # Abort installation if the read-only filesystem is enabled
 if grep -q "boot=overlay" /proc/cmdline ; then
   echo 'The read-only filesystem is enabled.' >&2

--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -34,7 +34,7 @@ fi
 if [[ "$(lsb_release --id --short)" == 'Raspbian' ]] \
     && (( "$(lsb_release --release --short)" > 11 )); then
   echo "TinyPilot is not yet compatible with Raspberry Pi OS 12 \"Bookworm\"." >&2
-  echo "You can track our progress by visiting https://github.com/tiny-pilot/tinypilot/issues/1668." >&2
+  echo "You can track our progress by visiting https://github.com/tiny-pilot/tinypilot/issues/1668" >&2
   echo "To install TinyPilot, you'll need to downgrade your operating system to Raspberry Pi OS 11 \"Bullseye\"." >&2
   exit 1
 fi


### PR DESCRIPTION
Resolves #1667.

TinyPilot doesn't currently work on Raspberry Pi OS Bookworm, so this change adds a check to prevent installation on versions of Raspberry Pi OS newer than Bullseye. A link to the [issue for adding Bookworm support](https://github.com/tiny-pilot/tinypilot/issues/1668) is included in the error message for convenience. I've tested this on-device on both Bullseye and Bookworm.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1671"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>