### PR TITLE
Disable parallel e2e test execution locally

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -10,8 +10,9 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   retries: 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  /* Opt out of parallel tests, until we have fixed our test setup in that
+     regard. See https://github.com/tiny-pilot/tinypilot/issues/1694 */
+  workers: 1,
   reporter: "html",
   use: {
     baseURL: process.env.E2E_BASE_URL || "http://0.0.0.0:9000",


### PR DESCRIPTION
Until we have addressed https://github.com/tiny-pilot/tinypilot/issues/1694, I’d suggest to disable parallel e2e test execution locally, otherwise there can be erratic failures in Pro (due to the security tests interfering with other tests).

On my local machine, this changes e2e execution speed from ~20s to ~26s. On CI, it obviously doesn’t change.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1695"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>