### PR TITLE
Remove “Cancel” button from loading state

### DIFF
--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -39,7 +39,6 @@
     <div>
       <progress-spinner></progress-spinner>
     </div>
-    <button id="cancel-initialization" type="button">Cancel</button>
   </div>
 
   <div id="prompt">
@@ -133,7 +132,10 @@
           PROMPT: "prompt",
           CHANGING: "changing",
         };
-        statesWithoutDialogClose = new Set([this.states.CHANGING]);
+        statesWithoutDialogClose = new Set([
+          this.states.CHANGING,
+          this.states.INITIALIZING,
+        ]);
 
         connectedCallback() {
           this.attachShadow({ mode: "open" }).appendChild(
@@ -144,9 +146,6 @@
             hostnameInput: this.shadowRoot.getElementById("hostname-input"),
             changeAndRestart:
               this.shadowRoot.getElementById("change-and-restart"),
-            cancelInitialization: this.shadowRoot.getElementById(
-              "cancel-initialization"
-            ),
             cancelHostnameChange: this.shadowRoot.getElementById(
               "cancel-hostname-change"
             ),
@@ -163,9 +162,6 @@
             if (evt.code === "Enter") {
               this.elements.changeAndRestart.click();
             }
-          });
-          this.elements.cancelInitialization.addEventListener("click", () => {
-            this.dispatchEvent(new DialogClosedEvent());
           });
           this.elements.cancelHostnameChange.addEventListener("click", () => {
             this.dispatchEvent(new DialogClosedEvent());


### PR DESCRIPTION
In our style guide, we say [that dialog loading states shouldn’t have close/cancel buttons](https://github.com/tiny-pilot/tinypilot/blob/cbc2a379e71b1b8c2be7ac49e61e0b8a8d8c729f/app/templates/styleguide.html#L466-L468).

The `<change-hostname>` dialog violated this rule, which this PR fixes.

https://github.com/tiny-pilot/tinypilot/assets/83721279/e8e7df38-4ef9-42d0-82c8-2018b93cf0f8

Tangentially related https://github.com/tiny-pilot/tinypilot/issues/1684.

~Currently blocked by https://github.com/tiny-pilot/tinypilot/issues/1686 (e2e tests failing).~

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1687"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>