### PR TITLE
Unify initialization procedure of dialogs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -352,7 +352,7 @@ class extends HTMLElement {
 The class property `_states` can then be used in the JavaScript component code:
 
 ```javascript
-this._state = this._states.FETCH_FROM_URL;
+this._state = this._states.INITIALIZING;
 ```
 
 We then use CSS rules based on the `state` attribute to control the component's appearance:
@@ -387,6 +387,19 @@ We then use CSS rules based on the `state` attribute to control the component's 
 This ensures that the elements in the `<div id="initializing">` only appear when the component's state is `initializing`.
 
 Prefer to change a web component's appearance based on attributes and CSS rules as opposed to JavaScript that manipulates the `.style` attributes of elements within the component.
+
+We can then initialize the component when the dialog is opened by listening for the `overlay-toggled` event:
+
+```javascript
+connectedCallback() {
+  this.addEventListener("overlay-toggled", (evt) => {
+    if (!evt.detail.isShown) {
+      return;
+    }
+    this._state = this._states.INITIALIZING;
+  });
+}
+```
 
 ### Disable closing a dialog
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -388,16 +388,13 @@ This ensures that the elements in the `<div id="initializing">` only appear when
 
 Prefer to change a web component's appearance based on attributes and CSS rules as opposed to JavaScript that manipulates the `.style` attributes of elements within the component.
 
-We can then initialize the component when the dialog is opened by listening for the `overlay-toggled` event:
+We can then initialize the component when the dialog is opened by listening for the `overlay-shown` event:
 
 ```javascript
 connectedCallback() {
-  this.addEventListener("overlay-toggled", (evt) => {
-    if (!evt.detail.isShown) {
-      return;
-    }
-    this._state = this._states.INITIALIZING;
-  });
+  this.addEventListener("overlay-shown", () => {
+    this._state = this._states.INITIALIZING);
+  };
 }
 ```
 

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -230,8 +230,11 @@ document.onload = document.getElementById("app").focus();
 
 document.addEventListener("keydown", onKeyDown);
 document.addEventListener("keyup", onKeyUp);
-document.addEventListener("overlay-toggled", (evt) => {
-  overlayTracker.trackStatus(evt.detail.overlay, evt.detail.isShown);
+document.addEventListener("overlay-shown", (evt) => {
+  overlayTracker.trackStatus(evt.detail.overlay, /*isShown=*/ true);
+});
+document.addEventListener("overlay-hidden", (evt) => {
+  overlayTracker.trackStatus(evt.detail.overlay, /*isShown=*/ false);
 });
 document.addEventListener("video-streaming-mode-changed", (evt) => {
   document.getElementById("status-bar").videoStreamIndicator.mode =

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -231,7 +231,7 @@ document.onload = document.getElementById("app").focus();
 document.addEventListener("keydown", onKeyDown);
 document.addEventListener("keyup", onKeyUp);
 document.addEventListener("overlay-toggled", (evt) => {
-  overlayTracker.trackStatus(evt.target, evt.detail.isShown);
+  overlayTracker.trackStatus(evt.detail.overlay, evt.detail.isShown);
 });
 document.addEventListener("video-streaming-mode-changed", (evt) => {
   document.getElementById("status-bar").videoStreamIndicator.mode =
@@ -314,35 +314,21 @@ menuBar.addEventListener("update-dialog-requested", () => {
   document.getElementById("update-dialog").checkVersion();
 });
 menuBar.addEventListener("change-hostname-dialog-requested", () => {
-  // Note: we have to call `initialize()` after `show()`, to ensure that the
-  // dialog is able to focus the main input element.
-  // See https://github.com/tiny-pilot/tinypilot/issues/1770
   document.getElementById("change-hostname-overlay").show();
-  document.getElementById("change-hostname-dialog").initialize();
 });
 menuBar.addEventListener("wifi-dialog-requested", () => {
-  // Note: we have to call `initialize()` after `show()`, to ensure that the
-  // dialog is able to focus the main input element.
-  // See https://github.com/tiny-pilot/tinypilot/issues/1770
   document.getElementById("wifi-overlay").show();
-  document.getElementById("wifi-dialog").initialize();
 });
 menuBar.addEventListener("network-status-dialog-requested", () => {
-  // Note: we have to call `initialize()` after `show()`, to ensure that the
-  // dialog is able to focus the main input element.
-  // See https://github.com/tiny-pilot/tinypilot/issues/1770
   document.getElementById("network-status-overlay").show();
-  document.getElementById("network-status-dialog").initialize();
 });
 menuBar.addEventListener("fullscreen-requested", () => {
   document.getElementById("remote-screen").fullscreen = true;
 });
 menuBar.addEventListener("debug-logs-dialog-requested", () => {
-  document.getElementById("debug-dialog").retrieveLogs();
   document.getElementById("debug-overlay").show();
 });
 menuBar.addEventListener("about-dialog-requested", () => {
-  document.getElementById("about-dialog").initialize();
   document.getElementById("about-overlay").show();
 });
 menuBar.addEventListener("mass-storage-dialog-requested", () => {
@@ -355,15 +341,10 @@ menuBar.addEventListener("static-ip-dialog-requested", () => {
   document.getElementById("feature-pro-overlay").show();
 });
 menuBar.addEventListener("video-settings-dialog-requested", () => {
-  document.getElementById("video-settings-dialog").initialize();
   document.getElementById("video-settings-overlay").show();
 });
 menuBar.addEventListener("paste-dialog-requested", () => {
-  // Note: we have to call `initialize()` after `show()`, to ensure that the
-  // dialog is able to focus the main input element.
-  // See https://github.com/tiny-pilot/tinypilot/issues/1770
   document.getElementById("paste-overlay").show();
-  document.getElementById("paste-dialog").initialize();
 });
 menuBar.addEventListener("ctrl-alt-del-requested", () => {
   // Even though only the final keystroke matters, send them one at a time to

--- a/app/templates/custom-elements/about-dialog.html
+++ b/app/templates/custom-elements/about-dialog.html
@@ -82,6 +82,12 @@
           this.attachShadow({ mode: "open" }).appendChild(
             template.content.cloneNode(true)
           );
+          this.addEventListener("overlay-toggled", (evt) => {
+            if (!evt.detail.isShown) {
+              return;
+            }
+            this._initialize();
+          });
           this.shadowRoot
             .querySelector(".close-btn")
             .addEventListener("click", () =>
@@ -89,7 +95,7 @@
             );
         }
 
-        initialize() {
+        _initialize() {
           this._checkVersion();
           this._populateCredits();
         }
@@ -111,6 +117,7 @@
         }
 
         _populateCredits() {
+          this.shadowRoot.querySelector(".credits").innerHTML = "";
           getLicensingMetadata().then((metadata) => {
             // Sort credits by project name.
             metadata.sort((a, b) => a.name.localeCompare(b.name, "en"));

--- a/app/templates/custom-elements/about-dialog.html
+++ b/app/templates/custom-elements/about-dialog.html
@@ -112,7 +112,6 @@
         }
 
         _populateCredits() {
-          this.shadowRoot.querySelector(".credits").innerHTML = "";
           getLicensingMetadata().then((metadata) => {
             // Sort credits by project name.
             metadata.sort((a, b) => a.name.localeCompare(b.name, "en"));

--- a/app/templates/custom-elements/about-dialog.html
+++ b/app/templates/custom-elements/about-dialog.html
@@ -82,12 +82,7 @@
           this.attachShadow({ mode: "open" }).appendChild(
             template.content.cloneNode(true)
           );
-          this.addEventListener("overlay-toggled", (evt) => {
-            if (!evt.detail.isShown) {
-              return;
-            }
-            this._initialize();
-          });
+          this.addEventListener("overlay-shown", () => this._initialize());
           this.shadowRoot
             .querySelector(".close-btn")
             .addEventListener("click", () =>

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -125,6 +125,12 @@
             futureLocation: this.shadowRoot.getElementById("future-location"),
           };
 
+          this.addEventListener("overlay-toggled", (evt) => {
+            if (!evt.detail.isShown) {
+              return;
+            }
+            this._initialize();
+          });
           this._elements.hostnameInput.addEventListener("input", () => {
             this._onInputChanged();
           });
@@ -162,7 +168,7 @@
           this.setAttribute("initial-hostname", initialHostname);
         }
 
-        initialize() {
+        _initialize() {
           this._elements.inputError.hide();
           this._state = this._states.INITIALIZING;
           determineHostname()

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -125,12 +125,7 @@
             futureLocation: this.shadowRoot.getElementById("future-location"),
           };
 
-          this.addEventListener("overlay-toggled", (evt) => {
-            if (!evt.detail.isShown) {
-              return;
-            }
-            this._initialize();
-          });
+          this.addEventListener("overlay-shown", () => this._initialize());
           this._elements.hostnameInput.addEventListener("input", () => {
             this._onInputChanged();
           });

--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -82,9 +82,6 @@
         constructor() {
           super();
           this.attachShadow({ mode: "open" });
-          // Ensure that these methods always refer to the correct "this",
-          // regardless of where they are called.
-          this.retrieveLogs = this.retrieveLogs.bind(this);
         }
 
         connectedCallback() {
@@ -106,6 +103,13 @@
             shareLogsButton:
               this.shadowRoot.querySelector("#share-logs-button"),
           };
+
+          this.addEventListener("overlay-toggled", (evt) => {
+            if (!evt.detail.isShown) {
+              return;
+            }
+            this._initialize();
+          });
           this._elements.includeSensitiveData.addEventListener(
             "input",
             (event) => {
@@ -145,7 +149,7 @@
           return this.hasAttribute("include-sensitive-data");
         }
 
-        retrieveLogs() {
+        _initialize() {
           this._state = this._states.LOGS_LOADING;
           getDebugLogs()
             .then((text) => {

--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -104,12 +104,7 @@
               this.shadowRoot.querySelector("#share-logs-button"),
           };
 
-          this.addEventListener("overlay-toggled", (evt) => {
-            if (!evt.detail.isShown) {
-              return;
-            }
-            this._initialize();
-          });
+          this.addEventListener("overlay-shown", () => this._initialize());
           this._elements.includeSensitiveData.addEventListener(
             "input",
             (event) => {

--- a/app/templates/custom-elements/network-status-dialog.html
+++ b/app/templates/custom-elements/network-status-dialog.html
@@ -68,26 +68,21 @@
           this._updateTicker = null;
 
           this.addEventListener("overlay-toggled", (evt) => {
-            if (!evt.detail.isShown) {
+            if (evt.detail.isShown) {
+              this._initialize();
               return;
             }
-            this._initialize();
+            // Stop the update ticker when the dialog is closed, otherwise the
+            // status requests would continue to be fired even when the dialog
+            // is not visible anymore.
+            this._shouldAutoUpdate = false;
+            clearTimeout(this._updateTicker);
           });
           this.shadowRoot
             .querySelector("#close-button")
             .addEventListener("click", () => {
               this.dispatchEvent(new DialogClosedEvent());
             });
-          // Stop the update ticker when the dialog is closed, otherwise the
-          // status requests would continue to be fired even when the dialog is
-          // not visible anymore.
-          this.addEventListener("overlay-toggled", (evt) => {
-            if (evt.detail.isShown) {
-              return;
-            }
-            this._shouldAutoUpdate = false;
-            clearTimeout(this._updateTicker);
-          });
         }
 
         get _state() {

--- a/app/templates/custom-elements/network-status-dialog.html
+++ b/app/templates/custom-elements/network-status-dialog.html
@@ -67,11 +67,8 @@
           this._shouldAutoUpdate = false;
           this._updateTicker = null;
 
-          this.addEventListener("overlay-toggled", (evt) => {
-            if (evt.detail.isShown) {
-              this._initialize();
-              return;
-            }
+          this.addEventListener("overlay-shown", () => this._initialize());
+          this.addEventListener("overlay-hidden", () => {
             // Stop the update ticker when the dialog is closed, otherwise the
             // status requests would continue to be fired even when the dialog
             // is not visible anymore.

--- a/app/templates/custom-elements/network-status-dialog.html
+++ b/app/templates/custom-elements/network-status-dialog.html
@@ -66,20 +66,27 @@
           };
           this._shouldAutoUpdate = false;
           this._updateTicker = null;
+
+          this.addEventListener("overlay-toggled", (evt) => {
+            if (!evt.detail.isShown) {
+              return;
+            }
+            this._initialize();
+          });
           this.shadowRoot
             .querySelector("#close-button")
             .addEventListener("click", () => {
               this.dispatchEvent(new DialogClosedEvent());
             });
-
-          // For all events that terminate the dialog, make sure to stop the
-          // update ticker, otherwise the status requests would continue to be
-          // fired even when the dialog is not visible anymore.
-          ["dialog-closed", "dialog-failed"].forEach((evtName) => {
-            this.addEventListener(evtName, () => {
-              this._shouldAutoUpdate = false;
-              clearTimeout(this._updateTicker);
-            });
+          // Stop the update ticker when the dialog is closed, otherwise the
+          // status requests would continue to be fired even when the dialog is
+          // not visible anymore.
+          this.addEventListener("overlay-toggled", (evt) => {
+            if (evt.detail.isShown) {
+              return;
+            }
+            this._shouldAutoUpdate = false;
+            clearTimeout(this._updateTicker);
           });
         }
 
@@ -96,7 +103,7 @@
           );
         }
 
-        async initialize() {
+        async _initialize() {
           this._state = this._states.INITIALIZING;
           await this._update();
           this._state = this._states.DISPLAY;

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -112,31 +112,39 @@
         show(isShown = true) {
           if (isShown) {
             this._elements.dialog.showModal();
+            this._injectEvent(
+              new CustomEvent("overlay-shown", {
+                detail: { overlay: this },
+                bubbles: true,
+                composed: true,
+              })
+            );
           } else {
             this._elements.dialog.close();
-          }
-          // Dispatch overlay-toggled event into slotted element(s), to allow
-          // the dialog to react to it if need be (e.g., for performing
-          // initializations/clean-ups). In theory, there could be multiple
-          // elements in the slot, so they all need to receive the event – hence
-          // the `forEach`. In reality, we usually only slot a single dialog
-          // element, though.
-          this.shadowRoot
-            .querySelector("#dialog-slot")
-            .assignedElements()
-            .forEach((el) =>
-              el.dispatchEvent(
-                new CustomEvent("overlay-toggled", {
-                  detail: { isShown, overlay: this },
-                  bubbles: true,
-                  composed: true,
-                })
-              )
+            this._injectEvent(
+              new CustomEvent("overlay-hidden", {
+                detail: { overlay: this },
+                bubbles: true,
+                composed: true,
+              })
             );
+          }
         }
 
         isShown() {
           return this._elements.dialog.open;
+        }
+
+        // Dispatch an event into the slotted element(s), to allow the dialog to
+        // react to it if need be (e.g., for performing initializations/
+        // clean-ups). In theory, there could be multiple elements in the slot,
+        // so they all need to receive the event – hence the `forEach`. In
+        // reality, we usually only slot a single dialog element, though.
+        _injectEvent(event) {
+          this.shadowRoot
+            .querySelector("#dialog-slot")
+            .assignedElements()
+            .forEach((el) => el.dispatchEvent(event));
         }
       }
     );

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -101,20 +101,10 @@
               }
             }
           );
-          // Dispatch dialog-closed event into slotted element(s), to allow the
-          // dialog to react to it if need be (e.g., for performing clean-ups).
-          // In theory, there could be multiple elements in the slot, so they
-          // all need to receive the close event – hence the `forEach`. In
-          // reality, we usually only slot a single dialog element, though. It
-          // shouldn’t matter anyway, since the dialog-closed event handler is
-          // idempotent.
           this.shadowRoot
             .querySelector("#close-button")
             .addEventListener("click", () =>
-              this.shadowRoot
-                .querySelector("#dialog-slot")
-                .assignedElements()
-                .forEach((el) => el.dispatchEvent(new DialogClosedEvent()))
+              this.show(false)
             );
           // Prevent auto-close behavior of native <dialog> if the user presses
           // the ESC key.
@@ -129,13 +119,22 @@
           } else {
             this._elements.dialog.close();
           }
-          this.dispatchEvent(
-            new CustomEvent("overlay-toggled", {
-              detail: { isShown },
-              bubbles: true,
-              composed: true,
-            })
-          );
+          // Dispatch overlay-toggled event into slotted element(s), to allow
+          // the dialog to react to it if need be (e.g., for performing
+          // initializations/clean-ups). In theory, there could be multiple
+          // elements in the slot, so they all need to receive the event – hence
+          // the `forEach`. In reality, we usually only slot a single dialog
+          // element, though.
+          this.shadowRoot
+            .querySelector("#dialog-slot")
+            .assignedElements()
+            .forEach((el) => el.dispatchEvent(
+              new CustomEvent("overlay-toggled", {
+                detail: { isShown, overlay: this },
+                bubbles: true,
+                composed: true,
+              })
+            ));
         }
 
         isShown() {

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -66,8 +66,6 @@
 </template>
 
 <script type="module">
-  import { DialogClosedEvent } from "/js/events.js";
-
   (function () {
     const template = document.querySelector("#overlay-panel-template");
 

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -103,9 +103,7 @@
           );
           this.shadowRoot
             .querySelector("#close-button")
-            .addEventListener("click", () =>
-              this.show(false)
-            );
+            .addEventListener("click", () => this.show(false));
           // Prevent auto-close behavior of native <dialog> if the user presses
           // the ESC key.
           this._elements.dialog.addEventListener("cancel", (evt) => {
@@ -128,13 +126,15 @@
           this.shadowRoot
             .querySelector("#dialog-slot")
             .assignedElements()
-            .forEach((el) => el.dispatchEvent(
-              new CustomEvent("overlay-toggled", {
-                detail: { isShown, overlay: this },
-                bubbles: true,
-                composed: true,
-              })
-            ));
+            .forEach((el) =>
+              el.dispatchEvent(
+                new CustomEvent("overlay-toggled", {
+                  detail: { isShown, overlay: this },
+                  bubbles: true,
+                  composed: true,
+                })
+              )
+            );
         }
 
         isShown() {

--- a/app/templates/custom-elements/paste-dialog.html
+++ b/app/templates/custom-elements/paste-dialog.html
@@ -93,6 +93,13 @@
             cancelButton: this.shadowRoot.querySelector("#cancel-btn"),
             maskInputButton: this.shadowRoot.querySelector("#mask-input"),
           };
+
+          this.addEventListener("overlay-toggled", (evt) => {
+            if (!evt.detail.isShown) {
+              return;
+            }
+            this._initialize();
+          });
           this._elements.pasteArea.addEventListener("input", () =>
             this._elements.confirmButton.toggleAttribute(
               "disabled",
@@ -118,7 +125,7 @@
           });
         }
 
-        initialize() {
+        _initialize() {
           this.toggleAttribute("mask-input", isPasteAreaMasked());
           this._elements.maskInputButton.checked = isPasteAreaMasked();
           this._elements.pasteArea.value = "";

--- a/app/templates/custom-elements/paste-dialog.html
+++ b/app/templates/custom-elements/paste-dialog.html
@@ -94,12 +94,7 @@
             maskInputButton: this.shadowRoot.querySelector("#mask-input"),
           };
 
-          this.addEventListener("overlay-toggled", (evt) => {
-            if (!evt.detail.isShown) {
-              return;
-            }
-            this._initialize();
-          });
+          this.addEventListener("overlay-shown", () => this._initialize());
           this._elements.pasteArea.addEventListener("input", () =>
             this._elements.confirmButton.toggleAttribute(
               "disabled",

--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -274,12 +274,7 @@
             ),
           };
 
-          this.addEventListener("overlay-toggled", (evt) => {
-            if (!evt.detail.isShown) {
-              return;
-            }
-            this._initialize();
-          });
+          this.addEventListener("overlay-shown", () => this._initialize());
           this._elements.closeButton.addEventListener("click", () =>
             this.dispatchEvent(new DialogClosedEvent())
           );

--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -273,6 +273,13 @@
               "#stun-validation-error"
             ),
           };
+
+          this.addEventListener("overlay-toggled", (evt) => {
+            if (!evt.detail.isShown) {
+              return;
+            }
+            this._initialize();
+          });
           this._elements.closeButton.addEventListener("click", () =>
             this.dispatchEvent(new DialogClosedEvent())
           );
@@ -362,7 +369,7 @@
           );
         }
 
-        initialize() {
+        _initialize() {
           this._state = this._states.LOADING;
 
           // Reset all transient view state.

--- a/app/templates/custom-elements/wifi-dialog.html
+++ b/app/templates/custom-elements/wifi-dialog.html
@@ -201,6 +201,12 @@
             disableButton: this.shadowRoot.querySelector("#disable-button"),
           };
 
+          this.addEventListener("overlay-toggled", (evt) => {
+            if (!evt.detail.isShown) {
+              return;
+            }
+            this._initialize();
+          });
           [
             this._elements.ssidInput,
             this._elements.pskInput,
@@ -243,7 +249,7 @@
           );
         }
 
-        async initialize() {
+        async _initialize() {
           this._state = this._states.INITIALIZING;
           let wifiSettings, networkStatus;
           try {

--- a/app/templates/custom-elements/wifi-dialog.html
+++ b/app/templates/custom-elements/wifi-dialog.html
@@ -201,12 +201,7 @@
             disableButton: this.shadowRoot.querySelector("#disable-button"),
           };
 
-          this.addEventListener("overlay-toggled", (evt) => {
-            if (!evt.detail.isShown) {
-              return;
-            }
-            this._initialize();
-          });
+          this.addEventListener("overlay-shown", () => this._initialize());
           [
             this._elements.ssidInput,
             this._elements.pskInput,


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1773

This PR replaces the `overlay-toggled` event with two separate `overlay-shown`/`overlay-hidden` events and fires them into the slotted (dialog) element which allows slotted custom components to initialize themselves when the dialog is shown. For example:

```javascript
connectedCallback() {
  // ...
  this.addEventListener("overlay-shown", () => {
    this._state = this._states.INITIALIZING;
  });
}
```

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1835"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>