### PR TITLE
Remove legacy upgrade script

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ See the [CONTRIBUTING](CONTRIBUTING.md) file.
 To update to the latest version of TinyPilot, run the update script:
 
 ```bash
-/opt/tinypilot/scripts/upgrade && sudo reboot
+sudo /opt/tinypilot-privileged/scripts/update && sudo reboot
 ```
 
 ## Diagnostics

--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -44,7 +44,7 @@ if [[ "${HAS_PRO_INSTALLED}" = 1 ]]; then
     printf "Community Edition.\n\n"
     printf "You probably want to update to the latest version of TinyPilot "
     printf "Pro instead:\n\n"
-    printf "  /opt/tinypilot/scripts/upgrade && sudo reboot\n"
+    printf "  sudo /opt/tinypilot-privileged/scripts/update && sudo reboot\n"
     printf "\n"
     printf "If you *really* want to downgrade to TinyPilot Community Edition, "
     printf "type the following:\n\n"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# The canonical way to update is through the update script below,
-# but this file is here for backwards compatibility.
-
-# Without this file, we have no way of giving users an update command
-# that will work regardless of TinyPilot version.
-
-sudo /opt/tinypilot-privileged/scripts/update


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot-pro/issues/1214

Based on our efforts to mitigate privilege escalation, the `scripts/upgrade` script was identified as both tinypilot-writeable and requiring root privileges. However, this script is now considered legacy and can be removed because [it was only needed at a time when TinyPilot could only be updated via the terminal](https://codeapprove.com/pr/tiny-pilot/tinypilot/1743#thread-5433ea94-c337-4b07-a1cd-20651c032dd5).

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1744"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>