### PR TITLE
Conditionally load EDID on device with TC358743 capture chip

### DIFF
--- a/debian-pkg/debian/tinypilot.load-tc358743-edid.service
+++ b/debian-pkg/debian/tinypilot.load-tc358743-edid.service
@@ -10,6 +10,7 @@ Type=oneshot
 User=root
 ExecCondition=grep \
   --regexp '^dtoverlay=tc358743$' \
+  --silent \
   /boot/config.txt
 ExecStart=v4l2-ctl \
   --set-edid=file=/home/ustreamer/edids/tc358743-edid.hex \

--- a/debian-pkg/debian/tinypilot.load-tc358743-edid.service
+++ b/debian-pkg/debian/tinypilot.load-tc358743-edid.service
@@ -8,6 +8,9 @@ StartLimitBurst=20
 [Service]
 Type=oneshot
 User=root
+ExecCondition=grep \
+  --regexp '^dtoverlay=tc358743$' \
+  /boot/config.txt
 ExecStart=v4l2-ctl \
   --set-edid=file=/home/ustreamer/edids/tc358743-edid.hex \
   --fix-edid-checksums


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1726

This PR only starts the `load-tc358743-edid.service` when a TC358743 capture chip is installed. This change avoids reporting the service as "failed" when a TC358743 capture chip is not installed on the device.

**Caveat:** The `load-tc358743-edid.service` process is still marked as `(code=exited, status=1/FAILURE)`, but it's active state is no longer `failed (Result: exit-code)`. Instead, its active state is `inactive (dead) (Result: exec-condition)`.

Example output of service being skipped:
```
Jan 28 18:41:02 raspberrypi systemd[1]: Starting Load EDID for TC358743 HDMI capture chip....
Jan 28 18:41:02 raspberrypi systemd[1]: load-tc358743-edid.service: Control process exited, code=exited, status=1/FAILURE
Jan 28 18:41:02 raspberrypi systemd[1]: load-tc358743-edid.service: Skipped due to 'exec-condition'.
Jan 28 18:41:02 raspberrypi systemd[1]: Condition check resulted in Load EDID for TC358743 HDMI capture chip. being skipped.
```

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1730"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>