### PR TITLE
Add privilege check to render-template script

### DIFF
--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -6,9 +6,6 @@ set -e
 # Exit on unset variable.
 set -u
 
-# Echo commands before executing them, by default to stderr.
-set -x
-
 readonly TINYPILOT_USER="tinypilot"
 readonly TINYPILOT_GROUP="tinypilot"
 readonly TINYPILOT_HOME_DIR="/home/${TINYPILOT_USER}"
@@ -65,23 +62,23 @@ MOUSE_PATH = '{{ tinypilot_mouse_interface }}'
 EOF
 )"
 readonly SETTINGS_TEMPLATE
-. venv/bin/activate && \
-  PYTHONPATH=/opt/tinypilot/app \
-    ./scripts/render-template \
+. venv/bin/activate
+PYTHONPATH=/opt/tinypilot/app \
+  ./scripts/render-template \
   <<< "${SETTINGS_TEMPLATE}" \
-  > "${TINYPILOT_APP_SETTINGS}" && \
-  deactivate
+  > "${TINYPILOT_APP_SETTINGS}"
+deactivate
 chown "${TINYPILOT_USER}:${TINYPILOT_GROUP}" "${TINYPILOT_APP_SETTINGS}"
 popd
 
 # Populate TinyPilot's NGINX config file.
 pushd /opt/tinypilot
-. venv/bin/activate && \
-  PYTHONPATH=/opt/tinypilot/app \
-    ./scripts/render-template \
+. venv/bin/activate
+PYTHONPATH=/opt/tinypilot/app \
+  ./scripts/render-template \
   < /usr/share/tinypilot/templates/tinypilot.conf.j2 \
-  > /etc/nginx/conf.d/tinypilot.conf && \
-  deactivate
+  > /etc/nginx/conf.d/tinypilot.conf
+deactivate
 popd
 
 # Workaround to restore the default NGINX config that has been previously
@@ -113,12 +110,12 @@ if grep --silent '^dtoverlay=tc358743$' "${BOOT_CONFIG_PATH}" ; then
   # Populate TinyPilot's EDID.
   mkdir -p /home/ustreamer/edids
   pushd /opt/tinypilot
-  . venv/bin/activate && \
-    PYTHONPATH=/opt/tinypilot/app \
-      ./scripts/render-template \
+  . venv/bin/activate
+  PYTHONPATH=/opt/tinypilot/app \
+    ./scripts/render-template \
     <<< '{{ ustreamer_edid }}' \
-    > /home/ustreamer/edids/tc358743-edid.hex && \
-    deactivate
+    > /home/ustreamer/edids/tc358743-edid.hex
+  deactivate
   chmod 0644 /home/ustreamer/edids/tc358743-edid.hex
   popd
 fi

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -6,6 +6,9 @@ set -e
 # Exit on unset variable.
 set -u
 
+# Echo commands before executing them, by default to stderr.
+set -x
+
 readonly TINYPILOT_USER="tinypilot"
 readonly TINYPILOT_GROUP="tinypilot"
 readonly TINYPILOT_HOME_DIR="/home/${TINYPILOT_USER}"
@@ -62,23 +65,23 @@ MOUSE_PATH = '{{ tinypilot_mouse_interface }}'
 EOF
 )"
 readonly SETTINGS_TEMPLATE
-. venv/bin/activate && \
-  PYTHONPATH=/opt/tinypilot/app \
-    ./scripts/render-template \
+. venv/bin/activate
+PYTHONPATH=/opt/tinypilot/app \
+  ./scripts/render-template \
   <<< "${SETTINGS_TEMPLATE}" \
-  > "${TINYPILOT_APP_SETTINGS}" && \
-  deactivate
+  > "${TINYPILOT_APP_SETTINGS}"
+deactivate
 chown "${TINYPILOT_USER}:${TINYPILOT_GROUP}" "${TINYPILOT_APP_SETTINGS}"
 popd
 
 # Populate TinyPilot's NGINX config file.
 pushd /opt/tinypilot
-. venv/bin/activate && \
-  PYTHONPATH=/opt/tinypilot/app \
-    ./scripts/render-template \
+. venv/bin/activate
+PYTHONPATH=/opt/tinypilot/app \
+  ./scripts/render-template \
   < /usr/share/tinypilot/templates/tinypilot.conf.j2 \
-  > /etc/nginx/conf.d/tinypilot.conf && \
-  deactivate
+  > /etc/nginx/conf.d/tinypilot.conf
+deactivate
 popd
 
 # Workaround to restore the default NGINX config that has been previously
@@ -110,12 +113,12 @@ if grep --silent '^dtoverlay=tc358743$' "${BOOT_CONFIG_PATH}" ; then
   # Populate TinyPilot's EDID.
   mkdir -p /home/ustreamer/edids
   pushd /opt/tinypilot
-  . venv/bin/activate && \
-    PYTHONPATH=/opt/tinypilot/app \
-      ./scripts/render-template \
+  . venv/bin/activate
+  PYTHONPATH=/opt/tinypilot/app \
+    ./scripts/render-template \
     <<< '{{ ustreamer_edid }}' \
-    > /home/ustreamer/edids/tc358743-edid.hex && \
-    deactivate
+    > /home/ustreamer/edids/tc358743-edid.hex
+  deactivate
   chmod 0644 /home/ustreamer/edids/tc358743-edid.hex
   popd
 fi

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -6,6 +6,9 @@ set -e
 # Exit on unset variable.
 set -u
 
+# Echo commands before executing them, by default to stderr.
+set -x
+
 readonly TINYPILOT_USER="tinypilot"
 readonly TINYPILOT_GROUP="tinypilot"
 readonly TINYPILOT_HOME_DIR="/home/${TINYPILOT_USER}"

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -6,9 +6,6 @@ set -e
 # Exit on unset variable.
 set -u
 
-# Echo commands before executing them, by default to stderr.
-set -x
-
 readonly TINYPILOT_USER="tinypilot"
 readonly TINYPILOT_GROUP="tinypilot"
 readonly TINYPILOT_HOME_DIR="/home/${TINYPILOT_USER}"
@@ -65,23 +62,23 @@ MOUSE_PATH = '{{ tinypilot_mouse_interface }}'
 EOF
 )"
 readonly SETTINGS_TEMPLATE
-. venv/bin/activate
-PYTHONPATH=/opt/tinypilot/app \
-  ./scripts/render-template \
+. venv/bin/activate && \
+  PYTHONPATH=/opt/tinypilot/app \
+    ./scripts/render-template \
   <<< "${SETTINGS_TEMPLATE}" \
-  > "${TINYPILOT_APP_SETTINGS}"
-deactivate
+  > "${TINYPILOT_APP_SETTINGS}" && \
+  deactivate
 chown "${TINYPILOT_USER}:${TINYPILOT_GROUP}" "${TINYPILOT_APP_SETTINGS}"
 popd
 
 # Populate TinyPilot's NGINX config file.
 pushd /opt/tinypilot
-. venv/bin/activate
-PYTHONPATH=/opt/tinypilot/app \
-  ./scripts/render-template \
+. venv/bin/activate && \
+  PYTHONPATH=/opt/tinypilot/app \
+    ./scripts/render-template \
   < /usr/share/tinypilot/templates/tinypilot.conf.j2 \
-  > /etc/nginx/conf.d/tinypilot.conf
-deactivate
+  > /etc/nginx/conf.d/tinypilot.conf && \
+  deactivate
 popd
 
 # Workaround to restore the default NGINX config that has been previously
@@ -113,12 +110,12 @@ if grep --silent '^dtoverlay=tc358743$' "${BOOT_CONFIG_PATH}" ; then
   # Populate TinyPilot's EDID.
   mkdir -p /home/ustreamer/edids
   pushd /opt/tinypilot
-  . venv/bin/activate
-  PYTHONPATH=/opt/tinypilot/app \
-    ./scripts/render-template \
+  . venv/bin/activate && \
+    PYTHONPATH=/opt/tinypilot/app \
+      ./scripts/render-template \
     <<< '{{ ustreamer_edid }}' \
-    > /home/ustreamer/edids/tc358743-edid.hex
-  deactivate
+    > /home/ustreamer/edids/tc358743-edid.hex && \
+    deactivate
   chmod 0644 /home/ustreamer/edids/tc358743-edid.hex
   popd
 fi

--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -63,8 +63,8 @@ EOF
 )"
 readonly SETTINGS_TEMPLATE
 . venv/bin/activate
-PYTHONPATH=/opt/tinypilot/app \
-  ./scripts/render-template \
+runuser tinypilot \
+  --command 'PYTHONPATH=/opt/tinypilot/app ./scripts/render-template' \
   <<< "${SETTINGS_TEMPLATE}" \
   > "${TINYPILOT_APP_SETTINGS}"
 deactivate
@@ -74,8 +74,8 @@ popd
 # Populate TinyPilot's NGINX config file.
 pushd /opt/tinypilot
 . venv/bin/activate
-PYTHONPATH=/opt/tinypilot/app \
-  ./scripts/render-template \
+runuser tinypilot \
+  --command 'PYTHONPATH=/opt/tinypilot/app ./scripts/render-template' \
   < /usr/share/tinypilot/templates/tinypilot.conf.j2 \
   > /etc/nginx/conf.d/tinypilot.conf
 deactivate
@@ -111,8 +111,8 @@ if grep --silent '^dtoverlay=tc358743$' "${BOOT_CONFIG_PATH}" ; then
   mkdir -p /home/ustreamer/edids
   pushd /opt/tinypilot
   . venv/bin/activate
-  PYTHONPATH=/opt/tinypilot/app \
-    ./scripts/render-template \
+  runuser tinypilot \
+    --command 'PYTHONPATH=/opt/tinypilot/app ./scripts/render-template' \
     <<< '{{ ustreamer_edid }}' \
     > /home/ustreamer/edids/tc358743-edid.hex
   deactivate

--- a/debian-pkg/opt/tinypilot-privileged/scripts/configure-janus
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/configure-janus
@@ -34,10 +34,10 @@ done
 
 # Generate and write config file from template.
 pushd /opt/tinypilot
-. venv/bin/activate && \
-  PYTHONPATH=/opt/tinypilot/app \
-    ./scripts/render-template \
+. venv/bin/activate
+PYTHONPATH=/opt/tinypilot/app \
+  ./scripts/render-template \
   < /usr/share/tinypilot/templates/janus.jcfg.j2 \
-  > /etc/janus/janus.jcfg && \
-  deactivate
+  > /etc/janus/janus.jcfg
+deactivate
 popd

--- a/debian-pkg/opt/tinypilot-privileged/scripts/configure-janus
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/configure-janus
@@ -35,8 +35,8 @@ done
 # Generate and write config file from template.
 pushd /opt/tinypilot
 . venv/bin/activate
-PYTHONPATH=/opt/tinypilot/app \
-  ./scripts/render-template \
+runuser tinypilot \
+  --command 'PYTHONPATH=/opt/tinypilot/app ./scripts/render-template' \
   < /usr/share/tinypilot/templates/janus.jcfg.j2 \
   > /etc/janus/janus.jcfg
 deactivate

--- a/scripts/render-template
+++ b/scripts/render-template
@@ -28,9 +28,11 @@ def main(_):
 
 
 if os.geteuid() == 0:
-    print('This script doesn\'t require root privileges.', file=sys.stderr)
+    print("This script doesn't require root privileges.", file=sys.stderr)
     print('Please re-run as tinypilot:', file=sys.stderr)
-    print('  sudo su tinypilot', ''.join(sys.argv), file=sys.stderr)
+    print('  runuser tinypilot --command',
+          f"'{' '.join(sys.argv)}'",
+          file=sys.stderr)
     sys.exit(1)
 
 if __name__ == '__main__':

--- a/scripts/render-template
+++ b/scripts/render-template
@@ -13,6 +13,7 @@ EOF
 # pylint:disable=invalid-name
 
 import argparse
+import os
 import sys
 
 import jinja2
@@ -25,6 +26,12 @@ def main(_):
 
     print(jinja2.Template(sys.stdin.read()).render(settings.as_dict()))
 
+
+if os.geteuid() == 0:
+    print('This script doesn\'t require root privileges.', file=sys.stderr)
+    print('Please re-run as tinypilot:', file=sys.stderr)
+    print('  sudo su tinypilot', ''.join(sys.argv), file=sys.stderr)
+    sys.exit(1)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(

--- a/scripts/render-template
+++ b/scripts/render-template
@@ -27,6 +27,8 @@ def main(_):
     print(jinja2.Template(sys.stdin.read()).render(settings.as_dict()))
 
 
+# Ensure that the script doesn't have unnecessary privileges.
+# https://github.com/tiny-pilot/tinypilot-pro/issues/1190
 if os.geteuid() == 0:
     print("This script doesn't require root privileges.", file=sys.stderr)
     print('Please re-run as tinypilot:', file=sys.stderr)

--- a/scripts/render-template
+++ b/scripts/render-template
@@ -27,17 +27,17 @@ def main(_):
     print(jinja2.Template(sys.stdin.read()).render(settings.as_dict()))
 
 
-# Ensure that the script doesn't have unnecessary privileges.
-# https://github.com/tiny-pilot/tinypilot-pro/issues/1190
-if os.geteuid() == 0:
-    print("This script doesn't require root privileges.", file=sys.stderr)
-    print('Please re-run as tinypilot:', file=sys.stderr)
-    print('  runuser tinypilot --command',
-          f"'{' '.join(sys.argv)}'",
-          file=sys.stderr)
-    sys.exit(1)
-
 if __name__ == '__main__':
+    # Ensure that the script doesn't have unnecessary privileges.
+    # https://github.com/tiny-pilot/tinypilot-pro/issues/1190
+    if os.geteuid() == 0:
+        print("This script doesn't require root privileges.", file=sys.stderr)
+        print('Please re-run as tinypilot:', file=sys.stderr)
+        print('  runuser tinypilot --command',
+              f"'{' '.join(sys.argv)}'",
+              file=sys.stderr)
+        sys.exit(1)
+
     parser = argparse.ArgumentParser(
         prog='TinyPilot Template Renderer',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot-pro/issues/1190

Please refer to https://github.com/tiny-pilot/tinypilot-pro/issues/1190#issue-2094765706 for PR rationale.

Executing the `render-template` script with root privileges with now fail. For example, as part of the TinyPilot installation:

```bash
$ apt-get install -y ./tinypilot_20240128105411_armhf.deb
...
Preparing to unpack .../tinypilot_20240128105411_armhf.deb ...
Unpacking tinypilot (20240128105411) over (20240128094116) ...
Setting up tinypilot (20240128105411) ...
Warning: The home dir /home/tinypilot you specified already exists.
The system user `tinypilot' already exists. Exiting.
/opt/tinypilot /

This script doesn't require root privileges.
Please re-run as tinypilot:
  runuser tinypilot --command './scripts/render-template'

dpkg: error processing package tinypilot (--configure):
 installed tinypilot package post-installation script subprocess returned error exit status 1
Errors were encountered while processing:
 tinypilot
E: Sub-process /usr/bin/dpkg returned an error code (1)
+ clean_up
+ umount --lazy /mnt/tinypilot-installer
+ rm -rf /opt/tinypilot-updater /mnt/tinypilot-installer
```

## Notes

1. We had to expand the previously used `render-template` command into multiple independent commands because the exit code was being ignored/swallowed.
1. To execute `render-template` as the `tinypilot` user, we use the `runuser` command instead of `su`. Based on the [`runuser` manual](https://man7.org/linux/man-pages/man1/runuser.1.html), `runuser` can only be used by root users which is currently the only way we use `render-template`:

    > The difference between the commands `runuser` and `su` is that `runuser` does not ask
    > for a password (because it may be executed by the root user only)
    > and it uses a different PAM configuration.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1728"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>