### PR TITLE
Rename private elements field with underscore prefix 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -415,13 +415,13 @@ This event will be picked up by the `overlay-panel` which will hide the X close 
 
 ### Create element references in `connectedCallback()`
 
-If a component's JavaScript requires access to any of the elements in the web component's HTML, assign those elements an `id` attribute and store them in a member object called `this.elements`
+If a component's JavaScript requires access to any of the elements in the web component's HTML, assign those elements an `id` attribute and store them in a member object called `this._elements`
 
 ```javascript
 connectedCallback() {
   this.attachShadow({ mode: "open" });
   this.shadowRoot.appendChild(template.content.cloneNode(true));
-  this.elements = {
+  this._elements = {
     noFilesText: this.shadowRoot.getElementById("no-backing-files"),
     table: this.shadowRoot.getElementById("backing-files-table"),
     tableBody: this.shadowRoot.getElementById("table-body"),

--- a/app/templates/custom-elements/button-dropdown.html
+++ b/app/templates/custom-elements/button-dropdown.html
@@ -66,11 +66,11 @@
           this._handleCloseOnOutsideClick =
             this._handleCloseOnOutsideClick.bind(this);
 
-          this.elements = {
+          this._elements = {
             dropdownButton: this.shadowRoot.getElementById("dropdown-button"),
             dropdownItems: this.shadowRoot.getElementById("dropdown-items"),
           };
-          this.elements.dropdownButton.addEventListener("click", () =>
+          this._elements.dropdownButton.addEventListener("click", () =>
             this._toggleDropdown()
           );
         }
@@ -91,18 +91,18 @@
         }
 
         _isDropdownShowing() {
-          return this.elements.dropdownItems.style.display === "block";
+          return this._elements.dropdownItems.style.display === "block";
         }
 
         _showDropdown() {
-          this.elements.dropdownItems.style.display = "block";
+          this._elements.dropdownItems.style.display = "block";
           // `addEventListener` will only register a function once, so it’s safe
           // to call this method multiple times.
           document.addEventListener("click", this._handleCloseOnOutsideClick);
         }
 
         _closeDropdown() {
-          this.elements.dropdownItems.style.display = "none";
+          this._elements.dropdownItems.style.display = "none";
           document.removeEventListener(
             "click",
             this._handleCloseOnOutsideClick

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -115,7 +115,7 @@
           this.attachShadow({ mode: "open" }).appendChild(
             template.content.cloneNode(true)
           );
-          this.elements = {
+          this._elements = {
             inputError: this.shadowRoot.getElementById("input-error"),
             hostnameInput: this.shadowRoot.getElementById("hostname-input"),
             changeAndRestart:
@@ -126,18 +126,18 @@
             futureLocation: this.shadowRoot.getElementById("future-location"),
           };
 
-          this.elements.hostnameInput.addEventListener("input", () => {
+          this._elements.hostnameInput.addEventListener("input", () => {
             this._onInputChanged();
           });
-          this.elements.changeAndRestart.addEventListener("click", () => {
+          this._elements.changeAndRestart.addEventListener("click", () => {
             this._doChangeHostname();
           });
-          this.elements.hostnameInput.addEventListener("keydown", (evt) => {
+          this._elements.hostnameInput.addEventListener("keydown", (evt) => {
             if (evt.code === "Enter") {
-              this.elements.changeAndRestart.click();
+              this._elements.changeAndRestart.click();
             }
           });
-          this.elements.cancelHostnameChange.addEventListener("click", () => {
+          this._elements.cancelHostnameChange.addEventListener("click", () => {
             this.dispatchEvent(new DialogClosedEvent());
           });
         }
@@ -164,15 +164,15 @@
         }
 
         initialize() {
-          this.elements.inputError.hide();
+          this._elements.inputError.hide();
           this.state = this.states.INITIALIZING;
           determineHostname()
             .then((hostname) => {
               this.initialHostname = hostname;
-              this.elements.hostnameInput.value = hostname;
+              this._elements.hostnameInput.value = hostname;
               this._onInputChanged(hostname);
               this.state = this.states.PROMPT;
-              this.elements.hostnameInput.focus();
+              this._elements.hostnameInput.focus();
             })
             .catch((error) => {
               this.dispatchEvent(
@@ -186,14 +186,14 @@
 
         _onInputChanged() {
           const isEqualToInitialValue =
-            this.elements.hostnameInput.value === this.initialHostname;
-          const isEmpty = this.elements.hostnameInput.value === "";
-          this.elements.changeAndRestart.disabled =
+            this._elements.hostnameInput.value === this.initialHostname;
+          const isEmpty = this._elements.hostnameInput.value === "";
+          this._elements.changeAndRestart.disabled =
             isEmpty || isEqualToInitialValue;
         }
 
         _doChangeHostname() {
-          changeHostname(this.elements.hostnameInput.value)
+          changeHostname(this._elements.hostnameInput.value)
             .then((newHostname) => {
               return shutdown(/*restart=*/ true).then(() => newHostname);
             })
@@ -205,8 +205,8 @@
               );
             })
             .then((redirectURL) => {
-              this.elements.futureLocation.innerText = redirectURL;
-              this.elements.futureLocation.href = redirectURL;
+              this._elements.futureLocation.innerText = redirectURL;
+              this._elements.futureLocation.href = redirectURL;
               this.state = this.states.CHANGING;
               return this._waitForReboot(redirectURL);
             })
@@ -214,7 +214,7 @@
               if (error.code === "INVALID_HOSTNAME") {
                 // Display validation errors inline in order to make it more
                 // convenient for the user to correct them.
-                this.elements.inputError.show();
+                this._elements.inputError.show();
                 this.state = this.states.PROMPT;
                 return;
               }

--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -99,7 +99,7 @@
             redacted: null, // The text with sensitive data being redacted.
           };
 
-          this.elements = {
+          this._elements = {
             includeSensitiveData: this.shadowRoot.getElementById(
               "include-sensitive-data"
             ),
@@ -107,7 +107,7 @@
             shareLogsButton:
               this.shadowRoot.querySelector("#share-logs-button"),
           };
-          this.elements.includeSensitiveData.addEventListener(
+          this._elements.includeSensitiveData.addEventListener(
             "input",
             (event) => {
               this.includeSensitiveData = !event.target.checked;
@@ -168,7 +168,7 @@
         }
 
         _getLogTextAsDisplayed() {
-          return this.elements.logsText.textContent;
+          return this._elements.logsText.textContent;
         }
 
         /**
@@ -182,8 +182,8 @@
           const logsDisplayText = this.includeSensitiveData
             ? this._logText.original
             : this._logText.redacted;
-          this.elements.logsText.textContent = logsDisplayText;
-          this.elements.shareLogsButton.initialize(
+          this._elements.logsText.textContent = logsDisplayText;
+          this._elements.shareLogsButton.initialize(
             /*getLogsTextCb=*/ () => logsDisplayText
           );
         }

--- a/app/templates/custom-elements/feature-pro-dialog.html
+++ b/app/templates/custom-elements/feature-pro-dialog.html
@@ -30,12 +30,12 @@
         this.attachShadow({ mode: "open" }).appendChild(
           template.content.cloneNode(true)
         );
-        this.elements = {
+        this._elements = {
           cancelUpgradeToPro: this.shadowRoot.getElementById(
             "cancel-upgrade-to-pro"
           ),
         };
-        this.elements.cancelUpgradeToPro.addEventListener("click", () => {
+        this._elements.cancelUpgradeToPro.addEventListener("click", () => {
           this.dispatchEvent(new DialogClosedEvent());
         });
       }

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -76,7 +76,7 @@
           this.attachShadow({ mode: "open" }).appendChild(
             template.content.cloneNode(true)
           );
-          this.elements = {
+          this._elements = {
             dialog: this.shadowRoot.querySelector("#panel"),
           };
           this.show = this.show.bind(this);
@@ -105,16 +105,16 @@
 
           // Prevent auto-close behavior of native <dialog> if the user presses
           // the ESC key.
-          this.elements.dialog.addEventListener("cancel", (evt) => {
+          this._elements.dialog.addEventListener("cancel", (evt) => {
             evt.preventDefault();
           });
         }
 
         show(isShown = true) {
           if (isShown) {
-            this.elements.dialog.showModal();
+            this._elements.dialog.showModal();
           } else {
-            this.elements.dialog.close();
+            this._elements.dialog.close();
           }
           this.dispatchEvent(
             new CustomEvent("overlay-toggled", {
@@ -126,7 +126,7 @@
         }
 
         isShown() {
-          return this.elements.dialog.open;
+          return this._elements.dialog.open;
         }
       }
     );

--- a/app/templates/custom-elements/paste-dialog.html
+++ b/app/templates/custom-elements/paste-dialog.html
@@ -45,41 +45,41 @@
           this.attachShadow({ mode: "open" }).appendChild(
             template.content.cloneNode(true)
           );
-          this.elements = {
+          this._elements = {
             pasteArea: this.shadowRoot.querySelector("#paste-area"),
             confirmButton: this.shadowRoot.querySelector("#confirm-btn"),
             cancelButton: this.shadowRoot.querySelector("#cancel-btn"),
           };
-          this.elements.pasteArea.addEventListener("input", () =>
-            this.elements.confirmButton.toggleAttribute(
+          this._elements.pasteArea.addEventListener("input", () =>
+            this._elements.confirmButton.toggleAttribute(
               "disabled",
-              this.elements.pasteArea.value.length === 0
+              this._elements.pasteArea.value.length === 0
             )
           );
-          this.elements.pasteArea.addEventListener("keydown", (evt) => {
+          this._elements.pasteArea.addEventListener("keydown", (evt) => {
             if (evt.code === "Enter" && !evt.shiftKey) {
               evt.preventDefault();
-              this.elements.confirmButton.click();
+              this._elements.confirmButton.click();
               // Prevent this keystroke from being forwarded to the target system.
               evt.stopPropagation();
             }
           });
-          this.elements.confirmButton.addEventListener("click", () =>
+          this._elements.confirmButton.addEventListener("click", () =>
             this._handleConfirmPaste()
           );
-          this.elements.cancelButton.addEventListener("click", () =>
+          this._elements.cancelButton.addEventListener("click", () =>
             this._closeDialog()
           );
         }
 
         initialize() {
-          this.elements.pasteArea.value = "";
-          this.elements.pasteArea.focus();
-          this.elements.confirmButton.toggleAttribute("disabled", true);
+          this._elements.pasteArea.value = "";
+          this._elements.pasteArea.focus();
+          this._elements.confirmButton.toggleAttribute("disabled", true);
         }
 
         _handleConfirmPaste() {
-          const text = this.elements.pasteArea.value;
+          const text = this._elements.pasteArea.value;
           const language = this._browserLanguage();
           pasteText(text, language)
             .then(() => this._closeDialog())

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -129,7 +129,7 @@
             template.content.cloneNode(true)
           );
 
-          this.elements = {
+          this._elements = {
             video: this.shadowRoot.getElementById("webrtc-output"),
             image: this.shadowRoot.getElementById("mjpeg-output"),
           };
@@ -140,10 +140,10 @@
           // spinner for the browser tab. Therefore, we need to initialize the
           // source object lazily whenever we want to access it, and clear it
           // when we don’t need it anymore.
-          this.elements.video.srcObject = null;
+          this._elements.video.srcObject = null;
 
-          this._addScreenEventListeners(this.elements.video);
-          this._addScreenEventListeners(this.elements.image);
+          this._addScreenEventListeners(this._elements.video);
+          this._addScreenEventListeners(this._elements.image);
 
           window.addEventListener("resize", this.onWindowResize);
 
@@ -337,7 +337,7 @@
          *   unmute the audio track. (Which might not succeed, though.)
          */
         async enableWebrtc() {
-          const video = this.elements.video;
+          const video = this._elements.video;
           if (!video.srcObject) {
             return;
           }
@@ -364,7 +364,7 @@
             return;
           }
           this.webrtcEnabled = true;
-          this.elements.image.removeAttribute("src");
+          this._elements.image.removeAttribute("src");
           this.dispatchEvent(new VideoStreamingModeChangedEvent("H264"));
         }
 
@@ -374,7 +374,7 @@
          * @param {MediaStreamTrack} mediaStreamTrack - https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack
          */
         async addWebrtcStreamTrack(mediaStreamTrack) {
-          const video = this.elements.video;
+          const video = this._elements.video;
           if (!video.srcObject) {
             // Lazy-initialize the media stream. (See comment in
             // `connectedCallback`.)
@@ -407,7 +407,7 @@
          * @param {MediaStreamTrack} mediaStreamTrack - https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack
          */
         removeWebrtcStreamTrack(mediaStreamTrack) {
-          const video = this.elements.video;
+          const video = this._elements.video;
           if (!video.srcObject) {
             return;
           }
@@ -425,7 +425,7 @@
          * retry playing, so that we at least end up having video active.
          */
         async _playWebrtcVideo(shouldRetryWithMuting = true) {
-          const video = this.elements.video;
+          const video = this._elements.video;
 
           try {
             await video.play();
@@ -472,7 +472,7 @@
          * eligible. We have to act on best guess basis here.
          */
         _onGlobalUserInteraction() {
-          const video = this.elements.video;
+          const video = this._elements.video;
           if (!this.webrtcEnabled || video.muted === false) {
             return;
           }
@@ -489,21 +489,21 @@
          * Displays the MJPEG stream while hiding the WebRTC stream.
          */
         enableMjpeg() {
-          if (this.elements.image.hasAttribute("src")) {
+          if (this._elements.image.hasAttribute("src")) {
             return;
           }
-          this.elements.image.src = "/stream?advance_headers=1";
+          this._elements.image.src = "/stream?advance_headers=1";
           this.webrtcEnabled = false;
           // Clean up the media stream. (See comment in `connectedCallback`.)
-          this.elements.video.srcObject = null;
+          this._elements.video.srcObject = null;
           this.dispatchEvent(new VideoStreamingModeChangedEvent("MJPEG"));
         }
 
         _getCurrentScreenElement() {
           if (this.webrtcEnabled) {
-            return this.elements.video;
+            return this._elements.video;
           } else {
-            return this.elements.image;
+            return this._elements.image;
           }
         }
       }

--- a/app/templates/custom-elements/share-logs-button.html
+++ b/app/templates/custom-elements/share-logs-button.html
@@ -132,16 +132,16 @@
             template.content.cloneNode(true)
           );
 
-          this.elements = {
+          this._elements = {
             getUrlButton: this.shadowRoot.querySelector("#get-url-button"),
             urlLink: this.shadowRoot.querySelector("#display-link a"),
             copyButton: this.shadowRoot.querySelector("#copy-button"),
           };
 
-          this.elements.getUrlButton.addEventListener("click", () => {
+          this._elements.getUrlButton.addEventListener("click", () => {
             this._handleRequestShareableUrl();
           });
-          this.elements.copyButton.addEventListener("click", () => {
+          this._elements.copyButton.addEventListener("click", () => {
             this._handleCopyToClipboard();
           });
 
@@ -150,7 +150,7 @@
 
         set state(newValue) {
           this.setAttribute("state", newValue);
-          this.elements.getUrlButton.disabled =
+          this._elements.getUrlButton.disabled =
             newValue === this.states.LOADING;
         }
 
@@ -174,11 +174,11 @@
             const url = await textToShareableUrl(this.getLogsText());
             // For the displayed URL, strip the protocol prefix, to make it
             // look a bit slimmer.
-            this.elements.urlLink.textContent = url
+            this._elements.urlLink.textContent = url
               .replace("http://", "")
               .replace("https://", "");
-            this.elements.urlLink.setAttribute("href", url);
-            this.elements.urlLink.setAttribute("title", url);
+            this._elements.urlLink.setAttribute("href", url);
+            this._elements.urlLink.setAttribute("title", url);
           } catch (error) {
             console.error("Failed to upload logs: " + error);
             // In case of failure, we just reset the button, since we cannot
@@ -198,15 +198,15 @@
           // To do that, we briefly replace the display URL with the canonical
           // one for the duration of the “copy to clipboard” operation. The user
           // shouldn’t notice anything about this.
-          const previousDisplayText = this.elements.urlLink.textContent;
-          this.elements.urlLink.textContent =
-            this.elements.urlLink.getAttribute("href");
-          copyElementTextToClipboard(this.elements.urlLink);
-          this.elements.urlLink.textContent = previousDisplayText;
+          const previousDisplayText = this._elements.urlLink.textContent;
+          this._elements.urlLink.textContent =
+            this._elements.urlLink.getAttribute("href");
+          copyElementTextToClipboard(this._elements.urlLink);
+          this._elements.urlLink.textContent = previousDisplayText;
 
-          this.elements.copyButton.classList.add("copied");
+          this._elements.copyButton.classList.add("copied");
           setTimeout(() => {
-            this.elements.copyButton.classList.remove("copied");
+            this._elements.copyButton.classList.remove("copied");
           }, 2000);
         }
       }

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -154,7 +154,7 @@
             template.content.cloneNode(true)
           );
 
-          this.elements = {
+          this._elements = {
             updateLogs: this.shadowRoot.querySelector(
               "#update-container .logs"
             ),
@@ -173,13 +173,13 @@
               location.reload();
             });
 
-          this.elements.updatePromptAutomatic.addEventListener(
+          this._elements.updatePromptAutomatic.addEventListener(
             "update-prompt-confirmed",
             () => {
               this._doUpdate();
             }
           );
-          this.elements.updatePromptAutomatic.addEventListener(
+          this._elements.updatePromptAutomatic.addEventListener(
             "update-prompt-canceled",
             () => {
               this.dispatchEvent(new DialogClosedEvent());
@@ -266,7 +266,7 @@
           return shutdown(/*restart=*/ true)
             .then(() => {
               this._state = this.states.RESTARTING;
-              this.elements.updateLogs.textContent +=
+              this._elements.updateLogs.textContent +=
                 "Restarting to complete update...\n";
             })
             .catch((error) => {
@@ -288,7 +288,7 @@
           })
             .then(() => {
               this._state = this.states.UPDATE_FINISHED;
-              this.elements.updateLogs.textContent +=
+              this._elements.updateLogs.textContent +=
                 "Update is now complete.\n";
             })
             .catch((error) => {
@@ -327,11 +327,11 @@
 
           const updateLogsStreamer = new UpdateLogsStreamer();
           // Let the user know that the update logs are loading.
-          this.elements.updateLogs.textContent =
+          this._elements.updateLogs.textContent =
             "Retrieving update logs from TinyPilot device...\n";
           // Display new update logs as they come in.
           updateLogsStreamer.onNewLogs((logs) => {
-            this.elements.updateLogs.textContent += logs;
+            this._elements.updateLogs.textContent += logs;
           });
           updateLogsStreamer.start();
 
@@ -362,7 +362,7 @@
                 title: "Failed to Complete Update",
                 // Include full update logs in the error details, as it likely
                 // contains specific information about the error.
-                details: `${error}\n\n${this.elements.updateLogs.textContent}`,
+                details: `${error}\n\n${this._elements.updateLogs.textContent}`,
                 isShareable: true,
               })
             );

--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -235,7 +235,7 @@
 
         connectedCallback() {
           this.shadowRoot.appendChild(template.content.cloneNode(true));
-          this.elements = {
+          this._elements = {
             saveButton: this.shadowRoot.querySelector("#edit .save-btn"),
             closeButton: this.shadowRoot.querySelector(".close-btn"),
             streamingModeMjpegButton: this.shadowRoot.querySelector(
@@ -274,62 +274,62 @@
               "#stun-validation-error"
             ),
           };
-          this.elements.closeButton.addEventListener("click", () =>
+          this._elements.closeButton.addEventListener("click", () =>
             this.dispatchEvent(new DialogClosedEvent())
           );
-          this.elements.saveButton.addEventListener("click", () =>
+          this._elements.saveButton.addEventListener("click", () =>
             this._saveSettings()
           );
-          this.elements.streamingModeMjpegButton.addEventListener(
+          this._elements.streamingModeMjpegButton.addEventListener(
             "click",
             () => {
               this._setStreamingMode("MJPEG");
             }
           );
-          this.elements.streamingModeH264Button.addEventListener(
+          this._elements.streamingModeH264Button.addEventListener(
             "click",
             () => {
               this._setStreamingMode("H264");
             }
           );
-          this.elements.frameRateSlider.addEventListener("input", (event) => {
+          this._elements.frameRateSlider.addEventListener("input", (event) => {
             this._setFrameRate(parseInt(event.target.value, 10));
           });
-          this.elements.frameRateRestoreButton.addEventListener("click", () => {
+          this._elements.frameRateRestoreButton.addEventListener("click", () => {
             this._setFrameRate(this._defaultSettings.frameRate);
           });
-          this.elements.mjpegQualitySlider.addEventListener(
+          this._elements.mjpegQualitySlider.addEventListener(
             "input",
             (event) => {
               this._setMjpegQuality(parseInt(event.target.value, 10));
             }
           );
-          this.elements.mjpegQualityRestoreButton.addEventListener(
+          this._elements.mjpegQualityRestoreButton.addEventListener(
             "click",
             () => {
               this._setMjpegQuality(this._defaultSettings.mjpegQuality);
             }
           );
-          this.elements.h264BitrateSlider.addEventListener("input", (event) => {
+          this._elements.h264BitrateSlider.addEventListener("input", (event) => {
             this._setH264Bitrate(parseInt(event.target.value, 10));
           });
-          this.elements.h264BitrateRestoreButton.addEventListener(
+          this._elements.h264BitrateRestoreButton.addEventListener(
             "click",
             () => {
               this._setH264Bitrate(this._defaultSettings.h264Bitrate);
             }
           );
-          this.elements.h264StunSettings.addEventListener(
+          this._elements.h264StunSettings.addEventListener(
             "h264-stun-value-changed",
             () => {
               this._refreshButtons();
-              this.elements.h264StunValidationError.hide();
+              this._elements.h264StunValidationError.hide();
             }
           );
-          this.elements.h264StunSettings.addEventListener(
+          this._elements.h264StunSettings.addEventListener(
             "h264-stun-submission-requested",
             () => {
-              this.elements.saveButton.click();
+              this._elements.saveButton.click();
             }
           );
           this.shadowRoot
@@ -361,7 +361,7 @@
           this.state = this.states.LOADING;
 
           // Reset all transient view state.
-          this.elements.h264StunValidationError.hide();
+          this._elements.h264StunValidationError.hide();
           this.toggleAttribute("show-advanced-h264-settings", false);
 
           // Fetch and fill in data from server.
@@ -395,7 +395,7 @@
                 this._initialSettings.h264Bitrate = h264Bitrate;
                 this._defaultSettings.h264Bitrate = defaultH264Bitrate;
 
-                this.elements.h264StunSettings.initialize(
+                this._elements.h264StunSettings.initialize(
                   h264StunServer,
                   h264StunPort
                 );
@@ -429,11 +429,11 @@
          * @param {string} streamingMode
          */
         _setStreamingMode(streamingMode) {
-          this.elements.streamingModeMjpegButton.classList.toggle(
+          this._elements.streamingModeMjpegButton.classList.toggle(
             "disabled",
             streamingMode === "MJPEG"
           );
-          this.elements.streamingModeH264Button.classList.toggle(
+          this._elements.streamingModeH264Button.classList.toggle(
             "disabled",
             streamingMode === "H264"
           );
@@ -445,15 +445,15 @@
          * @returns {number}
          */
         _getFrameRate() {
-          return parseInt(this.elements.frameRateSlider.value, 10);
+          return parseInt(this._elements.frameRateSlider.value, 10);
         }
 
         /**
          * @param {number} frameRate
          */
         _setFrameRate(frameRate) {
-          this.elements.frameRateSlider.value = frameRate;
-          this.elements.frameRateValue.innerHTML = `${frameRate} fps`;
+          this._elements.frameRateSlider.value = frameRate;
+          this._elements.frameRateValue.innerHTML = `${frameRate} fps`;
           this._refreshButtons();
         }
 
@@ -461,15 +461,15 @@
          * @returns {number}
          */
         _getMjpegQuality() {
-          return parseInt(this.elements.mjpegQualitySlider.value, 10);
+          return parseInt(this._elements.mjpegQualitySlider.value, 10);
         }
 
         /**
          * @param {number} mjpegQuality
          */
         _setMjpegQuality(mjpegQuality) {
-          this.elements.mjpegQualitySlider.value = mjpegQuality;
-          this.elements.mjpegQualityValue.innerHTML = `${mjpegQuality} %`;
+          this._elements.mjpegQualitySlider.value = mjpegQuality;
+          this._elements.mjpegQualityValue.innerHTML = `${mjpegQuality} %`;
           this._refreshButtons();
         }
 
@@ -477,16 +477,16 @@
          * @returns {number}
          */
         _getH264Bitrate() {
-          return parseInt(this.elements.h264BitrateSlider.value, 10);
+          return parseInt(this._elements.h264BitrateSlider.value, 10);
         }
 
         /**
          * @param {number} h264Bitrate
          */
         _setH264Bitrate(h264Bitrate) {
-          this.elements.h264BitrateSlider.value = h264Bitrate;
+          this._elements.h264BitrateSlider.value = h264Bitrate;
           const h264BitrateValue = (h264Bitrate / 1000).toFixed(2);
-          this.elements.h264BitrateValue.innerHTML = `${h264BitrateValue} Mb/s`;
+          this._elements.h264BitrateValue.innerHTML = `${h264BitrateValue} Mb/s`;
           this._refreshButtons();
         }
 
@@ -496,7 +496,7 @@
          */
         _refreshButtons() {
           const { h264StunServer, h264StunPort } =
-            this.elements.h264StunSettings.getValue();
+            this._elements.h264StunSettings.getValue();
 
           // Save Button: only enable if the user actually changed some value.
           const hasChangedValues = [
@@ -507,7 +507,7 @@
             [h264StunServer, this._initialSettings.h264StunServer],
             [h264StunPort, this._initialSettings.h264StunPort],
           ].some(([actualValue, initialValue]) => actualValue !== initialValue);
-          this.elements.saveButton.disabled = !hasChangedValues;
+          this._elements.saveButton.disabled = !hasChangedValues;
 
           // Reset Buttons: only show if the respective slider value differs
           // from the default setting.
@@ -515,17 +515,17 @@
             [
               this._getFrameRate(),
               this._defaultSettings.frameRate,
-              this.elements.frameRateRestoreButton,
+              this._elements.frameRateRestoreButton,
             ],
             [
               this._getMjpegQuality(),
               this._defaultSettings.mjpegQuality,
-              this.elements.mjpegQualityRestoreButton,
+              this._elements.mjpegQualityRestoreButton,
             ],
             [
               this._getH264Bitrate(),
               this._defaultSettings.h264Bitrate,
-              this.elements.h264BitrateRestoreButton,
+              this._elements.h264BitrateRestoreButton,
             ],
           ].forEach(([actualValue, defaultValue, resetButton]) => {
             resetButton.classList.toggle(
@@ -539,7 +539,7 @@
           this.state = this.states.SAVING;
 
           const { h264StunServer, h264StunPort } =
-            this.elements.h264StunSettings.getValue();
+            this._elements.h264StunSettings.getValue();
           return saveVideoSettings({
             streamingMode: this._getStreamingMode(),
             frameRate: this._getFrameRate(),
@@ -572,7 +572,7 @@
               if (error.code === "INVALID_STUN_ADDRESS") {
                 // Display validation errors inline in order to make it more
                 // convenient for the user to correct them.
-                this.elements.h264StunValidationError.show();
+                this._elements.h264StunValidationError.show();
                 this.state = this.states.EDIT;
                 return;
               }

--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -295,9 +295,12 @@
           this._elements.frameRateSlider.addEventListener("input", (event) => {
             this._setFrameRate(parseInt(event.target.value, 10));
           });
-          this._elements.frameRateRestoreButton.addEventListener("click", () => {
-            this._setFrameRate(this._defaultSettings.frameRate);
-          });
+          this._elements.frameRateRestoreButton.addEventListener(
+            "click",
+            () => {
+              this._setFrameRate(this._defaultSettings.frameRate);
+            }
+          );
           this._elements.mjpegQualitySlider.addEventListener(
             "input",
             (event) => {
@@ -310,9 +313,12 @@
               this._setMjpegQuality(this._defaultSettings.mjpegQuality);
             }
           );
-          this._elements.h264BitrateSlider.addEventListener("input", (event) => {
-            this._setH264Bitrate(parseInt(event.target.value, 10));
-          });
+          this._elements.h264BitrateSlider.addEventListener(
+            "input",
+            (event) => {
+              this._setH264Bitrate(parseInt(event.target.value, 10));
+            }
+          );
           this._elements.h264BitrateRestoreButton.addEventListener(
             "click",
             () => {

--- a/app/templates/custom-elements/video-settings-h264-stun.html
+++ b/app/templates/custom-elements/video-settings-h264-stun.html
@@ -165,22 +165,22 @@
             return option;
           });
 
-          this.elements = {
+          this._elements = {
             server: this.shadowRoot.querySelector("#server"),
             port: this.shadowRoot.querySelector("#port"),
           };
-          this.elements.server.addEventListener("input", () => {
+          this._elements.server.addEventListener("input", () => {
             this.dispatchEvent(new InputChangedEvent());
           });
-          this.elements.port.addEventListener("input", () => {
+          this._elements.port.addEventListener("input", () => {
             this.dispatchEvent(new InputChangedEvent());
           });
-          this.elements.server.addEventListener("keydown", (evt) => {
+          this._elements.server.addEventListener("keydown", (evt) => {
             if (evt.code === "Enter") {
               this.dispatchEvent(new SubmissionRequestedEvent());
             }
           });
-          this.elements.port.addEventListener("keydown", (evt) => {
+          this._elements.port.addEventListener("keydown", (evt) => {
             if (evt.code === "Enter") {
               this.dispatchEvent(new SubmissionRequestedEvent());
             }
@@ -213,8 +213,8 @@
           // If the selection is “custom”, read the data from the input fields.
           // Otherwise, return the presets from the option.
           if (selectedOption.id === "custom") {
-            const server = this.elements.server.value;
-            const port = parseInt(this.elements.port.value);
+            const server = this._elements.server.value;
+            const port = parseInt(this._elements.port.value);
             return {
               h264StunServer: server.trim() || null,
               h264StunPort: Number.isNaN(port) ? null : port,
@@ -232,8 +232,8 @@
          */
         initialize(h264StunServer, h264StunPort) {
           // Clear any potentially previous view state.
-          this.elements.server.value = "";
-          this.elements.port.value = "";
+          this._elements.server.value = "";
+          this._elements.port.value = "";
 
           // Determine selection by finding an option with matching server and
           // port values. If there is no such option, assume the selection to be
@@ -243,8 +243,8 @@
               option.server === h264StunServer && option.port === h264StunPort
           );
           if (selectedOption.id === "custom") {
-            this.elements.server.value = h264StunServer;
-            this.elements.port.value = h264StunPort;
+            this._elements.server.value = h264StunServer;
+            this._elements.port.value = h264StunPort;
           }
           this._select(selectedOption);
         }


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot/issues/1120

This is non-functional change.

Notes
* Pattern matched: `this\.elements(?=\W)`
   Replaced with: `this._elements`

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1758"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>