### PR TITLE
Use bash arithmetic checks

### DIFF
--- a/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/collect-debug-logs
@@ -46,7 +46,7 @@ while getopts "hq" opt; do
     esac
 done
 
-if [[ "${EUID}" -ne 0 ]]; then
+if (( "${EUID}" != 0 )); then
   echo "This script requires root privileges." >&2
   echo "Please re-run with sudo:" >&2
   echo "  sudo ${0}" >&2

--- a/debian-pkg/opt/tinypilot-privileged/scripts/print-marker-sections.bats
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/print-marker-sections.bats
@@ -22,7 +22,7 @@ Prints the contents of marker sections from a file.
 EOF
   )"
 
-  [[ "${status}" == 0 ]]
+  (( "${status}" == 0 ))
   [[ "${output}" == "${expected_output}" ]]
 }
 
@@ -34,7 +34,7 @@ Use the '--help' flag for more information
 EOF
   )"
 
-  [[ "${status}" == 1 ]]
+  (( "${status}" == 1 ))
   [[ "${output}" == "${expected_output}" ]]
 }
 
@@ -46,7 +46,7 @@ Use the '--help' flag for more information
 EOF
   )"
 
-  [[ "${status}" == 1 ]]
+  (( "${status}" == 1 ))
   [[ "${output}" == "${expected_output}" ]]
 }
 
@@ -58,7 +58,7 @@ Use the '--help' flag for more information
 EOF
   )"
 
-  [[ "${status}" == 1 ]]
+  (( "${status}" == 1 ))
   [[ "${output}" == "${expected_output}" ]]
 }
 
@@ -71,7 +71,7 @@ Use the '--help' flag for more information
 EOF
   )"
 
-  [[ "${status}" == 1 ]]
+  (( "${status}" == 1 ))
   [[ "${output}" == "${expected_output}" ]]
 }
 
@@ -84,7 +84,7 @@ line 3
 EOF
   run print-marker-sections "${target_file}"
 
-  [[ "${status}" == 0 ]]
+  (( "${status}" == 0 ))
   [[ "${output}" == "" ]]
 }
 
@@ -106,7 +106,7 @@ printed
 EOF
   )"
 
-  [[ "${status}" == 0 ]]
+  (( "${status}" == 0 ))
   [[ "${output}" == "${expected_output}" ]]
 }
 
@@ -131,7 +131,7 @@ printed
 EOF
   )"
 
-  [[ "${status}" == 0 ]]
+  (( "${status}" == 0 ))
   [[ "${output}" == "${expected_output}" ]]
 }
 
@@ -144,7 +144,7 @@ to be printed
 EOF
   run print-marker-sections "${target_file}"
 
-  [[ "${status}" == 1 ]]
+  (( "${status}" == 1 ))
   [[ "${output}" == "Unmatched start marker" ]]
 }
 
@@ -157,6 +157,6 @@ final line
 EOF
   run print-marker-sections "${target_file}"
 
-  [[ "${status}" == 1 ]]
+  (( "${status}" == 1 ))
   [[ "${output}" == 'Unmatched end marker' ]]
 }

--- a/debian-pkg/opt/tinypilot-privileged/scripts/read-update-log
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/read-update-log
@@ -8,7 +8,7 @@ set -e
 # Treat undefined environment variables as errors.
 set -u
 
-if [[ "${EUID}" -ne 0 ]]; then
+if (( "${EUID}" != 0 )); then
   echo "This script requires root privileges." >&2
   echo "Please re-run with sudo:" >&2
   echo "  sudo ${0}" >&2

--- a/debian-pkg/opt/tinypilot-privileged/scripts/strip-marker-sections.bats
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/strip-marker-sections.bats
@@ -22,28 +22,28 @@ Strips TinyPilot marker sections from a file.
 EOF
   )"
 
-  [[ "${status}" == 0 ]]
+  (( "${status}" == 0 ))
   [[ "${output}" == "${expected_output}" ]]
 }
 
 rejects-missing-input-arg() { #@test
   run strip-marker-sections
 
-  [[ "${status}" == 1 ]]
+  (( "${status}" == 1 ))
   [[ "${output}" == 'Input parameter missing: TARGET_FILE' ]]
 }
 
 rejects-illegal-flag() { #@test
   run strip-marker-sections --foo
 
-  [[ "${status}" == 1 ]]
+  (( "${status}" == 1 ))
   [[ "${output}" == 'Illegal option: --foo' ]]
 }
 
 rejects-non-existing-file() { #@test
   run strip-marker-sections foo-file.txt
 
-  [[ "${status}" == 1 ]]
+  (( "${status}" == 1 ))
   [[ "${output}" == 'Not a file: foo-file.txt' ]]
 }
 
@@ -51,7 +51,7 @@ rejects-non-file() { #@test
   tmp_dir="$(mktemp --directory)"
   run strip-marker-sections "${tmp_dir}"
 
-  [[ "${status}" == 1 ]]
+  (( "${status}" == 1 ))
   [[ "${output}" == "Not a file: ${tmp_dir}" ]]
 }
 
@@ -71,7 +71,7 @@ line 3
 EOF
   )"
 
-  [[ "${status}" == 0 ]]
+  (( "${status}" == 0 ))
   [[ "${output}" == "" ]]
   [[ "${actual_contents}" == "${expected_contents}" ]]
 }
@@ -92,7 +92,7 @@ EOF
 EOF
   )"
 
-  [[ "${status}" == 0 ]]
+  (( "${status}" == 0 ))
   [[ "${output}" == "" ]]
   [[ "${actual_contents}" == "${expected_contents}" ]]
 }
@@ -116,7 +116,7 @@ final line
 EOF
   )"
 
-  [[ "${status}" == 0 ]]
+  (( "${status}" == 0 ))
   [[ "${output}" == "" ]]
   [[ "${actual_contents}" == "${expected_contents}" ]]
 }
@@ -145,7 +145,7 @@ final line
 EOF
   )"
 
-  [[ "${status}" == 0 ]]
+  (( "${status}" == 0 ))
   [[ "${output}" == "" ]]
   [[ "${actual_contents}" == "${expected_contents}" ]]
 }
@@ -166,7 +166,7 @@ to be stripped
 EOF
   )"
 
-  [[ "${status}" == 1 ]]
+  (( "${status}" == 1 ))
   [[ "${output}" == "Unmatched start marker" ]]
   [[ "${actual_contents}" == "${expected_contents}" ]]
 }
@@ -187,7 +187,7 @@ final line
 EOF
   )"
 
-  [[ "${status}" == 1 ]]
+  (( "${status}" == 1 ))
   [[ "${output}" == 'Unmatched end marker' ]]
   [[ "${actual_contents}" == "${expected_contents}" ]]
 }

--- a/dev-scripts/check-privilege-guard
+++ b/dev-scripts/check-privilege-guard
@@ -23,7 +23,7 @@ if [[ -n "${MATCHES}" ]]; then
   >&2 echo "${MATCHES}"
   >&2 echo 'Please add the following check (or similar) to the above scripts:'
   >&2 cat <<'EOF'
-if [[ "${EUID}" == 0 ]]; then
+if (( "${EUID}" == 0 )); then
   >&2 echo "This script doesn't require root privileges."
   >&2 echo 'Please re-run as tinypilot:'
   >&2 echo "  runuser tinypilot --command '$0 $*'"

--- a/dev-scripts/device/install-bundle
+++ b/dev-scripts/device/install-bundle
@@ -19,7 +19,7 @@ set -u
 # Exit on first error.
 set -e
 
-if [[ "${EUID}" -ne 0 ]]; then
+if (( "${EUID}" != 0 )); then
   echo "This script requires root privileges." >&2
   echo "Please re-run with sudo:" >&2
   echo "  sudo $0 $*" >&2

--- a/dev-scripts/enable-mock-scripts
+++ b/dev-scripts/enable-mock-scripts
@@ -6,7 +6,7 @@
 # Exit on first failure.
 set -e
 
-if [[ "${EUID}" -ne 0 ]]; then
+if (( "${EUID}" != 0 )); then
   echo "This script requires root privileges." >&2
   echo "Please re-run with sudo:" >&2
   echo "  sudo ${0}" >&2

--- a/dev-scripts/enable-passwordless-sudo
+++ b/dev-scripts/enable-passwordless-sudo
@@ -15,7 +15,7 @@
 # To undo this script's changes, run:
 #   sudo rm /etc/sudoers.d/tinypilot
 
-if [[ "${EUID}" -ne 0 ]]; then
+if (( "${EUID}" != 0 )); then
   echo "This script requires root privileges." >&2
   echo "Please re-run with sudo:" >&2
   echo "  sudo ${0}" >&2

--- a/scripts/is-ssh-enabled
+++ b/scripts/is-ssh-enabled
@@ -8,7 +8,7 @@ set -u
 # Exit on first error.
 set -e
 
-if [[ "${EUID}" == 0 ]]; then
+if (( "${EUID}" == 0 )); then
   >&2 echo "This script doesn't require root privileges."
   >&2 echo 'Please re-run as tinypilot:'
   >&2 echo "  runuser tinypilot --command '$0 $*'"

--- a/scripts/streaming-mode
+++ b/scripts/streaming-mode
@@ -8,7 +8,7 @@ set -e
 # Exit on unset variable.
 set -u
 
-if [[ "${EUID}" == 0 ]]; then
+if (( "${EUID}" == 0 )); then
   >&2 echo "This script doesn't require root privileges."
   >&2 echo 'Please re-run as tinypilot:'
   >&2 echo "  runuser tinypilot --command '$0 $*'"


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1780

This PR align our bash scripts with the [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html#s6.9-arithmetic):
> For preference, don’t use `[[ … ]]` at all for numeric comparisons, use `(( … ))` instead.

Notes:
1. I've replaced numerics checks using `[[ -ne ]]` with `(( != ))`
2. I've replaced numerics checks using `[[ == ]]` with `(( == ))`

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1836"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>