### PR TITLE
License link check timeout message

### DIFF
--- a/e2e/about.spec.js
+++ b/e2e/about.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, errors } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 
 test.describe("about dialog", () => {
   test.beforeEach(async ({ page }) => {

--- a/e2e/about.spec.js
+++ b/e2e/about.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, errors } from "@playwright/test";
 
 test.describe("about dialog", () => {
   test.beforeEach(async ({ page }) => {
@@ -107,15 +107,19 @@ test.describe("about dialog", () => {
     const paths = await Promise.all(
       links.map((link) => link.getAttribute("href"))
     );
-    const responses = await Promise.all(
-      paths.map((path) => fetch(`${baseURL}${path}`))
+    const failedUrls = [];
+    await Promise.all(
+      paths
+        .map((path) => `${baseURL}${path}`)
+        .map((url) =>
+          fetch(url, { signal: AbortSignal.timeout(10000) }).catch(() =>
+            failedUrls.push(url)
+          )
+        )
     );
-    const failedResponses = responses.filter((res) => res.status !== 200);
     expect(
-      failedResponses.length,
-      `License link broken for URLs: ${failedResponses
-        .map((response) => response.url)
-        .join(", ")}`
+      failedUrls.length,
+      `License link broken for URLs: ${failedUrls.join(", ")}`
     ).toBe(0);
   });
 });


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1689

By default, Playwright limits each test to a 30s runtime. Unfortunately, when the the test reaches its timeout, it display an opaque error message:
<img width="331" alt="Screen Shot 2023-12-05 at 14 42 47" src="https://github.com/tiny-pilot/tinypilot/assets/6730025/e44424f0-89f3-4569-98b2-7dd3a8dde7ee">

In this case, the test timed out because one of the license URLs took >30s to respond.

To avoid this issue, I've applied a 10s timeout to each license URL check.

### Notes
1. I couldn't find a way to catch the actual test's [TimeoutError](https://playwright.dev/docs/api/class-timeouterror) or how to set a custom test timeout message 🤷‍♂️ 
