### PR TITLE
Use CircleCI secure context when uploading bundle to Backblaze

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,7 +307,7 @@ workflows:
             - build_bundle
       - upload_bundle:
           context:
-            - production
+            - community-production
           requires:
             - verify_bundle
           # Uploading a new bundle affects Gatekeeper's view of the latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,7 +307,7 @@ workflows:
             - build_bundle
       - upload_bundle:
           context:
-            - community-production
+            - production-tinypilot-community
           requires:
             - verify_bundle
           # Uploading a new bundle affects Gatekeeper's view of the latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,6 +306,8 @@ workflows:
           requires:
             - build_bundle
       - upload_bundle:
+          context:
+            - production
           requires:
             - verify_bundle
           # Uploading a new bundle affects Gatekeeper's view of the latest


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot-pro/issues/1260

<s>We need to make the following changes in CircleCI:
1. Create a CircleCI secure context for TinyPilot Community.
    1. Open the [TinyPilot CircleCI context](https://app.circleci.com/settings/organization/github/tiny-pilot/contexts)
    1. Click "Create Context"
    1. Enter a context name:
        * Perhaps we should name it `community-production`?
    1. Click "Create Context"

1. Restrict the TinyPilot Community context to only be used on the `master` branch and when SSH is disabled on the CI job.
    1. Click the TinyPilot Community context
    1. Click "Add Expression Restriction"
    1. Enter the following expression in the text box:
        * `pipeline.git.branch == "master" and not job.ssh.enabled`
    1. Click "Add Expression Restriction"

1. Add new production Backblaze credentials to the TinyPilot Community context
    * [Follow these instructions.](https://github.com/tiny-pilot/tinypilot-pro/blob/a8c064b6d60929c23d16e7042a0b8a15600ff42b/docs/cycle-service-credentials.md#backblaze-application-key-for-tinypilot-community)</s>

After we've merged this PR, we can remove the `BACKBLAZE_*` environment variables from the [TinyPilot Community CircleCI project settings](https://app.circleci.com/settings/project/github/tiny-pilot/tinypilot/environment-variables).

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1755"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>