### PR TITLE
Unified success state for dialogs

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -39,6 +39,7 @@
   --brand-green-dark: hsl(var(--brand-hue-green), 43%, 33%);
   --brand-green-light: hsl(var(--brand-hue-green), 34%, 70%);
   --brand-green-bright: hsl(var(--brand-hue-green), 70%, 45%);
+  --brand-green-background: hsl(var(--brand-hue-green), 54%, 95%);
 
   /* This is the green color that is used in the logo. It should only be
      scarcely used outside the logo, for example for brand- or marketing-related

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -26,6 +26,14 @@ function showError(errorInfo) {
   document.getElementById("error-overlay").show();
 }
 
+/**
+ * @see `DialogSuccessEvent` for parameter `successInfo`
+ */
+function showSuccess(successInfo) {
+  document.getElementById("success-dialog").setup(successInfo);
+  document.getElementById("success-overlay").show();
+}
+
 function isIgnoredKeystroke(code) {
   // Ignore the keystroke if this is a modifier keycode and the modifier was
   // already pressed. Otherwise, something like holding down the Shift key
@@ -404,6 +412,10 @@ document
 
 document.addEventListener("dialog-failed", (evt) => {
   showError(evt.detail);
+});
+
+document.addEventListener("dialog-success", (evt) => {
+  showSuccess(evt.detail);
 });
 
 const shutdownDialog = document.getElementById("shutdown-dialog");

--- a/app/static/js/events.js
+++ b/app/static/js/events.js
@@ -32,6 +32,24 @@ export class DialogFailedEvent extends CustomEvent {
   }
 }
 
+export class DialogSuccessEvent extends CustomEvent {
+  /**
+   * Event that closes the dialog and displays the success dialog instead.
+   * @param {Object} successInfo
+   * @param {string} successInfo.title - A concise summary of what successfully
+   *     happened.
+   * @param {string} [successInfo.message] - A user-friendly message that
+   *     explains what this successful state means.
+   */
+  constructor(successInfo) {
+    super("dialog-success", {
+      detail: successInfo,
+      bubbles: true,
+      composed: true,
+    });
+  }
+}
+
 export class DialogCloseStateChangedEvent extends CustomEvent {
   /**
    * Event that advises a state change affecting the dialog close

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -50,6 +50,11 @@
       border-top: 0.4rem solid var(--brand-red-bright);
       background-color: var(--brand-red-background);
     }
+
+    :host([variant="success"]) #panel {
+      border-top: 0.4rem solid var(--brand-green-bright);
+      background-color: var(--brand-green-background);
+    }
   </style>
 
   <dialog id="panel">
@@ -86,6 +91,10 @@
             this.show(false)
           );
           this.shadowRoot.addEventListener("dialog-failed", () =>
+            // This event is further handled in `app.js`.
+            this.show(false)
+          );
+          this.shadowRoot.addEventListener("dialog-success", () =>
             // This event is further handled in `app.js`.
             this.show(false)
           );

--- a/app/templates/custom-elements/success-dialog.html
+++ b/app/templates/custom-elements/success-dialog.html
@@ -5,14 +5,13 @@
     #message:empty {
       display: none;
     }
-    #spacer {
-      margin-bottom: 2em;
+    #close {
+      margin-top: 2em;
     }
   </style>
 
   <h3 id="title"></h3>
   <p id="message"></p>
-  <div id="spacer"></div>
   <button id="close">Close</button>
 </template>
 

--- a/app/templates/custom-elements/success-dialog.html
+++ b/app/templates/custom-elements/success-dialog.html
@@ -1,0 +1,49 @@
+<template id="success-dialog-template">
+  <style>
+    @import "css/style.css";
+
+    #message:empty {
+      display: none;
+    }
+    #spacer {
+      margin-bottom: 2em;
+    }
+  </style>
+
+  <h3 id="title"></h3>
+  <p id="message"></p>
+  <div id="spacer"></div>
+  <button id="close">Close</button>
+</template>
+
+<script type="module">
+  import { DialogClosedEvent } from "/js/events.js";
+
+  (function () {
+    const template = document.querySelector("#success-dialog-template");
+
+    customElements.define(
+      "success-dialog",
+      class extends HTMLElement {
+        connectedCallback() {
+          this.attachShadow({ mode: "open" }).appendChild(
+            template.content.cloneNode(true)
+          );
+          this.shadowRoot
+            .getElementById("close")
+            .addEventListener("click", () =>
+              this.dispatchEvent(new DialogClosedEvent())
+            );
+        }
+
+        /**
+         * @see `DialogSuccessEvent` for description of parameters.
+         */
+        setup({ title, message }) {
+          this.shadowRoot.getElementById("title").innerText = title;
+          this.shadowRoot.getElementById("message").innerText = message || "";
+        }
+      }
+    );
+  })();
+</script>

--- a/app/templates/custom-elements/wifi-dialog.html
+++ b/app/templates/custom-elements/wifi-dialog.html
@@ -129,24 +129,6 @@
     <h3>Applying Changes</h3>
     <progress-spinner></progress-spinner>
   </div>
-
-  <div id="success-enabled">
-    <h3>Wi-Fi Credentials Saved</h3>
-    <p>
-      Your Wi-Fi credentials have been saved. When your TinyPilot device is in
-      range of the wireless network, it will automatically try to connect to it.
-    </p>
-    <button class="close-button" type="button">Close</button>
-  </div>
-
-  <div id="success-disabled">
-    <h3>Wi-Fi Credentials Removed</h3>
-    <p>
-      Your Wi-Fi credentials have been removed. Your TinyPilot device will no
-      longer try to connect to the wireless network.
-    </p>
-    <button class="close-button" type="button">Close</button>
-  </div>
 </template>
 
 <script type="module">
@@ -154,6 +136,7 @@
     DialogClosedEvent,
     DialogFailedEvent,
     DialogCloseStateChangedEvent,
+    DialogSuccessEvent,
   } from "/js/events.js";
   import {
     getNetworkStatus,
@@ -173,8 +156,6 @@
           INITIALIZING: "initializing",
           PROMPT: "prompt",
           CHANGING: "changing",
-          SUCCESS_ENABLED: "success-enabled",
-          SUCCESS_DISABLED: "success-disabled",
         };
         _statesWithoutDialogClose = new Set([
           this._states.INITIALIZING,
@@ -333,7 +314,15 @@
             );
             return;
           }
-          this._state = this._states.SUCCESS_ENABLED;
+          this.dispatchEvent(
+            new DialogSuccessEvent({
+              title: "Wi-Fi Credentials Saved",
+              message:
+                "Your Wi-Fi credentials have been saved. When your TinyPilot" +
+                " device is in range of the wireless network, it will" +
+                " automatically try to connect to it.",
+            })
+          );
         }
 
         async _disable() {
@@ -349,7 +338,15 @@
             );
             return;
           }
-          this._state = this._states.SUCCESS_DISABLED;
+          this.dispatchEvent(
+            new DialogSuccessEvent({
+              title: "Wi-Fi Credentials Removed",
+              message:
+                "Your Wi-Fi credentials have been removed. Your TinyPilot" +
+                " device will no longer try to connect to the wireless" +
+                " network.",
+            })
+          );
         }
       }
     );

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -48,6 +48,9 @@
       <overlay-panel id="error-overlay" variant="danger">
         <error-dialog id="error-dialog"></error-dialog>
       </overlay-panel>
+      <overlay-panel id="success-overlay" variant="success">
+        <success-dialog id="success-dialog"></success-dialog>
+      </overlay-panel>
       <overlay-panel id="shutdown-overlay">
         <shutdown-dialog id="shutdown-dialog"></shutdown-dialog>
       </overlay-panel>

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -143,6 +143,10 @@
           class="colorcard"
           style="background-color: var(--brand-green-light)"
         ></div>
+        <div
+          class="colorcard"
+          style="background-color: var(--brand-green-background)"
+        ></div>
         <br style="clear: both" />
         <div
           class="colorcard"
@@ -560,6 +564,26 @@
                 "  fooBarBaz\n".repeat(80),
             });
             document.getElementById("error-overlay").show();
+          });
+      </script>
+      <!-- Success overlay: -->
+      <overlay-panel id="success-overlay" variant="success">
+        <success-dialog id="success-dialog"></success-dialog>
+      </overlay-panel>
+      <button id="show-success-overlay-btn" class="btn-success">
+        Open Success Overlay
+      </button>
+      <script type="module">
+        document
+          .getElementById("show-success-overlay-btn")
+          .addEventListener("click", () => {
+            document.getElementById("success-dialog").setup({
+              title: "Example Success Message",
+              message:
+                "The title is set in Title Case. The message should be" +
+                " user-friendly and explain what this successful state means.",
+            });
+            document.getElementById("success-overlay").show();
           });
       </script>
       <h3>Loading States</h3>


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1639

This PR adds the `<success-dialog>` component, similar to the `<error-dialog>` component, but for successful states where the user's only next action is to close the dialog.

Screenshot
<img width="1021" alt="Screen Shot 2024-08-02 at 16 23 55" src="https://github.com/user-attachments/assets/edeaaf6a-a492-44db-bf69-1ca780d7c992">

Notes
1. I made use of the `<success-dialog>` within the `<wifi-dialog>`, replacing the `success-enabled` and `success-disabled` states.
2. I did not use of the `<success-dialog>` within the `<update-dialog>` to replace the `update-finished` state because it has a more complex structure where it displays the update logs:
    - https://github.com/tiny-pilot/tinypilot/blob/b7c75575f36365b80c2f1b0cfc73826e92aa56a0/app/templates/custom-elements/update-dialog.html#L103-L111
3. I did not use of the `<success-dialog>` within the `<shutdown-dialog>` to replace the `shutdown-complete` state because we don't even give the user an option to close the dialog:
    - https://github.com/tiny-pilot/tinypilot/blob/b7c75575f36365b80c2f1b0cfc73826e92aa56a0/app/templates/custom-elements/shutdown-dialog.html#L55-L57


<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1833"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>