### PR TITLE
Backport documentation updates from TinyPilot Pro

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ For TinyPilot Pro, CircleCI prevents anonymous downloads of CircleCI artifacts. 
 
 1. Download the bundle file from CircleCI.
 1. Upload the bundle file to TinyPilot's PicoShare server.
-   - https://p.tinypilotkvm.com/g/5PbZ3L4qbFyyKmo9
+   - [See this (org-private) Wiki page for our internal sharing URL](https://github.com/tiny-pilot/tinypilot-pro/wiki/PicoShare-Server-for-Uploading-Dev-Bundles).
 1. Copy the PicoShare URL for the TinyPilot bundle.
 
 In order to install a TinyPilot bundle on device, run the following command:


### PR DESCRIPTION
While reviewing https://github.com/tiny-pilot/tinypilot/pull/1736, I noticed that the CONTRIBUTING doc differs between Community and Pro.

I believe that we accidentally updated the Pro doc, where we meant to update the Community one instead. (We actually even cover Community in the new text, see L165.)

The respective changes originally came from https://github.com/tiny-pilot/tinypilot-pro/pull/985/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055, when we faded out Ansible. I’ve copy&pasted everything over verbatim, except for the (now-invalidated) PicoShare URL, which I’ve swapped in favour of a Wiki page.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1738"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>