### PR TITLE
Add instructions for viewing style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,6 +227,12 @@ TinyPilot accepts various options through environment variables:
 
 See [tinypilot/style-guides](https://github.com/tiny-pilot/style-guides).
 
+## User interface style guide
+
+We document UI patterns and components in a style guide, to maintain a consistent user experience throughout the web application.
+
+After launching TinyPilot in debug mode, the style guide is available at [localhost:8000/styleguide](http://localhost:8000/styleguide).
+
 ## Web Components Conventions
 
 TinyPilot implements most of its UI components through standard JavaScript, using [web components](https://css-tricks.com/an-introduction-to-web-components/). TinyPilot does not use any heavy frontend frameworks like Angular or React, nor does it use any broad libraries such as jQuery.

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -1,5 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
+  <!-- This page is available when you launch TinyPilot in debug mode by running
+
+           ./dev-scripts/serve-dev
+
+       The page will be available at:
+
+           http://localhost:8000/styleguide -->
   <head>
     <meta charset="utf-8" />
     <title>TinyPilot Styleguide</title>


### PR DESCRIPTION
I realized we don't really explain how the user should view the style guide, so I added a brief comment on the top explaining how to view the style guide in the browser.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1736"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>