### PR TITLE
Replace custom dialog element with native one

### DIFF
--- a/app/static/js/overlays.js
+++ b/app/static/js/overlays.js
@@ -1,0 +1,20 @@
+/**
+ * A registry to keep track of all overlays being shown.
+ * Usually, there should be just one overlay at any time, but technically
+ * speaking it’s not safe to rely on that.
+ */
+export class OverlayTracker {
+  currentOverlays = new Set();
+
+  hasOverlays() {
+    return this.currentOverlays.size > 0;
+  }
+
+  trackStatus(overlayElement, isShown) {
+    if (isShown) {
+      this.currentOverlays.add(overlayElement);
+    } else {
+      this.currentOverlays.delete(overlayElement);
+    }
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1699.

This PR replaces our home-brewed dialog implementation with the [native `<dialog>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog).

Some notes on the branch:

- The semantics of the native `<dialog>` API are slightly different, although our own solution apparently also wasn’t wildly off track. At least the backdrop / shadow layer is noticeably simplified.
- The native `<dialog>` comes with a few CSS presets that we have to account for. E.g., we have to unset the `max-height`, to prevent the browser from scrolling *inside* the dialog. We also have to adjust the `width` implementation.
- I initially thought we could get rid of the [`OverlayTracker`](https://github.com/tiny-pilot/tinypilot/blob/3a3079e68d06fae0e8a0a37214adbbb99575ed73/app/static/js/overlays.js) for preventing keystroke forwarding while a dialog is open. However, we cannot reliably intercept `keydown` events, as those are only generated on [specific elements](https://developer.mozilla.org/en-US/docs/Web/API/Element/keydown_event#:~:text=Keyboard%20events%20are%20only%20generated%20by%20%3Cinput%3E%2C%20%3Ctextarea%3E%2C%20%3Csummary%3E%20and%20anything%20with%20the%20contentEditable%20or%20tabindex%20attribute.%20If%20not%20caught%2C%20they%20bubble%20up%20the%20DOM%20tree%20until%20they%20reach%20Document.), so we they don’t necessarily pass through the dialog element.
- I’ve tested in Chrome and Firefox.

Some learnings about `<dialog>` in general:

- The `<dialog>` has some useful default behaviour, e.g. when it comes to intercepting outside clicks, which it does automatically in “modal” mode. It also has better accessibility.
- However, we also have to watch out for some new things – e.g.:
  - The `<dialog>` automatically closes itself it the user presses `ESC`. I’m not sure what to think of potentially reconsidering that decision, but at least for now I’d leave it as is (i.e., no close on `ESC`).
  - `<dialog>` has some automagic behaviour if the dialog contains a `<form>` (which we use e.g. in the security dialog). I’ve tested the relevant dialogs in Pro, and couldn’t spot any problems/interferences.

(This PR was a draft initially.)

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1754"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>