### PR TITLE
Emulate double click from touch devices

### DIFF
--- a/app/static/js/touch.js
+++ b/app/static/js/touch.js
@@ -11,11 +11,13 @@
  *   - Double left click
  */
 export class TouchToMouseAdapter {
-  _lastTouchInfo = {
-    timestamp: new Date(),
-    clientX: 0,
-    clientY: 0,
-  };
+  constructor() {
+    this._lastTouchInfo = {
+      timestamp: new Date(),
+      clientX: 0,
+      clientY: 0,
+    };
+  }
 
   /**
    * Synthetic mouse event that includes all properties that the


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1781.

This PR improves double-click emulation so that both of the consecutive mouse (touch) events have the exact same location. On a touch device, you might otherwise accidentally direct the second click to a slightly different location, or the target operating system might not even recognise both clicks as proper double click.

## Notes

- I’ve slightly re-ordered the commentary, which I thought was sensible due to the increased complexity in the file.
- The parameters for detecting a double-click are heuristic at best – the 500ms delay is from [this article](https://en.wikipedia.org/wiki/Double-click#:~:text=rely%20upon%20it.-,Speed%20and%20timing,basis%20for%20other%20timed%20actions.), and the 500px distance just felt okay when trying from an iPad.

I’ve tested with this on an iPad, so from my side a pure code review would suffice.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1787"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>