### PR TITLE
Add note about WiFi to help text of WiFi-AP scripts

### DIFF
--- a/debian-pkg/opt/tinypilot-privileged/scripts/disable-wifi-ap
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/disable-wifi-ap
@@ -25,8 +25,8 @@ Disable TinyPilot WiFi access point.
   --help  Display this help and exit.
 
 Note: Running this script will clear any potentially existing custom static IP
-      configuration that might have been added previously by the set-static-ip
-      script.
+      configuration and also any potentially existing WiFi settings that might
+      have been set up previously.
 
 EOF
 }

--- a/debian-pkg/opt/tinypilot-privileged/scripts/enable-wifi-ap
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/enable-wifi-ap
@@ -35,8 +35,8 @@ Enable TinyPilot WiFi access point.
                               Defaults to: ${NETWORK_COUNTRY}
 
 Note: Running this script will clear any potentially existing custom static IP
-      configuration that might have been added previously by the set-static-ip
-      script.
+      configuration and also any potentially existing WiFi settings that might
+      have been set up previously.
 
 EOF
 }


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot/issues/131, subtask (g).

As the WiFi-AP scripts [overwrite the `wpa_supplicant.conf` file](https://github.com/tiny-pilot/tinypilot/blob/6f37e68acbb729d82b76ed0dad0f67763926f29d/debian-pkg/opt/tinypilot-privileged/scripts/enable-wifi-ap#L160-L172), we have to extend the note in the help text that running the scripts will clear any WiFi settings.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1817"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>