### PR TITLE
Emulate right click via dual-tap on touch devices

### DIFF
--- a/app/static/js/touch.js
+++ b/app/static/js/touch.js
@@ -42,8 +42,6 @@ export class TouchToMouseAdapter {
     }));
 
     const button = (() => {
-      // If this touch was a right click, use the mouse coordinates from the
-      // first touch point as primary touch.
       if (isRightClick(touchInfos)) {
         return 2;
       }


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1782.

This PR adds support for issuing context clicks from touch devices by tapping with two fingers at once.

- I had to slightly refactor the existing code in order to accommodate the right-click logic. Mainly:
  - `touchInfo` has now become a `touchInfos` list
  - The `isDoubleClick` and `isRightClick` methods now also take that list as first argument. Both function also check the arity of that list, so that they are more self-contained.
- Contrary to [the initial idea in the proof-of-concept branch](https://github.com/tiny-pilot/tinypilot/pull/1779#pullrequestreview-1992508026), I ended up implementing “dual tap” (two-finger tap) rather than “tap and hold” (with one finger). The logic of the latter would have become quite complex, because we then would have to make the decision when the tap is released (stopped), not when it’s started. This also would bring further complexity with it, because more things might happen between touch-start and touch-end, such as a drag-and-drop attempt, or some multi-finger gesture. So I thought it was most simple to implement “dual tap”, because then the logic appeared much simpler, and we can make the decision right away at touch-start time.
- I’ve also added a note to the top-level comment to make it clear that this implementation does not cover all cases 100% correctly.

I have tested this on my iPad, so a code check would suffice from my side.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1789"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>