### PR TITLE
Fix initial focus in paste dialog

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -314,6 +314,9 @@ menuBar.addEventListener("update-dialog-requested", () => {
   document.getElementById("update-dialog").checkVersion();
 });
 menuBar.addEventListener("change-hostname-dialog-requested", () => {
+  // Note: we have to call `initialize()` after `show()`, to ensure that the
+  // dialog is able to focus the main input element.
+  // See https://github.com/tiny-pilot/tinypilot/issues/1770
   document.getElementById("change-hostname-overlay").show();
   document.getElementById("change-hostname-dialog").initialize();
 });
@@ -342,8 +345,11 @@ menuBar.addEventListener("video-settings-dialog-requested", () => {
   document.getElementById("video-settings-overlay").show();
 });
 menuBar.addEventListener("paste-dialog-requested", () => {
-  document.getElementById("paste-dialog").initialize();
+  // Note: we have to call `initialize()` after `show()`, to ensure that the
+  // dialog is able to focus the main input element.
+  // See https://github.com/tiny-pilot/tinypilot/issues/1770
   document.getElementById("paste-overlay").show();
+  document.getElementById("paste-dialog").initialize();
 });
 menuBar.addEventListener("ctrl-alt-del-requested", () => {
   // Even though only the final keystroke matters, send them one at a time to


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1770.

This PR reverts to the original method call order, to bring back the auto-focus. I’ve left a comment to point out the issue (also for the hostname dialog, because we have the same issue there).
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1772"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>