### PR TITLE
Switch libwebsockets license link to Github

### DIFF
--- a/app/license_notice.py
+++ b/app/license_notice.py
@@ -202,6 +202,11 @@ _LICENSE_METADATA = [
     LicenseMetadata(
         name='libwebsockets',
         homepage_url='https://libwebsockets.org',
+        # In the past, we used to link to the license that was hosted on the
+        # git mirror at libwebsockets.org/git. We repeatedly experienced
+        # outages of their website, however, so for reliability reasons, we now
+        # link to Github instead.
+        # (See https://github.com/tiny-pilot/tinypilot/pull/1727)
         license_url=
         'https://github.com/warmcat/libwebsockets/blob/v3.2.2/LICENSE',
     ),


### PR DESCRIPTION
The libwebsockets website is down, so our [end-to-end tests are currently broken](https://app.circleci.com/pipelines/github/tiny-pilot/tinypilot-pro/3814/workflows/dd6cf195-4597-48ff-a1a3-f796b80dcbc6/jobs/35466) due to that.

This happened one or two times in the past already, and [this comment from the libwebsocket maintainer](https://github.com/warmcat/libwebsockets/issues/3053) suggests that it might be more reliable for us to use Github for referencing the sources.

We can otherwise also wait a bit to see whether things may eventually settle.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1727"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>