### PR TITLE
Fix keyboard state when browser window loses focus

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -244,11 +244,16 @@ document.addEventListener("video-streaming-mode-changed", (evt) => {
 // for example, then the browser would only receive the "keydown" event for Alt,
 // since the Tab press is intercepted by the operating system and switches focus
 // to another application. That way, the modifier key appears stuck on the
-// target machine. To avoid this, we release any modifier keycodes being pressed
-// when the browser window loses focus.
+// target machine.
+// For keycode combinations like Meta + L, which switches focus to the address
+// bar in Chrome, the browser would only receive the "keydown" events, since
+// the focus has exited the browser window and the "keyup" events are not
+// captured.
+// To avoid these situations, we release all keys being pressed when the
+// browser window loses focus.
 window.addEventListener("blur", () => {
   keyboardState
-    .getAllPressedModifierKeys()
+    .getAllPressedKeys()
     .forEach((keyCode) =>
       onKeyUp(new KeyboardEvent("keyup", { code: keyCode }))
     );

--- a/app/static/js/keyboardstate.js
+++ b/app/static/js/keyboardstate.js
@@ -83,9 +83,9 @@ export class KeyboardState {
   /**
    * @returns {string[]} An unordered array of canonical key codes.
    */
-  getAllPressedModifierKeys() {
+  getAllPressedKeys() {
     return Object.entries(this._isKeyPressed)
-      .filter(([keyCode, isPressed]) => isPressed && isModifierCode(keyCode))
+      .filter(([, isPressed]) => isPressed)
       .map(([keyCode]) => keyCode);
   }
 }

--- a/app/static/js/keyboardstate.test.js
+++ b/app/static/js/keyboardstate.test.js
@@ -42,22 +42,27 @@ describe("KeyboardState", () => {
     assert.strictEqual(false, keyboardState.isKeyPressed("AltRight"));
   });
 
-  describe("#getAllPressedModifierKeys()", () => {
-    it("should return an array of pressed modifier keys", () => {
+  describe("#getAllPressedKeys()", () => {
+    it("should return an array of pressed keys", () => {
       const keyboardState = new KeyboardState();
-      const event = {
+      keyboardState.onKeyDown({
         code: "KeyE",
         altKey: true,
         ctrlKey: true,
-      };
-      keyboardState.onKeyDown(event);
+      });
+      keyboardState.onKeyDown({
+        code: "KeyF",
+        altKey: true,
+        ctrlKey: true,
+      });
 
       assert.strictEqual(true, keyboardState.isKeyPressed("KeyE"));
       assert.strictEqual(true, keyboardState.isKeyPressed("AltLeft"));
       assert.strictEqual(true, keyboardState.isKeyPressed("ControlLeft"));
+      assert.strictEqual(true, keyboardState.isKeyPressed("KeyF"));
       assert.deepEqual(
-        new Set(["AltLeft", "ControlLeft"]),
-        new Set(keyboardState.getAllPressedModifierKeys())
+        new Set(["KeyE", "AltLeft", "ControlLeft", "KeyF"]),
+        new Set(keyboardState.getAllPressedKeys())
       );
     });
   });


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot/issues/1167

This PR fixes a minor bug in our keyboard state of currently pressed keys. I discovered this issue while exploring https://github.com/tiny-pilot/tinypilot/pull/1703.

The issue was that when I press <kbd>Meta</kbd> + <kbd>L</kbd> in chrome, the focus switches to the address bar and I release all keys, but the keyboard state still thinks `KeyL` is pressed.

I used https://github.com/tiny-pilot/tinypilot/pull/1705 to investigate the keyboard state.


<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1706"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>