### PR TITLE
Remove modifier attributes from on-screen keyboard keys

### DIFF
--- a/app/templates/custom-elements/key.html
+++ b/app/templates/custom-elements/key.html
@@ -63,6 +63,7 @@
 
 <script type="module">
   import { isModifierCode } from "/js/keycodes.js";
+
   (function () {
     const template = document.querySelector("#key-template");
 

--- a/app/templates/custom-elements/key.html
+++ b/app/templates/custom-elements/key.html
@@ -62,6 +62,7 @@
 </template>
 
 <script type="module">
+  import { isModifierCode } from "/js/keycodes.js";
   (function () {
     const template = document.querySelector("#key-template");
 
@@ -135,7 +136,7 @@
         }
 
         get isModifier() {
-          return this.getAttribute("modifier") === "true";
+          return isModifierCode(this.code);
         }
 
         get isPressed() {

--- a/app/templates/custom-elements/on-screen-keyboard.html
+++ b/app/templates/custom-elements/on-screen-keyboard.html
@@ -353,7 +353,8 @@
         }
 
         isModifierKeyPressed(keyCode) {
-          // Note: Only modifier keys can be "pressed" (i.e., pressed and held).
+          // Note: Only modifier keys can be considered "pressed" (i.e.,
+          // pressed and held).
           return (
             this.shadowRoot.querySelectorAll(
               `keyboard-key[code=${keyCode}][pressed=true]`

--- a/app/templates/custom-elements/on-screen-keyboard.html
+++ b/app/templates/custom-elements/on-screen-keyboard.html
@@ -220,8 +220,7 @@
       <!-- Row break -->
       <keyboard-key
         code="ShiftLeft"
-        modifier="true"
-        class="modifier accented"
+        class="accented"
         style="--span: 2.5"
         >Shift</keyboard-key
       >
@@ -246,39 +245,35 @@
       </keyboard-key>
       <keyboard-key
         code="ShiftRight"
-        modifier="true"
-        class="modifier accented"
+        class="accented"
         style="--span: 2.5"
         >Shift</keyboard-key
       >
       <!-- Row break -->
       <keyboard-key
         code="ControlLeft"
-        modifier="true"
-        class="modifier accented"
+        class="accented"
         style="--span: 2"
         >Control</keyboard-key
       >
       <keyboard-key
         code="MetaLeft"
-        modifier="true"
-        class="modifier accented"
+        class="accented"
         style="--span: 1.5"
         >Meta</keyboard-key
       >
-      <keyboard-key code="AltLeft" modifier="true" class="modifier accented"
+      <keyboard-key code="AltLeft" class="accented"
         >Alt</keyboard-key
       >
       <keyboard-key code="Space" class="key-space" style="--span: 4.5"
         >Space</keyboard-key
       >
-      <keyboard-key code="AltRight" modifier="true" class="modifier accented"
+      <keyboard-key code="AltRight" class="accented"
         >Alt</keyboard-key
       >
       <keyboard-key
         code="MetaRight"
-        modifier="true"
-        class="modifier accented"
+        class="accented"
         style="--span: 1.5"
         >Meta</keyboard-key
       >
@@ -291,8 +286,7 @@
       >
       <keyboard-key
         code="ControlRight"
-        modifier="true"
-        class="modifier accented"
+        class="accented"
         style="--span: 2"
         >Control</keyboard-key
       >
@@ -383,7 +377,7 @@
         isModifierKeyPressed(keyCode) {
           return (
             this.shadowRoot.querySelectorAll(
-              `.modifier[code=${keyCode}][pressed=true]`
+              `[code=${keyCode}][pressed=true]`
             ).length > 0
           );
         }
@@ -413,7 +407,7 @@
 
         clearPressedKeys() {
           this.shadowRoot
-            .querySelectorAll("[modifier=true][pressed=true]")
+            .querySelectorAll("[pressed=true]")
             .forEach((key) => {
               key.isPressed = false;
               this.emitKeyEvent("keyup", key.key, key.code);

--- a/app/templates/custom-elements/on-screen-keyboard.html
+++ b/app/templates/custom-elements/on-screen-keyboard.html
@@ -354,8 +354,9 @@
 
         isModifierKeyPressed(keyCode) {
           return (
-            this.shadowRoot.querySelectorAll(`[code=${keyCode}][pressed=true]`)
-              .length > 0
+            this.shadowRoot.querySelectorAll(
+              `keyboard-key[code=${keyCode}][pressed=true]`
+            ).length > 0
           );
         }
 
@@ -383,10 +384,12 @@
         }
 
         clearPressedKeys() {
-          this.shadowRoot.querySelectorAll("[pressed=true]").forEach((key) => {
-            key.isPressed = false;
-            this.emitKeyEvent("keyup", key.key, key.code);
-          });
+          this.shadowRoot
+            .querySelectorAll("keyboard-key[pressed=true]")
+            .forEach((key) => {
+              key.isPressed = false;
+              this.emitKeyEvent("keyup", key.key, key.code);
+            });
         }
 
         /**

--- a/app/templates/custom-elements/on-screen-keyboard.html
+++ b/app/templates/custom-elements/on-screen-keyboard.html
@@ -353,6 +353,7 @@
         }
 
         isModifierKeyPressed(keyCode) {
+          // Note: Only modifier keys can be "pressed" (i.e., pressed and held).
           return (
             this.shadowRoot.querySelectorAll(
               `keyboard-key[code=${keyCode}][pressed=true]`

--- a/app/templates/custom-elements/on-screen-keyboard.html
+++ b/app/templates/custom-elements/on-screen-keyboard.html
@@ -218,10 +218,7 @@
         >Enter</keyboard-key
       >
       <!-- Row break -->
-      <keyboard-key
-        code="ShiftLeft"
-        class="accented"
-        style="--span: 2.5"
+      <keyboard-key code="ShiftLeft" class="accented" style="--span: 2.5"
         >Shift</keyboard-key
       >
       <keyboard-key code="KeyZ">Z</keyboard-key>
@@ -243,38 +240,22 @@
         <slot>?</slot>
         <span slot="bottom">/</span>
       </keyboard-key>
-      <keyboard-key
-        code="ShiftRight"
-        class="accented"
-        style="--span: 2.5"
+      <keyboard-key code="ShiftRight" class="accented" style="--span: 2.5"
         >Shift</keyboard-key
       >
       <!-- Row break -->
-      <keyboard-key
-        code="ControlLeft"
-        class="accented"
-        style="--span: 2"
+      <keyboard-key code="ControlLeft" class="accented" style="--span: 2"
         >Control</keyboard-key
       >
-      <keyboard-key
-        code="MetaLeft"
-        class="accented"
-        style="--span: 1.5"
+      <keyboard-key code="MetaLeft" class="accented" style="--span: 1.5"
         >Meta</keyboard-key
       >
-      <keyboard-key code="AltLeft" class="accented"
-        >Alt</keyboard-key
-      >
+      <keyboard-key code="AltLeft" class="accented">Alt</keyboard-key>
       <keyboard-key code="Space" class="key-space" style="--span: 4.5"
         >Space</keyboard-key
       >
-      <keyboard-key code="AltRight" class="accented"
-        >Alt</keyboard-key
-      >
-      <keyboard-key
-        code="MetaRight"
-        class="accented"
-        style="--span: 1.5"
+      <keyboard-key code="AltRight" class="accented">Alt</keyboard-key>
+      <keyboard-key code="MetaRight" class="accented" style="--span: 1.5"
         >Meta</keyboard-key
       >
       <keyboard-key
@@ -284,10 +265,7 @@
         style="--span: 1.5"
         >Menu</keyboard-key
       >
-      <keyboard-key
-        code="ControlRight"
-        class="accented"
-        style="--span: 2"
+      <keyboard-key code="ControlRight" class="accented" style="--span: 2"
         >Control</keyboard-key
       >
     </div>
@@ -376,9 +354,8 @@
 
         isModifierKeyPressed(keyCode) {
           return (
-            this.shadowRoot.querySelectorAll(
-              `[code=${keyCode}][pressed=true]`
-            ).length > 0
+            this.shadowRoot.querySelectorAll(`[code=${keyCode}][pressed=true]`)
+              .length > 0
           );
         }
 
@@ -406,12 +383,10 @@
         }
 
         clearPressedKeys() {
-          this.shadowRoot
-            .querySelectorAll("[pressed=true]")
-            .forEach((key) => {
-              key.isPressed = false;
-              this.emitKeyEvent("keyup", key.key, key.code);
-            });
+          this.shadowRoot.querySelectorAll("[pressed=true]").forEach((key) => {
+            key.isPressed = false;
+            this.emitKeyEvent("keyup", key.key, key.code);
+          });
         }
 
         /**


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot/issues/1167

This PR simplifies the on-screen keyboard by removing redundant `modifier="true"` attribute and `modifier` class. The on-screen keyboard now only relies on the `isModifierCode` helper function as the single source of truth.

This PR is a non-functional change.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1704"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>