### PR TITLE
Group e2e tests

### DIFF
--- a/e2e/about.spec.js
+++ b/e2e/about.spec.js
@@ -1,24 +1,26 @@
 import { test, expect } from "@playwright/test";
 
-test("shows about page, license, privacy policy, and dependency pages and licenses", async ({
-  page,
-}) => {
-  await page.goto("/");
-  await page.getByRole("menuitem", { name: "Help" }).hover();
-  await page.getByRole("menuitem", { name: "About" }).click();
-  await expect(
-    page.getByRole("heading", { name: "About TinyPilot" })
-  ).toBeVisible();
+test.describe("about dialog", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("menuitem", { name: "Help" }).hover();
+    await page.getByRole("menuitem", { name: "About" }).click();
+    await expect(
+      page.getByRole("heading", { name: "About TinyPilot" })
+    ).toBeVisible();
+  });
 
-  const licensePagePromise = page.waitForEvent("popup");
-  await page.getByRole("link", { name: "MIT license" }).click();
-  const licensePage = await licensePagePromise;
-  await expect(licensePage.locator("body")).toContainText(
-    "Copyright 2022 TinyPilot, LLC"
-  );
-  await licensePage.close();
+  test("shows license", async ({ page }) => {
+    const licensePagePromise = page.waitForEvent("popup");
+    await page.getByRole("link", { name: "MIT license" }).click();
+    const licensePage = await licensePagePromise;
+    await expect(licensePage.locator("body")).toContainText(
+      "Copyright 2022 TinyPilot, LLC"
+    );
+    await licensePage.close();
+  });
 
-  {
+  test("shows privacy policy", async ({ page }) => {
     const privacyPolicyPagePromise = page.waitForEvent("popup");
     await page.getByRole("link", { name: "Privacy Policy" }).click();
     const privacyPolicyPage = await privacyPolicyPagePromise;
@@ -26,9 +28,9 @@ test("shows about page, license, privacy policy, and dependency pages and licens
       "PRIVACY POLICY"
     );
     await privacyPolicyPage.close();
-  }
+  });
 
-  {
+  test("has link to Flask website", async ({ page }) => {
     const flaskProjectPagePromise = page.waitForEvent("popup");
     await page
       .getByRole("link", { name: "Flask", exact: true })
@@ -38,12 +40,12 @@ test("shows about page, license, privacy policy, and dependency pages and licens
     await expect(flaskProjectPage).toHaveURL(
       new RegExp("https://flask.palletsprojects.com.*")
     );
-    // We assert the presense of some text so the trace report shows the page render.
+    // We assert the presence of some text so the trace report shows the page render.
     await expect(flaskProjectPage.locator("body")).not.toBeEmpty();
     await flaskProjectPage.close();
-  }
+  });
 
-  {
+  test("shows Flask license", async ({ page }) => {
     const flaskLicensePagePromise = page.waitForEvent("popup");
     await page
       .getByRole("listitem")
@@ -56,9 +58,9 @@ test("shows about page, license, privacy policy, and dependency pages and licens
     );
     await expect(flaskLicensePage.locator("body")).not.toBeEmpty();
     await flaskLicensePage.close();
-  }
+  });
 
-  {
+  test("has link to Janus website", async ({ page }) => {
     const janusProjectPagePromise = page.waitForEvent("popup");
     await page
       .getByRole("link", { name: "Janus", exact: true })
@@ -70,9 +72,9 @@ test("shows about page, license, privacy policy, and dependency pages and licens
     );
     await expect(janusProjectPage.locator("body")).not.toBeEmpty();
     await janusProjectPage.close();
-  }
+  });
 
-  {
+  test("shows Janus license", async ({ page }) => {
     const janusLicensePagePromise = page.waitForEvent("popup");
     await page
       .getByRole("listitem")
@@ -87,12 +89,14 @@ test("shows about page, license, privacy policy, and dependency pages and licens
     );
     await expect(janusLicensePage.locator("body")).not.toBeEmpty();
     await janusLicensePage.close();
-  }
+  });
 
-  await page.getByRole("button", { name: "Close", exact: true }).click();
-  await expect(
-    page.getByRole("heading", { name: "About TinyPilot" })
-  ).not.toBeVisible();
+  test("closes dialog", async ({ page }) => {
+    await page.getByRole("button", { name: "Close", exact: true }).click();
+    await expect(
+      page.getByRole("heading", { name: "About TinyPilot" })
+    ).not.toBeVisible();
 
-  await page.close();
+    await page.close();
+  });
 });


### PR DESCRIPTION
I noticed that our end-to-end tests are slightly hard to follow, as they contain sub-scopes that are supposed to divide the test into different aspects (e.g. [this one](https://github.com/tiny-pilot/tinypilot/blob/92298b427c77d534c769ab826abe3968d1486279/e2e/about.spec.js#L31-L44)), but these groups don’t have any description.

We could use [Playwright’s `test.describe` helper](https://playwright.dev/docs/api/class-test#test-describe-1) here to provide more structure. This PR demonstrates how that works:

- The individual aspects all have their own `test` block. These `test` blocks are grouped via an enclosing `test.describe` block.
- The setup routine (i.e., opening the “about” dialog via the menu) would go into an `test.beforeEach` helper.
- The sub-tests then receive that preconfigured `page` object for their assertions.

The sub-tests are run in parallel by default. That works fine for the about dialog. In Pro, we [also have sequential tests](https://github.com/tiny-pilot/tinypilot-pro/blob/master/e2e/security.spec.js), which we’d need to [configure explicitly via `test.decribe.configure`](https://playwright.dev/docs/api/class-test#test-describe-configure).

Advantages:

- If an individual aspect fails, we get a more fine-granular report on the CLI.
- We are forced to be more explicit when tests depend on each other. If they don’t depend on each other, we are free how we order them.

This PR is not meant for merging, it’s just a demo. If we’d be interested in this, I could either wrap up this branch, or create a ticket for us to refactor this later. I’d estimate as small, including Pro. We’d also have to wait for https://github.com/tiny-pilot/tinypilot/pull/1682.

An alternative would be to put comments above the scoped blocks. These wouldn’t be printed to the CLI in the same neat way as the nested tests, though, e.g. if one aspect fails.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1685"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>