### PR TITLE
Update automatic Community PR description to mention self-review step

### DIFF
--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -41,7 +41,7 @@ jobs:
           body: |
             Related ${{ env.COMMUNITY_PR_URL }}
 
-            ${{ github.actor }}, please merge the last changes from community repository:
+            @${{ github.actor }}, please review these changes yourself and merge them from the community repository:
 
             https://github.com/tiny-pilot/tinypilot/commit/${{ github.sha }}
 


### PR DESCRIPTION
Since https://github.com/tiny-pilot/tinypilot-pro/pull/1265#pullrequestreview-1949780397, we've added a review-requirement to the `tinypilot-pro` repo.

This PR updates the automatic community PR description to mention that we need to review the changes ourselves before merging.

Notes:
* I've also updated the description to @mention the author

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1756"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>