### PR TITLE
Revise bug template for better feedback

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,12 +30,16 @@ _If applicable, add screenshots to help explain your problem._
 
 ## Capture hardware
 
-If your issue relates to video capture, please report which HDMI capture device you're using, e.g., "MacroSilicon MS2109 HDMI to USB". Refer to the capture device wiki if you're unsure: https://github.com/tiny-pilot/tinypilot/wiki/HDMI-Capture-Devices
+If your issue relates to video capture, please report which HDMI capture device you're using (e.g., "MacroSilicon MS2109 HDMI to USB"). Refer to the capture device wiki if you're unsure: https://github.com/tiny-pilot/tinypilot/wiki/HDMI-Capture-Devices
 
 ## Logs
 
 Please share a link to a TinyPilot log for review.
 
-If you have access to the TinyPilot web interface, navigate to _System > Logs_ in the menu and click _Get Shareable URL_ to copy the URL. Please paste the URL.
+If you have access to the TinyPilot web interface, navigate to _System > Logs_ in the menu and click _Get Shareable URL_ to copy the URL.
 
-If you don't have access to the TinyPilot web interface, please share the URL you see when you run `sudo /opt/tinypilot-privileged/collect-debug-logs`
+If you don't have access to the TinyPilot web interface, please share the URL you see when you run:
+
+```
+sudo /opt/tinypilot-privileged/collect-debug-logs
+```

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,12 +30,12 @@ _If applicable, add screenshots to help explain your problem._
 
 ## Capture hardware
 
-If your issue relates to video capture, please report which HDMI capture device you're using, e.g., "MacroSilicon MS2109 HDMI to USB". You can refer to the [wiki](https://github.com/tiny-pilot/tinypilot/wiki/HDMI-Capture-Devices) if you're unsure.
+If your issue relates to video capture, please report which HDMI capture device you're using, e.g., "MacroSilicon MS2109 HDMI to USB". Refer to the capture device wiki if you're unsure: https://github.com/tiny-pilot/tinypilot/wiki/HDMI-Capture-Devices
 
 ## Logs
 
-Please share a TinyPilot log for review.
+Please share a link to a TinyPilot log for review.
 
-If you have access to the TinyPilot web interface, navigate to _System > Logs_ in the menu and click _Get Shareable URL_. Please paste the URL: `https://logs.tinypilotkvm.com/...`
+If you have access to the TinyPilot web interface, navigate to _System > Logs_ in the menu and click _Get Shareable URL_ to copy the URL. Please paste the URL.
 
 If you don't have access to the TinyPilot web interface, please share the URL you see when you run `sudo /opt/tinypilot-privileged/collect-debug-logs`

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,6 +28,14 @@ _Your answer_
 
 _If applicable, add screenshots to help explain your problem._
 
+## Capture hardware
+
+If your issue relates to video capture, please report which HDMI capture device you're using, e.g., "MacroSilicon MS2109 HDMI to USB". You can refer to the [wiki](https://github.com/tiny-pilot/tinypilot/wiki/HDMI-Capture-Devices) if you're unsure.
+
 ## Logs
 
-Please paste the URL you see when you run `/opt/tinypilot/dev-scripts/dump-logs`
+Please share a TinyPilot log for review.
+
+If you have access to the TinyPilot web interface, navigate to _System > Logs_ in the menu and click _Get Shareable URL_. Please paste the URL: `https://logs.tinypilotkvm.com/...`
+
+If you don't have access to the TinyPilot web interface, please share the URL you see when you run `sudo /opt/tinypilot-privileged/collect-debug-logs`


### PR DESCRIPTION
Resolves #1732 

This change updates the bug template to fix the command for collecting a log, add instructions for retrieving a log on the TinyPilot web interface, and add a section asking for video capture hardware (if applicable).
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1740"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>