### PR TITLE
Define standard CircleCI executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ executors:
   python:
     docker:
       - image: cimg/python:3.9.17
+  node:
+    docker:
+      - image: cimg/node:18.16.1
 jobs:
   check_whitespace:
     executor: ubuntu
@@ -49,8 +52,7 @@ jobs:
             pip install --requirement dev_requirements.txt
             ./dev-scripts/lint-sql
   check_style:
-    docker:
-      - image: cimg/node:18.16.1
+    executor: node
     steps:
       - checkout
       - run:
@@ -90,8 +92,7 @@ jobs:
             pip install --requirement dev_requirements.txt
             ./dev-scripts/build-python
   build_javascript:
-    docker:
-      - image: cimg/node:18.16.1
+    executor: node
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,7 @@ jobs:
           command: sudo apt-get update
       - run:
           name: Install lintian
-          command: sudo apt-get install -y lintian
+          command: sudo apt-get install -y lintian=2.114.0ubuntu1
       - run:
           name: Print lintian version
           command: lintian --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,8 +170,7 @@ jobs:
           paths:
             - "*.deb"
   lint_debian_package:
-    docker:
-      - image: cimg/base:2022.11-22.04
+    executor: ubuntu
     steps:
       - checkout
       - attach_workspace:
@@ -181,7 +180,7 @@ jobs:
           command: sudo apt-get update
       - run:
           name: Install lintian
-          command: sudo apt-get install -y lintian=2.114.0ubuntu1
+          command: sudo apt-get install -y lintian
       - run:
           name: Print lintian version
           command: lintian --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,14 @@
 version: 2.1
+executors:
+  ubuntu:
+    docker:
+      - image: cimg/base:2024.02
+  python:
+    docker:
+      - image: cimg/python:3.9.17
 jobs:
   check_whitespace:
-    docker:
-      - image: cimg/base:2020.01
+    executor: ubuntu
     steps:
       - checkout
       - run:
@@ -23,16 +29,14 @@ jobs:
           name: Run static analysis on bash scripts
           command: ./dev-scripts/check-bash
   check_privilege_guard:
-    docker:
-      - image: cimg/base:2020.01
+    executor: ubuntu
     steps:
       - checkout
       - run:
           name: Check for unnecessary privilege escalation
           command: ./dev-scripts/check-privilege-guard
   lint_sql:
-    docker:
-      - image: cimg/python:3.9.17
+    executor: python
     steps:
       - checkout
       - run:
@@ -56,8 +60,7 @@ jobs:
           name: Check code style
           command: ./dev-scripts/check-style
   decode_edid:
-    docker:
-      - image: cimg/python:3.9.17
+    executor: python
     resource_class: small
     steps:
       - checkout
@@ -74,8 +77,7 @@ jobs:
             pip install --requirement requirements.txt
             ./dev-scripts/decode-edid
   build_python:
-    docker:
-      - image: cimg/python:3.9.17
+    executor: python
     steps:
       - checkout
       - run:
@@ -99,8 +101,7 @@ jobs:
           name: Run build script
           command: ./dev-scripts/build-javascript
   build_bash:
-    docker:
-      - image: cimg/base:2024.01
+    executor: ubuntu
     steps:
       - checkout
       - run:
@@ -151,8 +152,7 @@ jobs:
       - store_artifacts:
           path: e2e-results
   build_debian_package:
-    docker:
-      - image: cimg/base:2023.06
+    executor: ubuntu
     resource_class: arm.medium
     steps:
       - checkout
@@ -198,8 +198,7 @@ jobs:
                 "${file}"
             done < <(ls *.deb)
   build_bundle:
-    docker:
-      - image: cimg/python:3.9.17
+    executor: python
     steps:
       - checkout
       - attach_workspace:
@@ -214,8 +213,7 @@ jobs:
           paths:
             - ./dist
   verify_bundle:
-    docker:
-      - image: cimg/base:2020.01
+    executor: ubuntu
     steps:
       - checkout
       - attach_workspace:
@@ -224,8 +222,7 @@ jobs:
           name: Verify bundle integrity
           command: ./bundler/verify-bundle
   upload_bundle:
-    docker:
-      - image: cimg/base:2024.02
+    executor: ubuntu
     environment:
       UPLOAD_PREFIX: community
     steps:


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot-pro/issues/1229

In an effort to reduce repetition on our CircleCI config, this PR defines standard CircleCI `executors` instead of redefining them on every job.

Notes:
1. FYI, CircleCI's `cimg/base` is an Ubuntu image:
    > `cimg/base` is an Ubuntu Docker image created by CircleCI with continuous integration builds in mind. As its name suggests, this image is designed to serve as a base image for other CircleCI Convenience Images (images prefixed with cimg/).
1. This means that most jobs would use the same base image and are now being upgraded to the latest available image (i.e., `cimg/base:2024.02`)
    - <s>We can't upgrade the base images on all jobs because some rely on very specific versions. For example:
       https://github.com/tiny-pilot/tinypilot/blob/399637566b5b54d5c881dcf2cb43dfaa560ff236/.circleci/config.yml#L171-L173
       </s>


<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1750"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>