### PR TITLE
Document user configurable settings

### DIFF
--- a/docs/user-configurable-settings.md
+++ b/docs/user-configurable-settings.md
@@ -6,8 +6,8 @@ It is no longer possible to make changes to TinyPilot's undocumented settings th
 
 The following settings are supported and remain configurable through `settings.yml`:
 
-- `janus_stun_server`
 - `janus_stun_port`
+- `janus_stun_server`
 - `tinypilot_external_port`
 - `tinypilot_external_tls_port` (Pro only)
 - `tinypilot_manage_tls_keys` (Pro only)
@@ -16,7 +16,7 @@ The following settings are supported and remain configurable through `settings.y
 - `ustreamer_h264_bitrate`
 - `ustreamer_quality`
 
-## Unsupported Settings (Legacy)
+## Deprecated Settings (Legacy)
 
 The following settings are configurable through `settings.yml`, but we may remove configuration support for them in the future:
 
@@ -28,3 +28,13 @@ The following settings are configurable through `settings.yml`, but we may remov
 - `ustreamer_resolution`
 - `ustreamer_use_dv_timings`
 - `ustreamer_workers`
+
+## Unsupported Settings (Non-configurable)
+
+The following settings are no longer configurable through `settings.yml`:
+
+- `tinypilot_install_janus`
+- `ustreamer_compile_janus_plugin`
+- `ustreamer_h264_sink`
+- `ustreamer_h264_sink_mode`
+- `ustreamer_h264_sink_rm`

--- a/docs/user-configurable-settings.md
+++ b/docs/user-configurable-settings.md
@@ -1,6 +1,6 @@
 # User Configurable Settings
 
-It is no longer possible to make changes to TinyPilot's undocumented settings through the `/home/tinypilot/settings.yml` file.
+It is no longer possible to make changes to TinyPilot's undocumented settings through the `/home/tinypilot/settings.yml` files. This document outlines which settings are supported, deprecated, and unsupported.
 
 ## Supported Settings
 
@@ -18,7 +18,7 @@ The following settings are supported and remain configurable through `settings.y
 
 ## Deprecated Settings (Legacy)
 
-The following settings are configurable through `settings.yml`, but we may remove configuration support for them in the future:
+The following settings are still configurable through `settings.yml`, but we may remove configuration support for them in the future:
 
 - `tinypilot_keyboard_interface`
 - `tinypilot_mouse_interface`
@@ -31,10 +31,25 @@ The following settings are configurable through `settings.yml`, but we may remov
 
 ## Unsupported Settings (Non-configurable)
 
-The following settings are no longer configurable through `settings.yml`:
+The following settings are unsupported and no longer configurable through `settings.yml`:
 
+- `tinypilot_debian_package_path`
+- `tinypilot_enable_debug_logging`
 - `tinypilot_install_janus`
+- `tinypilot_interface`
+- `tinypilot_port`
+- `ustreamer_brightness`
+- `ustreamer_capture_device`
 - `ustreamer_compile_janus_plugin`
+- `ustreamer_debian_package_path`
+- `ustreamer_edids_dir`
 - `ustreamer_h264_sink`
 - `ustreamer_h264_sink_mode`
 - `ustreamer_h264_sink_rm`
+- `ustreamer_interface`
+- `ustreamer_persistent`
+- `ustreamer_port`
+- `ustreamer_repo`
+- `ustreamer_repo_version`
+- `ustreamer_tcp_nodelay`
+- `ustreamer_video_path`

--- a/docs/user-configurable-settings.md
+++ b/docs/user-configurable-settings.md
@@ -11,10 +11,15 @@ The following settings are supported and remain configurable through `settings.y
 - `tinypilot_external_port`
 - `tinypilot_external_tls_port` (Pro only)
 - `tinypilot_manage_tls_keys` (Pro only)
+  - Whether TinyPilot manages TLS keys. Users can override this setting if they want to [provide their own TLS keys](https://tinypilotkvm.com/faq/own-tls-key).
 - `ustreamer_desired_fps`
+  - Desired frames per second. Defaults to 30 when not set.
 - `ustreamer_edid`
+  - EDID for TC358743 chip.
 - `ustreamer_h264_bitrate`
+  - Set the bitrate in Kb/s for the H264 stream (e.g., 2000). The range of allowed values is [25, 20000]. Defaults to 5000 when not set.
 - `ustreamer_quality`
+  - Quality of the JPEG encoding from 1 to 100 (best). Defaults to 80 when not set.
 
 ## Deprecated Settings (Legacy)
 
@@ -23,11 +28,17 @@ The following settings are still configurable through `settings.yml`, but we may
 - `tinypilot_keyboard_interface`
 - `tinypilot_mouse_interface`
 - `ustreamer_drop_same_frames`
+  - Number of same frames to drop.
 - `ustreamer_encoder`
+  - Encoding method to use, such as `m2m-image`.
 - `ustreamer_format`
+  - Device input format, such as `uyvy`.
 - `ustreamer_resolution`
+  - Stream resolution, such as `1280x720`.
 - `ustreamer_use_dv_timings`
+  - Whether to use Digital Video (DV) timings.
 - `ustreamer_workers`
+  - Number of worker threads to use.
 
 ## Unsupported Settings (Non-configurable)
 

--- a/docs/user-configurable-settings.md
+++ b/docs/user-configurable-settings.md
@@ -1,0 +1,26 @@
+# User Configurable Settings
+
+It is no longer possible to make changes to TinyPilot's undocumented settings through the `/home/tinypilot/settings.yml` file.
+
+## Supported Settings
+
+The following settings are supported and remain configurable through `settings.yml`:
+
+- `tinypilot_external_port`
+- `tinypilot_external_tls_port` (Pro only)
+- `tinypilot_manage_tls_keys` (Pro only)
+- `ustreamer_edid`
+- `ustreamer_desired_fps`
+- `ustreamer_quality`
+- `ustreamer_h264_bitrate`
+- `janus_stun_server`
+- `janus_stun_port`
+
+## Unsupported Settings (Legacy)
+
+The following settings are configurable through `settings.yml`, but we may remove configuration support for them in the future:
+
+- `tinypilot_keyboard_interface`
+- `tinypilot_mouse_interface`
+- `ustreamer_*`
+  - Any uStreamer specific settings that are not explicitly supported above.

--- a/docs/user-configurable-settings.md
+++ b/docs/user-configurable-settings.md
@@ -6,15 +6,15 @@ It is no longer possible to make changes to TinyPilot's undocumented settings th
 
 The following settings are supported and remain configurable through `settings.yml`:
 
+- `janus_stun_server`
+- `janus_stun_port`
 - `tinypilot_external_port`
 - `tinypilot_external_tls_port` (Pro only)
 - `tinypilot_manage_tls_keys` (Pro only)
-- `ustreamer_edid`
 - `ustreamer_desired_fps`
-- `ustreamer_quality`
+- `ustreamer_edid`
 - `ustreamer_h264_bitrate`
-- `janus_stun_server`
-- `janus_stun_port`
+- `ustreamer_quality`
 
 ## Unsupported Settings (Legacy)
 
@@ -22,5 +22,9 @@ The following settings are configurable through `settings.yml`, but we may remov
 
 - `tinypilot_keyboard_interface`
 - `tinypilot_mouse_interface`
-- `ustreamer_*`
-  - Any uStreamer specific settings that are not explicitly supported above.
+- `ustreamer_drop_same_frames`
+- `ustreamer_encoder`
+- `ustreamer_format`
+- `ustreamer_resolution`
+- `ustreamer_use_dv_timings`
+- `ustreamer_workers`


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1573

Since winning the war on Ansible, we've dropped support for many TinyPilot settings that were configurable via `/home/tinypilot/settings.yml`.

Apart from this blog post ([/whats-new-in-2022-05/](https://github.com/tiny-pilot/tinypilotkvm.com/blob/ba842c50235005fb9253e316cf4f85a543548634/content/blog/whats-new-in-2022-05/index.md)) we haven't really documented (publicly) which settings are supported, deprecated, and unsupported. This PR does just that:
* Document preview: [docs/user-configurable-settings.md](https://github.com/tiny-pilot/tinypilot/blob/document-user-configurable-settings/docs/user-configurable-settings.md)

### Notes
1. The list of [supported settings](https://github.com/tiny-pilot/tinypilot/blob/document-user-configurable-settings/docs/user-configurable-settings.md#supported-settings), were compiled from
    * [app/update/settings.py#L76-L86](https://github.com/tiny-pilot/tinypilot-pro/blob/78269651ca646746b7b55d83d19b377a943ec7de/app/update/settings.py#L76-L86)
3. The list of [deprecated settings](https://github.com/tiny-pilot/tinypilot/blob/document-user-configurable-settings/docs/user-configurable-settings.md#deprecated-settings-legacy), were compiled from a combination of
    * [debian-pkg/opt/ustreamer-launcher/launch#L95-L101](https://github.com/tiny-pilot/tinypilot-pro/blob/78269651ca646746b7b55d83d19b377a943ec7de/debian-pkg/opt/ustreamer-launcher/launch#L95-L101)
    * "Unsupported vars" from https://github.com/tiny-pilot/tinypilot-pro/issues/972#issue-1791847326
4. The list of [unsupported settings](https://github.com/tiny-pilot/tinypilot/blob/document-user-configurable-settings/docs/user-configurable-settings.md#unsupported-settings-non-configurable), were compiled from a combination of
    * [2.6.0/ansible-role/defaults/main.yml](https://github.com/tiny-pilot/tinypilot-pro/blob/2.6.0/ansible-role/defaults/main.yml)
    * [2.6.0/ansible-role-ustreamer/defaults/main.yml](https://github.com/tiny-pilot/tinypilot-pro/blob/2.6.0/ansible-role-ustreamer/defaults/main.yml)
    * [blog/whats-new-in-2022-05/index.md#enabling-h264-video](https://github.com/tiny-pilot/tinypilotkvm.com/blob/ba842c50235005fb9253e316cf4f85a543548634/content/blog/whats-new-in-2022-05/index.md#enabling-h264-video)

### Resources used
* https://tinypilotkvm.com/pro/changes#261
* https://github.com/tiny-pilot/tinypilot-pro/issues/972
* [blog/whats-new-in-2022-05/](https://github.com/tiny-pilot/tinypilotkvm.com/blob/ba842c50235005fb9253e316cf4f85a543548634/content/blog/whats-new-in-2022-05/index.md)
* [2.6.0/ansible-role/defaults/main.yml](https://github.com/tiny-pilot/tinypilot-pro/blob/2.6.0/ansible-role/defaults/main.yml)
* [2.6.0/ansible-role-ustreamer/defaults/main.yml](https://github.com/tiny-pilot/tinypilot-pro/blob/2.6.0/ansible-role-ustreamer/defaults/main.yml)

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1788"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>