### PR TITLE
Update change-hostname to use hostnamectl

### DIFF
--- a/debian-pkg/opt/tinypilot-privileged/scripts/change-hostname
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/change-hostname
@@ -8,6 +8,11 @@ set -u
 # Exit on first error.
 set -e
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+readonly SCRIPT_DIR
+# shellcheck source=lib/markers.sh
+. "${SCRIPT_DIR}/lib/markers.sh"
+
 readonly VALID_HOSTNAME_PATTERN='^[-0-9A-Za-z]+$'
 
 print_help() {
@@ -50,6 +55,18 @@ if ! [[ "${NEW_HOSTNAME}" =~ $VALID_HOSTNAME_PATTERN ]] \
   echo 'Invalid hostname' >&2
   exit 1
 fi
+
+# Remove any existing marker sections from the `/etc/hosts` file.
+"${SCRIPT_DIR}/strip-marker-sections" /etc/hosts
+
+# Populate new entry to `/etc/hosts`.
+# Note that the first matching entry takes precedence, which is why we prepend
+# our new entry.
+OLD_ETC_HOSTS="$(</etc/hosts)"
+readonly OLD_ETC_HOSTS
+printf "%s\n127.0.1.1 %s\n%s\n%s\n" \
+  "${MARKER_START}" "${NEW_HOSTNAME}" "${MARKER_END}" "${OLD_ETC_HOSTS}" \
+  > /etc/hosts
 
 # We use `hostnamectl set-hostname xyz` instead of `hostnamectl hostname xyz`
 # because `set-hostname` is backwards compatible with the Bullseye version of

--- a/debian-pkg/opt/tinypilot-privileged/scripts/change-hostname
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/change-hostname
@@ -8,11 +8,6 @@ set -u
 # Exit on first error.
 set -e
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-readonly SCRIPT_DIR
-# shellcheck source=lib/markers.sh
-. "${SCRIPT_DIR}/lib/markers.sh"
-
 readonly VALID_HOSTNAME_PATTERN='^[-0-9A-Za-z]+$'
 
 print_help() {
@@ -56,19 +51,8 @@ if ! [[ "${NEW_HOSTNAME}" =~ $VALID_HOSTNAME_PATTERN ]] \
   exit 1
 fi
 
-# Remove any existing marker sections from the `/etc/hosts` file.
-"${SCRIPT_DIR}/strip-marker-sections" /etc/hosts
-
-# Populate new entry to `/etc/hosts`.
-# Note that the first matching entry takes precedence, which is why we prepend
-# our new entry.
-OLD_ETC_HOSTS="$(</etc/hosts)"
-readonly OLD_ETC_HOSTS
-printf "%s\n127.0.1.1 %s\n%s\n%s\n" \
-  "${MARKER_START}" "${NEW_HOSTNAME}" "${MARKER_END}" "${OLD_ETC_HOSTS}" \
-  > /etc/hosts
-
-# Populate new hostname to `/etc/hostname`.
-# Note that the value must be newline-terminated, see:
-# https://manpages.debian.org/stretch/systemd/hostname.5.en.html
-printf "%s\n" "${NEW_HOSTNAME}" > /etc/hostname
+# We use `hostnamectl set-hostname xyz` instead of `hostnamectl hostname xyz`
+# because `set-hostname` is backwards compatible with the Bullseye version of
+# `hostnamectl`. `hostnamectl hostname xyz` is only supported on the Bookworm
+# version.
+hostnamectl set-hostname "${NEW_HOSTNAME}"


### PR DESCRIPTION
Resolves #1679

This change updates the `change-hostname` script to use `hostnamectl` instead of editing `/etc/hostname` directly.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1803"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>