### PR TITLE
Deprecate settings.yml, and document usage

### DIFF
--- a/app/update/settings.py
+++ b/app/update/settings.py
@@ -9,17 +9,21 @@ Typical usage example:
     settings.ustreamer_desired_fps = 15
     update_settings.save(settings)
 
-Note that we consider the use of settings.yml to be mostly deprecated nowadays.
-Historically, settings.yml was used as we relied on Ansible to manage and
-update the device system state. (The canonical way for configuration in Ansible
-is files in YAML format.) As of mid 2023, we have finished migrating away from
-Ansible, so there is no hard requirement for us to continue using the
-settings.yml file, except for backwards compatibility with existing files.
-
-The default place to store settings and configuration is the SQlite database.
-We should only add new properties to settings.yml in exceptional cases, e.g.:
+Note that we consider the use of settings.yml to be deprecated nowadays. The
+default place to store settings and configuration is the SQlite database. We
+should only add new properties to settings.yml in exceptional cases, such as:
 - Settings that are supposed to be manually overridden by users
 - Settings that are closely related to already existing legacy settings
+
+Historically, settings.yml was used as we relied on Ansible to manage and
+update the device system state. The canonical way for configuration in Ansible
+is files in YAML format, so a YAML file was an obvious choice here. This
+wrapper module resides in the update package, since settings.yml was only
+processed throughout the update process initially. Over time, we also added a
+few other settings, which are independent of the update context.
+As of mid 2023, we have finished migrating away from Ansible, so there is no
+hard requirement for us to continue using the settings.yml file, except for
+backwards compatibility with existing TinyPilot installations.
 """
 
 import yaml


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1524.

The outcome of our discussion in the ticket was this:

- The SQlite DB (`tinypilot.db`) should be the default place for new settings, whereas the YAML file (`settings.yml`) should only be used in exceptional cases, and obviously for legacy reasons.
- We favor having a single storage solution over a dual approach, as that simplifies future decision-making, and eliminates potential migration burden between the two storage formats.
- The SQlite DB doesn’t easily allow programmatic access right now (in contrast to the YAML file), so we [created this ticket for removing this hurdle](https://github.com/tiny-pilot/tinypilot/issues/1690).
- We [will document the parameters in `settings.yml` separately](https://github.com/tiny-pilot/tinypilot/issues/1573).

This PR adds a comment in `settings.py`, marking its usage as quasi-deprecated. It also adds some historical context, references the SQlite DB as default storage, and lists sample exceptional cases.

I realized that we probably don’t need to add any documentation to the SQlite DB, since there is not really an alternative to it any longer. So by deprecating `settings.yml`, the SQlite DB is the only storage option anyway, and there shouldn’t be any ambiguity left. Contrary to [my initial proposal](https://github.com/tiny-pilot/tinypilot/issues/1524#issuecomment-1814708626), I also don’t think we should move `settings.py` up to the `app` package, as that might mistakenly promote its usage.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1692"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>