### PR TITLE
Use arithmetic bash comparisons

### DIFF
--- a/bundler/verify-bundle
+++ b/bundler/verify-bundle
@@ -22,7 +22,7 @@ if [[ "${BUNDLE_SIZE_BYTES}" -eq 0 ]]; then
   >&2 echo 'Bundle size is zero.'
   exit 1
 fi
-if [[ "${BUNDLE_SIZE_BYTES}" -gt 10000000 ]]; then
+if (( "${BUNDLE_SIZE_BYTES}" > 10000000 )); then
   >&2 echo 'Bundle size is larger than 10mb.'
   exit 1
 fi

--- a/debian-pkg/opt/tinypilot-privileged/scripts/configure-janus
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/configure-janus
@@ -20,7 +20,7 @@ EOF
 }
 
 # Parse command-line arguments.
-while [[ "$#" -gt 0 ]]; do
+while (( "$#" > 0 )); do
   case "$1" in
     --help)
       print_help

--- a/debian-pkg/opt/tinypilot-privileged/scripts/strip-marker-sections
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/strip-marker-sections
@@ -34,7 +34,7 @@ EOF
 
 # Parse command-line arguments.
 TARGET_FILE=''
-while [[ "$#" -gt 0 ]]; do
+while (( "$#" > 0 )); do
   case "$1" in
     --help)
       print_help

--- a/dev-scripts/run-e2e-tests
+++ b/dev-scripts/run-e2e-tests
@@ -28,14 +28,14 @@ EOF
 # Parse command-line arguments.
 E2E_BASE_URL=''
 PLAYWRIGHT_ARGS=()
-while [[ "$#" -gt 0 ]]; do
+while (( "$#" > 0 )); do
   case "$1" in
     --help)
       print_help
       exit
       ;;
     --base-url)
-      if [[ "$#" -lt 2 ]]; then
+      if (( "$#" < 2 )); then
         shift;
         break;
       fi


### PR DESCRIPTION
As discussed in https://github.com/tiny-pilot/style-guides/issues/19#issuecomment-2036381414, and in eager compliance with the [Google bash style guide](https://google.github.io/styleguide/shellguide.html#s6.9-arithmetic), we can replace all instances of `[[ -gt ]]` or `[[ -lt ]]` with arithmetic expressions (`(( > ))` or `(( < ))`).

I’ve briefly tested all scripts, so from my side a double-check on the code would be enough as review.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1776"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>