### PR TITLE
Remove instructions for updating from the command-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,6 @@ See the [CONTRIBUTING](CONTRIBUTING.md) file.
 
 - [Advanced installation options](https://github.com/tiny-pilot/tinypilot/wiki/Installation-Options#advanced-installation)
 
-## Updates
-
-To update to the latest version of TinyPilot, run the update script:
-
-```bash
-sudo /opt/tinypilot-privileged/scripts/update && sudo reboot
-```
-
 ## Diagnostics
 
 If you're having trouble with TinyPilot, you can retrive logs from the web dashboard by clicking "Logs" in the bottom of the main dashboard.


### PR DESCRIPTION
The preferred way for users to update TinyPilot is via System > Update in the web UI.

The old CLI method still worked, but it's not how we want to encourage users to update, so we should remove this section of the README.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1757"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>