### PR TITLE
Support multiple keycodes per HID keystroke

### DIFF
--- a/app/hid/keyboard.py
+++ b/app/hid/keyboard.py
@@ -4,7 +4,8 @@ from hid import write as hid_write
 def send_keystroke(keyboard_path, keystroke):
     buf = [0] * 8
     buf[0] = keystroke.modifier
-    buf[2] = keystroke.keycode
+    for i, keycode in enumerate(keystroke.keycodes, start=2):
+        buf[i] = keycode
     hid_write.write_to_hid_interface(keyboard_path, buf)
 
     # If it's a normal keycode (i.e. not a standalone modifier key), add a
@@ -14,7 +15,7 @@ def send_keystroke(keyboard_path, keystroke):
     # events. However, auto-releasing has the disadvantage of preventing
     # genuinely long key presses (see
     # https://github.com/tiny-pilot/tinypilot/issues/1093).
-    if keystroke.keycode:
+    if keystroke.keycodes:
         release_keys(keyboard_path)
 
 

--- a/app/hid/keyboard_test.py
+++ b/app/hid/keyboard_test.py
@@ -11,7 +11,7 @@ class KeyboardTest(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as input_file:
             keyboard.send_keystroke(
                 keyboard_path=input_file.name,
-                keystroke=hid.Keystroke(keycode=hid.KEYCODE_A),
+                keystroke=hid.Keystroke(keycodes=[hid.KEYCODE_A]),
             )
             input_file.seek(0)
             # Press the key then release the key.
@@ -23,7 +23,7 @@ class KeyboardTest(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as input_file:
             keyboard.send_keystroke(
                 keyboard_path=input_file.name,
-                keystroke=hid.Keystroke(keycode=hid.KEYCODE_NONE,
+                keystroke=hid.Keystroke(keycodes=[],
                                         modifier=hid.MODIFIER_LEFT_SHIFT),
             )
             input_file.seek(0)
@@ -36,7 +36,7 @@ class KeyboardTest(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as input_file:
             keyboard.send_keystroke(
                 keyboard_path=input_file.name,
-                keystroke=hid.Keystroke(keycode=hid.KEYCODE_A,
+                keystroke=hid.Keystroke(keycodes=[hid.KEYCODE_A],
                                         modifier=hid.MODIFIER_LEFT_SHIFT),
             )
             input_file.seek(0)
@@ -55,9 +55,9 @@ class KeyboardTest(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as input_file:
             keyboard.send_keystrokes(keyboard_path=input_file.name,
                                      keystrokes=[
-                                         hid.Keystroke(keycode=hid.KEYCODE_A),
-                                         hid.Keystroke(keycode=hid.KEYCODE_B),
-                                         hid.Keystroke(keycode=hid.KEYCODE_C)
+                                         hid.Keystroke(keycodes=[hid.KEYCODE_A]),
+                                         hid.Keystroke(keycodes=[hid.KEYCODE_B]),
+                                         hid.Keystroke(keycodes=[hid.KEYCODE_C])
                                      ])
             self.assertEqual(
                 b'\x00\x00\x04\x00\x00\x00\x00\x00'

--- a/app/hid/keyboard_test.py
+++ b/app/hid/keyboard_test.py
@@ -53,12 +53,13 @@ class KeyboardTest(unittest.TestCase):
 
     def test_send_multiple_keystrokes_to_hid_interface(self):
         with tempfile.NamedTemporaryFile() as input_file:
-            keyboard.send_keystrokes(keyboard_path=input_file.name,
-                                     keystrokes=[
-                                         hid.Keystroke(keycodes=[hid.KEYCODE_A]),
-                                         hid.Keystroke(keycodes=[hid.KEYCODE_B]),
-                                         hid.Keystroke(keycodes=[hid.KEYCODE_C])
-                                     ])
+            keyboard.send_keystrokes(
+                keyboard_path=input_file.name,
+                keystrokes=[
+                    hid.Keystroke(keycodes=[hid.KEYCODE_A]),
+                    hid.Keystroke(keycodes=[hid.KEYCODE_B]),
+                    hid.Keystroke(keycodes=[hid.KEYCODE_C])
+                ])
             self.assertEqual(
                 b'\x00\x00\x04\x00\x00\x00\x00\x00'
                 b'\x00\x00\x00\x00\x00\x00\x00\x00'

--- a/app/hid/keycodes.py
+++ b/app/hid/keycodes.py
@@ -1,4 +1,5 @@
 import dataclasses
+from typing import List
 
 # USB Usage ID values for the keycodes that TinyPilot can emit to the target
 # computer through the USB keyboard interface.
@@ -147,5 +148,5 @@ KEYCODE_REFRESH = 0xfa
 
 @dataclasses.dataclass
 class Keystroke:
-    keycode: int
+    keycodes: List[int] = list
     modifier: int = KEYCODE_NONE

--- a/app/js_to_hid.py
+++ b/app/js_to_hid.py
@@ -159,7 +159,7 @@ def convert(keystroke):
         UnrecognizedKeyCodeError: If the JavaScript-esque Keystroke's keycode is
             unrecognized.
     """
-    return hid.Keystroke(keycode=_map_keycode(keystroke),
+    return hid.Keystroke(keycodes=_map_keycodes(keystroke),
                          modifier=_map_modifier_keys(keystroke))
 
 
@@ -189,7 +189,7 @@ def _map_modifier_keys(keystroke):
     return modifier_bitmask
 
 
-def _map_keycode(keystroke):
+def _map_keycodes(keystroke):
     # If the current key press is a modifier key and it's the *only* modifier
     # being pressed, treat it as a special case where we remap the HID code to
     # KEYCODE_NONE. This is based on a report that certain KVMs only recognize
@@ -197,10 +197,10 @@ def _map_keycode(keystroke):
     # that it matches behavior from normal USB keyboards.
     if (keystroke.code in _MODIFIER_KEYCODES and
             _count_modifiers(keystroke) == 1):
-        return hid.KEYCODE_NONE
+        return []
 
     try:
-        return _MAPPING[keystroke.code]
+        return [_MAPPING[keystroke.code]]
     except KeyError as e:
         raise UnrecognizedKeyCodeError(
             f'Unrecognized key code {keystroke.key} {keystroke.code}') from e

--- a/app/js_to_hid_test.py
+++ b/app/js_to_hid_test.py
@@ -71,8 +71,8 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 key='Control',
                                 code='ControlLeft'))
         self.assertEqual(
-            hid.Keystroke(keycodes=[],
-                          modifier=hid.MODIFIER_LEFT_CTRL), hid_keystroke)
+            hid.Keystroke(keycodes=[], modifier=hid.MODIFIER_LEFT_CTRL),
+            hid_keystroke)
 
     def test_converts_right_ctrl_keystroke(self):
         hid_keystroke = js_to_hid.convert(
@@ -87,8 +87,8 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 key='Control',
                                 code='ControlRight'))
         self.assertEqual(
-            hid.Keystroke(keycodes=[],
-                          modifier=hid.MODIFIER_RIGHT_CTRL), hid_keystroke)
+            hid.Keystroke(keycodes=[], modifier=hid.MODIFIER_RIGHT_CTRL),
+            hid_keystroke)
 
     def test_converts_left_ctrl_with_shift_left_keystroke(self):
         hid_keystroke = js_to_hid.convert(

--- a/app/js_to_hid_test.py
+++ b/app/js_to_hid_test.py
@@ -19,7 +19,7 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 right_ctrl_modifier=False,
                                 key='a',
                                 code='KeyA'))
-        self.assertEqual(hid.Keystroke(keycode=hid.KEYCODE_A), hid_keystroke)
+        self.assertEqual(hid.Keystroke(keycodes=[hid.KEYCODE_A]), hid_keystroke)
 
     def test_converts_shifted_keystroke(self):
         hid_keystroke = js_to_hid.convert(
@@ -34,7 +34,7 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 key='A',
                                 code='KeyA'))
         self.assertEqual(
-            hid.Keystroke(keycode=hid.KEYCODE_A,
+            hid.Keystroke(keycodes=[hid.KEYCODE_A],
                           modifier=hid.MODIFIER_LEFT_SHIFT), hid_keystroke)
 
     def test_converts_keystroke_with_all_modifiers_pressed(self):
@@ -51,7 +51,7 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 code='KeyA'))
         self.assertEqual(
             hid.Keystroke(
-                keycode=hid.KEYCODE_A,
+                keycodes=[hid.KEYCODE_A],
                 modifier=(hid.MODIFIER_LEFT_META | hid.MODIFIER_RIGHT_META |
                           hid.MODIFIER_LEFT_ALT | hid.MODIFIER_RIGHT_ALT |
                           hid.MODIFIER_LEFT_SHIFT | hid.MODIFIER_RIGHT_SHIFT |
@@ -71,7 +71,7 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 key='Control',
                                 code='ControlLeft'))
         self.assertEqual(
-            hid.Keystroke(keycode=hid.KEYCODE_NONE,
+            hid.Keystroke(keycodes=[],
                           modifier=hid.MODIFIER_LEFT_CTRL), hid_keystroke)
 
     def test_converts_right_ctrl_keystroke(self):
@@ -87,7 +87,7 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 key='Control',
                                 code='ControlRight'))
         self.assertEqual(
-            hid.Keystroke(keycode=hid.KEYCODE_NONE,
+            hid.Keystroke(keycodes=[],
                           modifier=hid.MODIFIER_RIGHT_CTRL), hid_keystroke)
 
     def test_converts_left_ctrl_with_shift_left_keystroke(self):
@@ -103,7 +103,7 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 key='Control',
                                 code='ControlLeft'))
         self.assertEqual(
-            hid.Keystroke(keycode=hid.KEYCODE_LEFT_CTRL,
+            hid.Keystroke(keycodes=[hid.KEYCODE_LEFT_CTRL],
                           modifier=(hid.MODIFIER_LEFT_CTRL |
                                     hid.MODIFIER_LEFT_SHIFT)), hid_keystroke)
 

--- a/app/request_parsers/paste_test.py
+++ b/app/request_parsers/paste_test.py
@@ -16,9 +16,9 @@ class KeystrokesParserTest(unittest.TestCase):
 
     def test_accepts(self):
         self.assertEqual([
-            hid.Keystroke(keycode=hid.KEYCODE_A),
-            hid.Keystroke(keycode=hid.KEYCODE_B),
-            hid.Keystroke(keycode=hid.KEYCODE_C),
+            hid.Keystroke(keycodes=[hid.KEYCODE_A]),
+            hid.Keystroke(keycodes=[hid.KEYCODE_B]),
+            hid.Keystroke(keycodes=[hid.KEYCODE_C]),
         ],
                          paste.parse_keystrokes(
                              make_mock_request({
@@ -49,10 +49,10 @@ class KeystrokesParserTest(unittest.TestCase):
 
     def test_skips_ignored_character(self):
         self.assertEqual([
-            hid.Keystroke(keycode=hid.KEYCODE_NUMBER_1),
-            hid.Keystroke(keycode=hid.KEYCODE_NUMBER_2),
-            hid.Keystroke(keycode=hid.KEYCODE_ENTER),
-            hid.Keystroke(keycode=hid.KEYCODE_NUMBER_3),
+            hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_1]),
+            hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_2]),
+            hid.Keystroke(keycodes=[hid.KEYCODE_ENTER]),
+            hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_3]),
         ],
                          paste.parse_keystrokes(
                              make_mock_request({

--- a/app/text_to_hid.py
+++ b/app/text_to_hid.py
@@ -15,250 +15,250 @@ _COMMON_CHAR_TO_HID_MAP = {
     '\r':
         None,
     '\t':
-        hid.Keystroke(keycode=hid.KEYCODE_TAB),
+        hid.Keystroke(keycodes=[hid.KEYCODE_TAB]),
     '\n':
-        hid.Keystroke(keycode=hid.KEYCODE_ENTER),
+        hid.Keystroke(keycodes=[hid.KEYCODE_ENTER]),
     ' ':
-        hid.Keystroke(keycode=hid.KEYCODE_SPACEBAR),
+        hid.Keystroke(keycodes=[hid.KEYCODE_SPACEBAR]),
     '1':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_1),
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_1]),
     '2':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_2),
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_2]),
     '3':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_3),
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_3]),
     '4':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_4),
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_4]),
     '5':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_5),
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_5]),
     '6':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_6),
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_6]),
     '7':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_7),
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_7]),
     '8':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_8),
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_8]),
     '9':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_9),
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_9]),
     '0':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_0),
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_0]),
     '$':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_4,
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_4],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '!':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_1,
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_1],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '%':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_5,
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_5],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '^':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_6,
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_6],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '&':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_7,
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_7],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '*':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_8,
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_8],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '(':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_9,
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_9],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     ')':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_0,
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_0],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '_':
-        hid.Keystroke(keycode=hid.KEYCODE_MINUS,
+        hid.Keystroke(keycodes=[hid.KEYCODE_MINUS],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '-':
-        hid.Keystroke(keycode=hid.KEYCODE_MINUS),
+        hid.Keystroke(keycodes=[hid.KEYCODE_MINUS]),
     '+':
-        hid.Keystroke(keycode=hid.KEYCODE_EQUAL_SIGN,
+        hid.Keystroke(keycodes=[hid.KEYCODE_EQUAL_SIGN],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '=':
-        hid.Keystroke(keycode=hid.KEYCODE_EQUAL_SIGN),
+        hid.Keystroke(keycodes=[hid.KEYCODE_EQUAL_SIGN]),
     ':':
-        hid.Keystroke(keycode=hid.KEYCODE_SEMICOLON,
+        hid.Keystroke(keycodes=[hid.KEYCODE_SEMICOLON],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     ';':
-        hid.Keystroke(keycode=hid.KEYCODE_SEMICOLON),
+        hid.Keystroke(keycodes=[hid.KEYCODE_SEMICOLON]),
     'a':
-        hid.Keystroke(keycode=hid.KEYCODE_A),
+        hid.Keystroke(keycodes=[hid.KEYCODE_A]),
     'b':
-        hid.Keystroke(keycode=hid.KEYCODE_B),
+        hid.Keystroke(keycodes=[hid.KEYCODE_B]),
     'c':
-        hid.Keystroke(keycode=hid.KEYCODE_C),
+        hid.Keystroke(keycodes=[hid.KEYCODE_C]),
     'd':
-        hid.Keystroke(keycode=hid.KEYCODE_D),
+        hid.Keystroke(keycodes=[hid.KEYCODE_D]),
     'e':
-        hid.Keystroke(keycode=hid.KEYCODE_E),
+        hid.Keystroke(keycodes=[hid.KEYCODE_E]),
     'f':
-        hid.Keystroke(keycode=hid.KEYCODE_F),
+        hid.Keystroke(keycodes=[hid.KEYCODE_F]),
     'g':
-        hid.Keystroke(keycode=hid.KEYCODE_G),
+        hid.Keystroke(keycodes=[hid.KEYCODE_G]),
     'h':
-        hid.Keystroke(keycode=hid.KEYCODE_H),
+        hid.Keystroke(keycodes=[hid.KEYCODE_H]),
     'i':
-        hid.Keystroke(keycode=hid.KEYCODE_I),
+        hid.Keystroke(keycodes=[hid.KEYCODE_I]),
     'j':
-        hid.Keystroke(keycode=hid.KEYCODE_J),
+        hid.Keystroke(keycodes=[hid.KEYCODE_J]),
     'k':
-        hid.Keystroke(keycode=hid.KEYCODE_K),
+        hid.Keystroke(keycodes=[hid.KEYCODE_K]),
     'l':
-        hid.Keystroke(keycode=hid.KEYCODE_L),
+        hid.Keystroke(keycodes=[hid.KEYCODE_L]),
     'm':
-        hid.Keystroke(keycode=hid.KEYCODE_M),
+        hid.Keystroke(keycodes=[hid.KEYCODE_M]),
     'n':
-        hid.Keystroke(keycode=hid.KEYCODE_N),
+        hid.Keystroke(keycodes=[hid.KEYCODE_N]),
     'o':
-        hid.Keystroke(keycode=hid.KEYCODE_O),
+        hid.Keystroke(keycodes=[hid.KEYCODE_O]),
     'p':
-        hid.Keystroke(keycode=hid.KEYCODE_P),
+        hid.Keystroke(keycodes=[hid.KEYCODE_P]),
     'q':
-        hid.Keystroke(keycode=hid.KEYCODE_Q),
+        hid.Keystroke(keycodes=[hid.KEYCODE_Q]),
     'r':
-        hid.Keystroke(keycode=hid.KEYCODE_R),
+        hid.Keystroke(keycodes=[hid.KEYCODE_R]),
     's':
-        hid.Keystroke(keycode=hid.KEYCODE_S),
+        hid.Keystroke(keycodes=[hid.KEYCODE_S]),
     't':
-        hid.Keystroke(keycode=hid.KEYCODE_T),
+        hid.Keystroke(keycodes=[hid.KEYCODE_T]),
     'u':
-        hid.Keystroke(keycode=hid.KEYCODE_U),
+        hid.Keystroke(keycodes=[hid.KEYCODE_U]),
     'v':
-        hid.Keystroke(keycode=hid.KEYCODE_V),
+        hid.Keystroke(keycodes=[hid.KEYCODE_V]),
     'w':
-        hid.Keystroke(keycode=hid.KEYCODE_W),
+        hid.Keystroke(keycodes=[hid.KEYCODE_W]),
     'x':
-        hid.Keystroke(keycode=hid.KEYCODE_X),
+        hid.Keystroke(keycodes=[hid.KEYCODE_X]),
     'y':
-        hid.Keystroke(keycode=hid.KEYCODE_Y),
+        hid.Keystroke(keycodes=[hid.KEYCODE_Y]),
     'z':
-        hid.Keystroke(keycode=hid.KEYCODE_Z),
+        hid.Keystroke(keycodes=[hid.KEYCODE_Z]),
     'A':
-        hid.Keystroke(keycode=hid.KEYCODE_A, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_A], modifier=hid.MODIFIER_LEFT_SHIFT),
     'B':
-        hid.Keystroke(keycode=hid.KEYCODE_B, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_B], modifier=hid.MODIFIER_LEFT_SHIFT),
     'C':
-        hid.Keystroke(keycode=hid.KEYCODE_C, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_C], modifier=hid.MODIFIER_LEFT_SHIFT),
     'D':
-        hid.Keystroke(keycode=hid.KEYCODE_D, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_D], modifier=hid.MODIFIER_LEFT_SHIFT),
     'E':
-        hid.Keystroke(keycode=hid.KEYCODE_E, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_E], modifier=hid.MODIFIER_LEFT_SHIFT),
     'F':
-        hid.Keystroke(keycode=hid.KEYCODE_F, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_F], modifier=hid.MODIFIER_LEFT_SHIFT),
     'G':
-        hid.Keystroke(keycode=hid.KEYCODE_G, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_G], modifier=hid.MODIFIER_LEFT_SHIFT),
     'H':
-        hid.Keystroke(keycode=hid.KEYCODE_H, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_H], modifier=hid.MODIFIER_LEFT_SHIFT),
     'I':
-        hid.Keystroke(keycode=hid.KEYCODE_I, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_I], modifier=hid.MODIFIER_LEFT_SHIFT),
     'J':
-        hid.Keystroke(keycode=hid.KEYCODE_J, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_J], modifier=hid.MODIFIER_LEFT_SHIFT),
     'K':
-        hid.Keystroke(keycode=hid.KEYCODE_K, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_K], modifier=hid.MODIFIER_LEFT_SHIFT),
     'L':
-        hid.Keystroke(keycode=hid.KEYCODE_L, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_L], modifier=hid.MODIFIER_LEFT_SHIFT),
     'M':
-        hid.Keystroke(keycode=hid.KEYCODE_M, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_M], modifier=hid.MODIFIER_LEFT_SHIFT),
     'N':
-        hid.Keystroke(keycode=hid.KEYCODE_N, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_N], modifier=hid.MODIFIER_LEFT_SHIFT),
     'O':
-        hid.Keystroke(keycode=hid.KEYCODE_O, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_O], modifier=hid.MODIFIER_LEFT_SHIFT),
     'P':
-        hid.Keystroke(keycode=hid.KEYCODE_P, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_P], modifier=hid.MODIFIER_LEFT_SHIFT),
     'Q':
-        hid.Keystroke(keycode=hid.KEYCODE_Q, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_Q], modifier=hid.MODIFIER_LEFT_SHIFT),
     'R':
-        hid.Keystroke(keycode=hid.KEYCODE_R, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_R], modifier=hid.MODIFIER_LEFT_SHIFT),
     'S':
-        hid.Keystroke(keycode=hid.KEYCODE_S, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_S], modifier=hid.MODIFIER_LEFT_SHIFT),
     'T':
-        hid.Keystroke(keycode=hid.KEYCODE_T, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_T], modifier=hid.MODIFIER_LEFT_SHIFT),
     'U':
-        hid.Keystroke(keycode=hid.KEYCODE_U, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_U], modifier=hid.MODIFIER_LEFT_SHIFT),
     'V':
-        hid.Keystroke(keycode=hid.KEYCODE_V, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_V], modifier=hid.MODIFIER_LEFT_SHIFT),
     'W':
-        hid.Keystroke(keycode=hid.KEYCODE_W, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_W], modifier=hid.MODIFIER_LEFT_SHIFT),
     'X':
-        hid.Keystroke(keycode=hid.KEYCODE_X, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_X], modifier=hid.MODIFIER_LEFT_SHIFT),
     'Y':
-        hid.Keystroke(keycode=hid.KEYCODE_Y, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_Y], modifier=hid.MODIFIER_LEFT_SHIFT),
     'Z':
-        hid.Keystroke(keycode=hid.KEYCODE_Z, modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_Z], modifier=hid.MODIFIER_LEFT_SHIFT),
     ',':
-        hid.Keystroke(keycode=hid.KEYCODE_COMMA),
+        hid.Keystroke(keycodes=[hid.KEYCODE_COMMA]),
     '<':
-        hid.Keystroke(keycode=hid.KEYCODE_COMMA,
+        hid.Keystroke(keycodes=[hid.KEYCODE_COMMA],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '.':
-        hid.Keystroke(keycode=hid.KEYCODE_PERIOD),
+        hid.Keystroke(keycodes=[hid.KEYCODE_PERIOD]),
     '>':
-        hid.Keystroke(keycode=hid.KEYCODE_PERIOD,
+        hid.Keystroke(keycodes=[hid.KEYCODE_PERIOD],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '/':
-        hid.Keystroke(keycode=hid.KEYCODE_FORWARD_SLASH),
+        hid.Keystroke(keycodes=[hid.KEYCODE_FORWARD_SLASH]),
     '?':
-        hid.Keystroke(keycode=hid.KEYCODE_FORWARD_SLASH,
+        hid.Keystroke(keycodes=[hid.KEYCODE_FORWARD_SLASH],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '[':
-        hid.Keystroke(keycode=hid.KEYCODE_LEFT_BRACKET),
+        hid.Keystroke(keycodes=[hid.KEYCODE_LEFT_BRACKET]),
     '{':
-        hid.Keystroke(keycode=hid.KEYCODE_LEFT_BRACKET,
+        hid.Keystroke(keycodes=[hid.KEYCODE_LEFT_BRACKET],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     ']':
-        hid.Keystroke(keycode=hid.KEYCODE_RIGHT_BRACKET),
+        hid.Keystroke(keycodes=[hid.KEYCODE_RIGHT_BRACKET]),
     '}':
-        hid.Keystroke(keycode=hid.KEYCODE_RIGHT_BRACKET,
+        hid.Keystroke(keycodes=[hid.KEYCODE_RIGHT_BRACKET],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '\'':
-        hid.Keystroke(keycode=hid.KEYCODE_SINGLE_QUOTE),
+        hid.Keystroke(keycodes=[hid.KEYCODE_SINGLE_QUOTE]),
 }
 
 _US_CHAR_TO_HID_MAP = _COMMON_CHAR_TO_HID_MAP | {
     '@':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_2,
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_2],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '#':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_3,
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_3],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '~':
-        hid.Keystroke(keycode=hid.KEYCODE_ACCENT_GRAVE,
+        hid.Keystroke(keycodes=[hid.KEYCODE_ACCENT_GRAVE],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '`':
-        hid.Keystroke(keycode=hid.KEYCODE_ACCENT_GRAVE),
+        hid.Keystroke(keycodes=[hid.KEYCODE_ACCENT_GRAVE]),
     '\\':
-        hid.Keystroke(keycode=hid.KEYCODE_BACKSLASH),
+        hid.Keystroke(keycodes=[hid.KEYCODE_BACKSLASH]),
     '|':
-        hid.Keystroke(keycode=hid.KEYCODE_BACKSLASH,
+        hid.Keystroke(keycodes=[hid.KEYCODE_BACKSLASH],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '"':
-        hid.Keystroke(keycode=hid.KEYCODE_SINGLE_QUOTE,
+        hid.Keystroke(keycodes=[hid.KEYCODE_SINGLE_QUOTE],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
 }
 
 _GB_CHAR_TO_HID_MAP = _COMMON_CHAR_TO_HID_MAP | {
     '"':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_2,
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_2],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '£':
-        hid.Keystroke(keycode=hid.KEYCODE_NUMBER_3,
+        hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_3],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '\\':
-        hid.Keystroke(keycode=hid.KEYCODE_102ND),
+        hid.Keystroke(keycodes=[hid.KEYCODE_102ND]),
     '|':
-        hid.Keystroke(keycode=hid.KEYCODE_102ND,
+        hid.Keystroke(keycodes=[hid.KEYCODE_102ND],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '~':
-        hid.Keystroke(keycode=hid.KEYCODE_BACKSLASH,
+        hid.Keystroke(keycodes=[hid.KEYCODE_BACKSLASH],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '#':
-        hid.Keystroke(keycode=hid.KEYCODE_BACKSLASH,
+        hid.Keystroke(keycodes=[hid.KEYCODE_BACKSLASH],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '`':
-        hid.Keystroke(keycode=hid.KEYCODE_ACCENT_GRAVE),
+        hid.Keystroke(keycodes=[hid.KEYCODE_ACCENT_GRAVE]),
     '¬':
-        hid.Keystroke(keycode=hid.KEYCODE_ACCENT_GRAVE,
+        hid.Keystroke(keycodes=[hid.KEYCODE_ACCENT_GRAVE],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
     '@':
-        hid.Keystroke(keycode=hid.KEYCODE_SINGLE_QUOTE,
+        hid.Keystroke(keycodes=[hid.KEYCODE_SINGLE_QUOTE],
                       modifier=hid.MODIFIER_LEFT_SHIFT),
 }
 

--- a/app/text_to_hid.py
+++ b/app/text_to_hid.py
@@ -132,57 +132,83 @@ _COMMON_CHAR_TO_HID_MAP = {
     'z':
         hid.Keystroke(keycodes=[hid.KEYCODE_Z]),
     'A':
-        hid.Keystroke(keycodes=[hid.KEYCODE_A], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_A],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'B':
-        hid.Keystroke(keycodes=[hid.KEYCODE_B], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_B],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'C':
-        hid.Keystroke(keycodes=[hid.KEYCODE_C], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_C],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'D':
-        hid.Keystroke(keycodes=[hid.KEYCODE_D], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_D],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'E':
-        hid.Keystroke(keycodes=[hid.KEYCODE_E], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_E],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'F':
-        hid.Keystroke(keycodes=[hid.KEYCODE_F], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_F],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'G':
-        hid.Keystroke(keycodes=[hid.KEYCODE_G], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_G],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'H':
-        hid.Keystroke(keycodes=[hid.KEYCODE_H], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_H],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'I':
-        hid.Keystroke(keycodes=[hid.KEYCODE_I], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_I],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'J':
-        hid.Keystroke(keycodes=[hid.KEYCODE_J], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_J],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'K':
-        hid.Keystroke(keycodes=[hid.KEYCODE_K], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_K],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'L':
-        hid.Keystroke(keycodes=[hid.KEYCODE_L], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_L],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'M':
-        hid.Keystroke(keycodes=[hid.KEYCODE_M], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_M],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'N':
-        hid.Keystroke(keycodes=[hid.KEYCODE_N], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_N],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'O':
-        hid.Keystroke(keycodes=[hid.KEYCODE_O], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_O],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'P':
-        hid.Keystroke(keycodes=[hid.KEYCODE_P], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_P],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'Q':
-        hid.Keystroke(keycodes=[hid.KEYCODE_Q], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_Q],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'R':
-        hid.Keystroke(keycodes=[hid.KEYCODE_R], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_R],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'S':
-        hid.Keystroke(keycodes=[hid.KEYCODE_S], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_S],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'T':
-        hid.Keystroke(keycodes=[hid.KEYCODE_T], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_T],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'U':
-        hid.Keystroke(keycodes=[hid.KEYCODE_U], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_U],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'V':
-        hid.Keystroke(keycodes=[hid.KEYCODE_V], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_V],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'W':
-        hid.Keystroke(keycodes=[hid.KEYCODE_W], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_W],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'X':
-        hid.Keystroke(keycodes=[hid.KEYCODE_X], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_X],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'Y':
-        hid.Keystroke(keycodes=[hid.KEYCODE_Y], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_Y],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     'Z':
-        hid.Keystroke(keycodes=[hid.KEYCODE_Z], modifier=hid.MODIFIER_LEFT_SHIFT),
+        hid.Keystroke(keycodes=[hid.KEYCODE_Z],
+                      modifier=hid.MODIFIER_LEFT_SHIFT),
     ',':
         hid.Keystroke(keycodes=[hid.KEYCODE_COMMA]),
     '<':

--- a/app/text_to_hid_test.py
+++ b/app/text_to_hid_test.py
@@ -7,26 +7,26 @@ from hid import keycodes as hid
 class ConvertTextToHidTest(unittest.TestCase):
 
     def test_keystroke_without_modifier(self):
-        self.assertEqual(hid.Keystroke(keycode=hid.KEYCODE_A),
+        self.assertEqual(hid.Keystroke(keycodes=[hid.KEYCODE_A]),
                          text_to_hid.convert('a', 'en-US'))
 
     def test_keystroke_with_modifier(self):
         self.assertEqual(
-            hid.Keystroke(keycode=hid.KEYCODE_A,
+            hid.Keystroke(keycodes=[hid.KEYCODE_A],
                           modifier=hid.MODIFIER_LEFT_SHIFT),
             text_to_hid.convert('A', 'en-US'))
 
     def test_language_mapping(self):
         self.assertEqual(
-            hid.Keystroke(hid.KEYCODE_NUMBER_2, hid.MODIFIER_LEFT_SHIFT),
+            hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_2], modifier=hid.MODIFIER_LEFT_SHIFT),
             text_to_hid.convert('@', 'en-US'))
         self.assertEqual(
-            hid.Keystroke(hid.KEYCODE_SINGLE_QUOTE, hid.MODIFIER_LEFT_SHIFT),
+            hid.Keystroke(keycodes=[hid.KEYCODE_SINGLE_QUOTE], modifier=hid.MODIFIER_LEFT_SHIFT),
             text_to_hid.convert('@', 'en-GB'))
 
     def test_defaults_to_us_english_language_mapping(self):
         self.assertEqual(
-            hid.Keystroke(hid.KEYCODE_NUMBER_2, hid.MODIFIER_LEFT_SHIFT),
+            hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_2], modifier=hid.MODIFIER_LEFT_SHIFT),
             text_to_hid.convert('@', 'fake-language'))
 
     def test_raises_error_on_unsupported_character(self):

--- a/app/text_to_hid_test.py
+++ b/app/text_to_hid_test.py
@@ -18,15 +18,18 @@ class ConvertTextToHidTest(unittest.TestCase):
 
     def test_language_mapping(self):
         self.assertEqual(
-            hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_2], modifier=hid.MODIFIER_LEFT_SHIFT),
+            hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_2],
+                          modifier=hid.MODIFIER_LEFT_SHIFT),
             text_to_hid.convert('@', 'en-US'))
         self.assertEqual(
-            hid.Keystroke(keycodes=[hid.KEYCODE_SINGLE_QUOTE], modifier=hid.MODIFIER_LEFT_SHIFT),
+            hid.Keystroke(keycodes=[hid.KEYCODE_SINGLE_QUOTE],
+                          modifier=hid.MODIFIER_LEFT_SHIFT),
             text_to_hid.convert('@', 'en-GB'))
 
     def test_defaults_to_us_english_language_mapping(self):
         self.assertEqual(
-            hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_2], modifier=hid.MODIFIER_LEFT_SHIFT),
+            hid.Keystroke(keycodes=[hid.KEYCODE_NUMBER_2],
+                          modifier=hid.MODIFIER_LEFT_SHIFT),
             text_to_hid.convert('@', 'fake-language'))
 
     def test_raises_error_on_unsupported_character(self):


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot/issues/1167

This PR adds support for writing multiple keycode combinations to the HID by refactoring the HID `Keystroke` object to expect a list of keycodes instead of only a single keycode.

This PR is a non-functional change and currently we still only write a single keycode to the HID, but at least we can support writing more.

This is how the code was refactored:
1. Find and replace HID `Keystroke.keycode: int` with [`Keystroke.keycodes: List[int]`](https://github.com/tiny-pilot/tinypilot/blob/d12e94e02c9d019307387eae163c0704d7c5cc9d/app/hid/keycodes.py#L149-L152)
    1. Find: `r'keycode=([\w\.\\_]+)'`
    1. Replace: `r'keycodes=[$1]'`
3. Find and replace HID `Keystroke.keycodes=[KEYCODE_NONE]` with `Keystroke.keycodes=[]`
4. Map a JS keystroke to a list of keycodes
    1. `_map_keycode(keystroke): int` -> [`_map_keycodes(keystroke): List[int]`](https://github.com/tiny-pilot/tinypilot/blob/d12e94e02c9d019307387eae163c0704d7c5cc9d/app/js_to_hid.py#L192-L206)
7. Actually write multiple keycodes to the HID:
    https://github.com/tiny-pilot/tinypilot/blob/d12e94e02c9d019307387eae163c0704d7c5cc9d/app/hid/keyboard.py#L7-L8
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1707"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>