### PR TITLE
Silence stderr in tests

### DIFF
--- a/app/execute_test.py
+++ b/app/execute_test.py
@@ -13,11 +13,16 @@ import execute
 # processes[1], which pickles these functions[2]. So, they must be defined
 # using `def` at the top level of a module[3].
 #
+# Another by-effect of this is that the `silence_stderr` context manager
+# doesn’t have any effect on MacOS systems, so we cannot prevent the stacktrace
+# printing there.[4]
+#
 # This was observed on a 2021 Macbook Pro M1 Max running OSX Ventura 13.2.1.
 #
 # [1] https://github.com/python/cpython/commit/17a5588740b3d126d546ad1a13bdac4e028e6d50
 # [2] https://docs.python.org/3.9/library/multiprocessing.html#the-spawn-and-forkserver-start-methods
 # [3] https://docs.python.org/3.9/library/pickle.html#what-can-be-pickled-and-unpickled:~:text=(using%20def%2C%20not%20lambda)
+# [4] https://github.com/tiny-pilot/tinypilot/issues/1713
 
 
 def do_nothing():
@@ -39,6 +44,7 @@ def return_string():
 @contextlib.contextmanager
 def silence_stderr():
     """Silences stderr to avoid polluting the terminal output of the tests."""
+    # Note: on MacOS systems, this doesn’t have an effect (see comment above).
     with mock.patch('sys.stderr', io.StringIO()):
         yield None
 


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1642: our test output [is nice and tidy again](https://app.circleci.com/pipelines/github/tiny-pilot/tinypilot/4286/workflows/253f8f8b-b3af-47f8-82dc-b88e22d1122b/jobs/29448?invite=true#step-103-8652_129).

Contrary to what I initially mentioned in the ticket, one of the two stacktraces didn’t come from [`test_process_with_result_child_exception`](https://github.com/tiny-pilot/tinypilot/blob/cd3f5ff30a04659a750aec6dbf60ca49927f10f0/app/execute_test.py#L58-L71), which already had the “[stderr silencing](https://github.com/tiny-pilot/tinypilot/blob/cd3f5ff30a04659a750aec6dbf60ca49927f10f0/app/execute_test.py#L61)”, but rather from [`test_background_thread_ignores_function_exception`](https://github.com/tiny-pilot/tinypilot/blob/cd3f5ff30a04659a750aec6dbf60ca49927f10f0/app/execute_test.py#L99-L100). (I’ve updated the ticket accordingly.)

The “stderr silencing” technique is working fine, we just didn’t have it on the other two functions. These were added later, so we likely just forgot about this issue.

I’ve extracted a context manager function, to make it easier to discover and re-use this technique in the tests, and to avoid us having to repeat the explanatory comment + exact invocation again and again.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1708"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>