### PR TITLE
Implicitly install requirements.txt when installing dev_requirements.txt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,6 @@ jobs:
           name: Install requirements and run build script
           command: |
             . venv/bin/activate
-            pip install --requirement requirements.txt
             pip install --requirement dev_requirements.txt
             ./dev-scripts/build-python
   build_javascript:
@@ -112,7 +111,6 @@ jobs:
           name: Install python requirements
           command: |
             . venv/bin/activate
-            pip install --requirement requirements.txt
             pip install --requirement dev_requirements.txt
       - run:
           name: Install node dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,6 @@ To install TinyPilot's dev packages, run the following command:
 ```bash
 python3 -m venv venv && \
   . venv/bin/activate && \
-  pip install --requirement requirements.txt && \
   pip install --requirement dev_requirements.txt && \
   npm install && \
   sudo npx playwright install-deps && \

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
---requirements requirements.txt
+--requirement requirements.txt
 
 coverage==7.2.7
 pylint==2.14.2

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 coverage==7.2.7
 pylint==2.14.2
 ruff==0.0.290

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,5 @@
--r requirements.txt
+--requirements requirements.txt
+
 coverage==7.2.7
 pylint==2.14.2
 ruff==0.0.290


### PR DESCRIPTION
I recently discovered that you can have a requirements.txt file include another requirements.txt file, so I thought it would be useful to take advantage of this and simplify some of our dev workflows.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1681"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>