### PR TITLE
Fix About dialog e2e license link tests

### DIFF
--- a/e2e/about.spec.js
+++ b/e2e/about.spec.js
@@ -108,19 +108,18 @@ test.describe("about dialog", () => {
       links.map((link) => link.getAttribute("href"))
     );
     const failedUrls = [];
-    await Promise.all(
-      paths
-        .map((path) => `${baseURL}${path}`)
-        .map((url) =>
-          fetch(url, { signal: AbortSignal.timeout(10000) })
-            .then((res) => {
-              if (res.status !== 200) {
-                failedUrls.push(url);
-              }
-            })
-            .catch(() => failedUrls.push(url))
-        )
-    );
+    for (const path of paths) {
+      const url = `${baseURL}${path}`;
+      await page.goto(url, { timeout: 10000 })
+        .then((res) => {
+          if (res.status() !== 200) {
+            failedUrls.push(url);
+          }
+        })
+        .catch(() => {
+          failedUrls.push(url);
+        });
+    }
     expect(
       failedUrls.length,
       `License link broken for URLs: ${failedUrls.join(", ")}`

--- a/e2e/about.spec.js
+++ b/e2e/about.spec.js
@@ -110,7 +110,8 @@ test.describe("about dialog", () => {
     const failedUrls = [];
     for (const path of paths) {
       const url = `${baseURL}${path}`;
-      await page.goto(url, { timeout: 10000 })
+      await page
+        .goto(url, { timeout: 10000 })
         .then((res) => {
           if (res.status() !== 200) {
             failedUrls.push(url);

--- a/e2e/about.spec.js
+++ b/e2e/about.spec.js
@@ -102,25 +102,28 @@ test.describe("about dialog", () => {
   test("checks that all license URLs are valid and reachable", async ({
     page,
     baseURL,
+    context,
   }) => {
     const links = await page.locator("a.license").all();
     const paths = await Promise.all(
       links.map((link) => link.getAttribute("href"))
     );
     const failedUrls = [];
-    for (const path of paths) {
-      const url = `${baseURL}${path}`;
-      await page
-        .goto(url, { timeout: 10000 })
-        .then((res) => {
-          if (res.status() !== 200) {
-            failedUrls.push(url);
-          }
+    await Promise.all(
+      paths
+        .map((path) => `${baseURL}${path}`)
+        .map(async (url) => {
+          const page = await context.newPage();
+          await page
+            .goto(url, { timeout: 10000 })
+            .then((res) => {
+              if (res.status() !== 200) {
+                failedUrls.push(url);
+              }
+            })
+            .catch(() => failedUrls.push(url));
         })
-        .catch(() => {
-          failedUrls.push(url);
-        });
-    }
+    );
     expect(
       failedUrls.length,
       `License link broken for URLs: ${failedUrls.join(", ")}`


### PR DESCRIPTION
Resolves #1751

This change fixes the license link tests that fail when running using HTTPS on a live device.

Instead of using `fetch`, the new test uses Playwright's `page.goto` to check for a 200 response from each license URL.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1806"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>