### PR TITLE
Exclude JavaScript test files from Debian package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 
 # Test files.
 **/*_test.py
+**/*.test.js
 
 /debian-pkg/Dockerfile
 /debian-pkg/releases/


### PR DESCRIPTION
I noticed that we forgot to exclude our (2 🙄) JavaScript test files from the Debian package. This PR fixes that.

# After

(1487 files total)

<img width="465" alt="Screenshot 2024-01-12 at 18 16 51" src="https://github.com/tiny-pilot/tinypilot/assets/83721279/3a58afd9-c957-482a-a430-06a7ccf7e4ec">

# Before

(1489 files total)

<img width="567" alt="Screenshot 2024-01-12 at 18 07 59" src="https://github.com/tiny-pilot/tinypilot/assets/83721279/97657a8a-6f2e-4084-98c2-535b6a1fe992">
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1717"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>