### PR TITLE
Reference style guide from CONTRIBUTING doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,6 +227,12 @@ TinyPilot accepts various options through environment variables:
 
 See [tinypilot/style-guides](https://github.com/tiny-pilot/style-guides).
 
+## User interface style guide
+
+We document UI patterns and components in a style guide, to maintain a consistent user experience throughout the web application. 
+
+After launching TinyPilot in debug mode, the style guide is available at [localhost:8000/styleguide](http://localhost:8000/styleguide).
+
 ## Web Components Conventions
 
 TinyPilot implements most of its UI components through standard JavaScript, using [web components](https://css-tricks.com/an-introduction-to-web-components/). TinyPilot does not use any heavy frontend frameworks like Angular or React, nor does it use any broad libraries such as jQuery.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,7 +229,7 @@ See [tinypilot/style-guides](https://github.com/tiny-pilot/style-guides).
 
 ## User interface style guide
 
-We document UI patterns and components in a style guide, to maintain a consistent user experience throughout the web application. 
+We document UI patterns and components in a style guide, to maintain a consistent user experience throughout the web application.
 
 After launching TinyPilot in debug mode, the style guide is available at [localhost:8000/styleguide](http://localhost:8000/styleguide).
 


### PR DESCRIPTION
Related to (and stacked on) https://github.com/tiny-pilot/tinypilot/pull/1736, I thought we could also add a style guide reference to the CONTRIBUTING doc.

Note that we are not consistent with title case vs. non-title case for headlines in that CONTRIBUTING doc. Most headlines  don’t seem to use it, so I’ve followed that for consistency.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1737"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>