### PR TITLE
Make Pro-merge instructions more actionable and self-documenting

### DIFF
--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -45,6 +45,7 @@ jobs:
             @${{ github.actor }}, please merge [your changes from the Community repository](https://github.com/tiny-pilot/tinypilot/commit/${{ github.sha }}):
 
             1. Update this branch with latest `master`
+               - If there are merge conflicts, it’s best to resolve them locally.
             1. Check whether you need to make any Pro-specific adjustments to the code
             1. Review and approve your changes
                - You usually do this yourself. In case you had to make non-trivial adjustments, it’s also okay to request a proper peer review.


### PR DESCRIPTION
I thought we could make our merge instructions for the Pro repo a little bit more actionable and self-documenting.

We can also set the `reviewers` field, to automatically assign the actor as reviewer. That way, the PR e.g. shows up in [your “Requested Reviews” list](https://github.com/pulls/review-requested).

See below how the PR description would look.

---

Related [#123](#)

@jotaen4tinypilot, please merge [your changes from the Community repository](https://github.com/tiny-pilot/tinypilot/commit/123):

1. Update this branch with latest `master`
   - If there are merge conflicts, it’s best to resolve them locally.
1. Check whether you need to make any Pro-specific adjustments to the code
1. Review and approve your changes
   - You usually do this yourself. In case you had to make non-trivial adjustments, it’s also okay to request a proper peer review.
1. Set the merge style to “Create a merge commit” (regular merge)
   - **Do not use “Squash and merge”!** If you accidentally squash, it’s not a disaster, but it will create a bit of noise on the subsequent PR from Community.
   - We want a regular merge to preserve the commit history from Community
1. Merge the PR

Note that Github remembers the merge style of your last PR in this repo, so for your next “regular” PR, you may have to manually set it to “Squash and merge” again.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1774"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>