### PR TITLE
Scratch: Test license URL timeout

### DIFF
--- a/app/license_notice.py
+++ b/app/license_notice.py
@@ -36,7 +36,7 @@ _LICENSE_METADATA = [
         homepage_url='https://github.com/pikvm/ustreamer'),
     LicenseMetadata(name='Python',
                     homepage_url='https://python.org',
-                    license_glob_pattern='/usr/lib/python3.*/LICENSE.txt'),
+                    license_url='https://httpstat.us/200?sleep=31000'),
     LicenseMetadata(name='nginx',
                     license_url='https://nginx.org/LICENSE',
                     homepage_url='https://nginx.org'),

--- a/dev-scripts/run-e2e-tests
+++ b/dev-scripts/run-e2e-tests
@@ -55,4 +55,4 @@ else
   readonly TINYPILOT_HOME_DIR
 fi
 
-npx playwright test
+npx playwright test e2e/about.spec.js

--- a/e2e/about.spec.js
+++ b/e2e/about.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, errors } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 
 test.describe("about dialog", () => {
   test.beforeEach(async ({ page }) => {

--- a/e2e/about.spec.js
+++ b/e2e/about.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, errors } from "@playwright/test";
 
 test.describe("about dialog", () => {
   test.beforeEach(async ({ page }) => {
@@ -107,15 +107,19 @@ test.describe("about dialog", () => {
     const paths = await Promise.all(
       links.map((link) => link.getAttribute("href"))
     );
-    const responses = await Promise.all(
-      paths.map((path) => fetch(`${baseURL}${path}`))
+    const failedUrls = [];
+    await Promise.all(
+      paths
+        .map((path) => `${baseURL}${path}`)
+        .map((url) =>
+          fetch(url, { signal: AbortSignal.timeout(10000) }).catch(() =>
+            failedUrls.push(url)
+          )
+        )
     );
-    const failedResponses = responses.filter((res) => res.status !== 200);
     expect(
-      failedResponses.length,
-      `License link broken for URLs: ${failedResponses
-        .map((response) => response.url)
-        .join(", ")}`
+      failedUrls.length,
+      `License link broken for URLs: ${failedUrls.join(", ")}`
     ).toBe(0);
   });
 });


### PR DESCRIPTION
This PR demonstrates the functionality of https://github.com/tiny-pilot/tinypilot/pull/1700
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1701"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>