### PR TITLE
Group e2e tests

### DIFF
--- a/e2e/about.spec.js
+++ b/e2e/about.spec.js
@@ -1,25 +1,34 @@
 import { test, expect } from "@playwright/test";
 
-test("shows about page, license, privacy policy, and dependency pages and licenses", async ({
-  page,
-  baseURL,
-}) => {
-  await page.goto("/");
-  await page.getByRole("menuitem", { name: "Help" }).hover();
-  await page.getByRole("menuitem", { name: "About" }).click();
-  await expect(
-    page.getByRole("heading", { name: "About TinyPilot" })
-  ).toBeVisible();
+test.describe("about dialog", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("menuitem", { name: "Help" }).hover();
+    await page.getByRole("menuitem", { name: "About" }).click();
+    await expect(
+      page.getByRole("heading", { name: "About TinyPilot" })
+    ).toBeVisible();
+  });
 
-  const licensePagePromise = page.waitForEvent("popup");
-  await page.getByRole("link", { name: "MIT license" }).click();
-  const licensePage = await licensePagePromise;
-  await expect(licensePage.locator("body")).toContainText(
-    "Copyright 2022 TinyPilot, LLC"
-  );
-  await licensePage.close();
+  test("closes about dialog", async ({ page }) => {
+    await page.getByRole("button", { name: "Close", exact: true }).click();
+    await expect(
+      page.getByRole("heading", { name: "About TinyPilot" })
+    ).not.toBeVisible();
+    await page.close();
+  });
 
-  {
+  test("shows license", async ({ page }) => {
+    const licensePagePromise = page.waitForEvent("popup");
+    await page.getByRole("link", { name: "MIT license" }).click();
+    const licensePage = await licensePagePromise;
+    await expect(licensePage.locator("body")).toContainText(
+      "Copyright 2022 TinyPilot, LLC"
+    );
+    await licensePage.close();
+  });
+
+  test("shows privacy policy", async ({ page }) => {
     const privacyPolicyPagePromise = page.waitForEvent("popup");
     await page.getByRole("link", { name: "Privacy Policy" }).click();
     const privacyPolicyPage = await privacyPolicyPagePromise;
@@ -27,9 +36,9 @@ test("shows about page, license, privacy policy, and dependency pages and licens
       "PRIVACY POLICY"
     );
     await privacyPolicyPage.close();
-  }
+  });
 
-  {
+  test("links to dependency’s project page (Flask)", async ({ page }) => {
     const flaskProjectPagePromise = page.waitForEvent("popup");
     await page
       .getByRole("link", { name: "Flask", exact: true })
@@ -39,12 +48,12 @@ test("shows about page, license, privacy policy, and dependency pages and licens
     await expect(flaskProjectPage).toHaveURL(
       new RegExp("https://flask.palletsprojects.com.*")
     );
-    // We assert the presense of some text so the trace report shows the page render.
+    // We assert the presence of some text so the trace report shows the page render.
     await expect(flaskProjectPage.locator("body")).not.toBeEmpty();
     await flaskProjectPage.close();
-  }
+  });
 
-  {
+  test("links to dependency’s license page (Flask)", async ({ page }) => {
     const flaskLicensePagePromise = page.waitForEvent("popup");
     await page
       .getByRole("listitem")
@@ -57,9 +66,9 @@ test("shows about page, license, privacy policy, and dependency pages and licens
     );
     await expect(flaskLicensePage.locator("body")).not.toBeEmpty();
     await flaskLicensePage.close();
-  }
+  });
 
-  {
+  test("links to dependency’s project page (Janus)", async ({ page }) => {
     const janusProjectPagePromise = page.waitForEvent("popup");
     await page
       .getByRole("link", { name: "Janus", exact: true })
@@ -71,9 +80,9 @@ test("shows about page, license, privacy policy, and dependency pages and licens
     );
     await expect(janusProjectPage.locator("body")).not.toBeEmpty();
     await janusProjectPage.close();
-  }
+  });
 
-  {
+  test("links to dependency’s license page (Janus)", async ({ page }) => {
     const janusLicensePagePromise = page.waitForEvent("popup");
     await page
       .getByRole("listitem")
@@ -88,9 +97,12 @@ test("shows about page, license, privacy policy, and dependency pages and licens
     );
     await expect(janusLicensePage.locator("body")).not.toBeEmpty();
     await janusLicensePage.close();
-  }
+  });
 
-  {
+  test("checks that all license URLs are valid and reachable", async ({
+    page,
+    baseURL,
+  }) => {
     const links = await page.locator("a.license").all();
     const paths = await Promise.all(
       links.map((link) => link.getAttribute("href"))
@@ -105,12 +117,5 @@ test("shows about page, license, privacy policy, and dependency pages and licens
         .map((response) => response.url)
         .join(", ")}`
     ).toBe(0);
-  }
-
-  await page.getByRole("button", { name: "Close", exact: true }).click();
-  await expect(
-    page.getByRole("heading", { name: "About TinyPilot" })
-  ).not.toBeVisible();
-
-  await page.close();
+  });
 });

--- a/e2e/debug-logs.spec.js
+++ b/e2e/debug-logs.spec.js
@@ -26,28 +26,33 @@ async function readClipboardContents(page) {
   return await input.inputValue();
 }
 
-test("loads debug logs and generates a shareable URL for them", async ({
-  page,
-}) => {
-  await page.goto("/");
+test.describe("debug logs dialog", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("menuitem", { name: "System" }).hover();
+    await page.getByRole("menuitem", { name: "Logs" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Debug Logs" })
+    ).toBeVisible();
+  });
 
-  await page.getByRole("menuitem", { name: "System" }).hover();
-  await page.getByRole("menuitem", { name: "Logs" }).click();
-  await expect(page.getByRole("heading", { name: "Debug Logs" })).toBeVisible();
+  test("loads debug logs and generates a shareable URL for them", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Get Shareable URL" }).click();
+    await page.getByRole("button", { name: "Copy" }).click();
+    const copiedUrl = await readClipboardContents(page);
+    await expect(copiedUrl).toMatch(
+      new RegExp("^https://logs.tinypilotkvm.com/.*")
+    );
 
-  await page.getByRole("button", { name: "Get Shareable URL" }).click();
-  await page.getByRole("button", { name: "Copy" }).click();
-  const copiedUrl = await readClipboardContents(page);
-  await expect(copiedUrl).toMatch(
-    new RegExp("^https://logs.tinypilotkvm.com/.*")
-  );
+    await expect(page.locator("#logs-success .logs-output")).toContainText(
+      "TinyPilot version: "
+    );
 
-  await expect(page.locator("#logs-success .logs-output")).toContainText(
-    "TinyPilot version: "
-  );
-
-  await page.getByRole("button", { name: "Close", exact: true }).click();
-  await expect(
-    page.getByRole("heading", { name: "Debug Logs" })
-  ).not.toBeVisible();
+    await page.getByRole("button", { name: "Close", exact: true }).click();
+    await expect(
+      page.getByRole("heading", { name: "Debug Logs" })
+    ).not.toBeVisible();
+  });
 });


### PR DESCRIPTION
As demonstrated in https://github.com/tiny-pilot/tinypilot/pull/1685, we can make use of Playwright’s grouping feature to improve our e2e test structure:

- Instead of ordinary block scopes, we can use dedicated and isolated `test` clauses. These blocks are grouped inside an [enclosing `test.describe`](https://playwright.dev/docs/api/class-test#test-describe-1).
- The individual test aspects now have their own description, which improves readability.
- If an individual test aspects fails, the CLI will also output the name of the test, so it’s easier to debug. The report is also more fine-granular:
  - [Playwright report before](https://output.circle-artifacts.com/output/job/70fcb241-3cd1-4abb-9686-1e793831d78a/artifacts/0/playwright-report/index.html)
  - [Playwright report after](https://output.circle-artifacts.com/output/job/c564b6a4-2bec-4c35-a47d-1965ff18a60c/artifacts/0/playwright-report/index.html)
- It seems that the execution time is slightly slower now compared to before, though it’s hard to tell exactly, because there is significant variance between passes.
  - In the reports linked above, you see an execution time of ~12s (after) vs. ~9s (before). The bootstrapping procedure of the CI job (installing dependencies, etc.) is usually 60–90 seconds, however, so I’m not sure we should be worried too much at this point. I also think we should have more leverage now to speed up the tests through parallelizing.
  - `test` clauses are usually run in parallel by default in Playwright, though it seems we [opted out of test parallelism in our Playwright config](https://github.com/tiny-pilot/tinypilot/blob/5bdbec7cbb604f259be41a8d62ef7c79b335d99e/playwright.config.js#L9-L14). I’m not sure why we did that, but we could now consider changing it back. (If at all, we should do that separately, though.)

This PR is a non-functional refactoring. It only introduces the grouping + group descriptions, without any other modifications (except code style).

Tagged @cghague for review, since [we just ran into this topic recently](https://github.com/tiny-pilot/tinypilot-pro/pull/1151#pullrequestreview-1756069705), so I thought it was fitting. I’d take care of adjusting the Pro-specific tests once we have merged this over.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1693"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>