### PR TITLE
Add CircleCI command that checks a project's environment variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,22 @@ executors:
   node:
     docker:
       - image: cimg/node:18.16.1
+commands:
+  check_project_env_vars:
+    steps:
+      - run:
+          name: Check for environment variables
+          # These environment variables can either come from the CircleCI
+          # project settings or from the CircleCI context. The latter takes
+          # precedence.
+          # See: https://circleci.com/docs/env-vars/#order-of-precedence
+          command: |
+            if [[ -z "${BACKBLAZE_KEY}"
+               || -z "${BACKBLAZE_KEY_ID}"
+            ]]; then
+              >&2 echo 'Missing environment variables'
+              exit 1
+            fi
 jobs:
   check_whitespace:
     executor: ubuntu
@@ -226,6 +242,7 @@ jobs:
     environment:
       UPLOAD_PREFIX: community
     steps:
+      - check_project_env_vars
       - checkout
       - attach_workspace:
           at: ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ commands:
           command: |
             if [[ -z "${BACKBLAZE_KEY}"
                || -z "${BACKBLAZE_KEY_ID}"
+               || -z "${UPLOAD_BUCKET}"
             ]]; then
               >&2 echo 'Missing environment variables'
               exit 1


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot-pro/issues/1229

In an effort to reduce repetition on our CircleCI config, this PR includes the following:
* Ports our [environment variable check from Tinypilot Pro](https://github.com/tiny-pilot/tinypilot-pro/blob/bddd86133a6685cef3ddc43631359ee97181d509/.circleci/config.yml#L273-L285).
    - Less one environment variable we don't use in Community.
* Introduces the env check as a reusable CircleCI command.
    * We do this because in pro we make use of the env check more than once.
        1. https://github.com/tiny-pilot/tinypilot-pro/blob/bddd86133a6685cef3ddc43631359ee97181d509/.circleci/config.yml#L273-L285
        2. https://github.com/tiny-pilot/tinypilot-pro/blob/bddd86133a6685cef3ddc43631359ee97181d509/.circleci/config.yml#L335-L347

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1752"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>