### PR TITLE
Add additional keyboard shortcuts

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -387,6 +387,56 @@ menuBar.addEventListener("ctrl-alt-del-requested", () => {
     code: "Delete",
   });
 });
+menuBar.addEventListener("ctrl-alt-backspace-requested", () => {
+  processKeystroke({
+    ctrlLeft: true,
+    key: "Control",
+    code: "ControlLeft",
+  });
+  processKeystroke({
+    ctrlLeft: true,
+    altLeft: true,
+    key: "Alt",
+    code: "AltLeft",
+  });
+  processKeystroke({
+    ctrlLeft: true,
+    altLeft: true,
+    key: "Backspace",
+    code: "Backspace",
+  });
+});
+menuBar.addEventListener("meta-alt-escape-requested", () => {
+  processKeystroke({
+    metaLeft: true,
+    key: "Meta",
+    code: "MetaLeft",
+  });
+  processKeystroke({
+    metaLeft: true,
+    altLeft: true,
+    key: "Alt",
+    code: "AltLeft",
+  });
+  processKeystroke({
+    metaLeft: true,
+    altLeft: true,
+    key: "Esc",
+    code: "Escape",
+  });
+});
+menuBar.addEventListener("alt-tab-requested", () => {
+  processKeystroke({
+    altLeft: true,
+    key: "Alt",
+    code: "AltLeft",
+  });
+  processKeystroke({
+    altLeft: true,
+    key: "Tab",
+    code: "Tab",
+  });
+});
 
 setKeystrokeHistoryStatus(settings.isKeystrokeHistoryEnabled());
 

--- a/app/templates/custom-elements/menu-bar.html
+++ b/app/templates/custom-elements/menu-bar.html
@@ -293,6 +293,21 @@
                 >Ctrl + Alt + Del</a
               >
             </li>
+            <li class="item" role="presentation">
+              <a data-onclick-event="ctrl-alt-backspace-requested" role="menuitem"
+                >Ctrl + Alt + Backspace</a
+              >
+            </li>
+            <li class="item" role="presentation">
+              <a data-onclick-event="meta-alt-escape-requested" role="menuitem"
+                >Meta + Alt + Escape</a
+              >
+            </li>
+            <li class="item" role="presentation">
+              <a data-onclick-event="alt-tab-requested" role="menuitem"
+                >Alt + Tab</a
+              >
+            </li>
           </ul>
         </li>
       </ul>

--- a/app/templates/custom-elements/menu-bar.html
+++ b/app/templates/custom-elements/menu-bar.html
@@ -290,11 +290,13 @@
           <ul class="items" role="group">
             <li class="item" role="presentation">
               <a data-onclick-event="ctrl-alt-del-requested" role="menuitem"
-                >Ctrl + Alt + Del</a
+                >Ctrl + Alt + Delete</a
               >
             </li>
             <li class="item" role="presentation">
-              <a data-onclick-event="ctrl-alt-backspace-requested" role="menuitem"
+              <a
+                data-onclick-event="ctrl-alt-backspace-requested"
+                role="menuitem"
                 >Ctrl + Alt + Backspace</a
               >
             </li>


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1838.
Related https://github.com/tiny-pilot/tinypilot/issues/481.

This change adds the following additional keyboard shortcuts:

- Ctrl+Alt+Backspace - Restart the desktop environment on Linux.
- Meta+Alt+Escape - Open the "Force Quit" utility on macOS.
- Alt+Tab - Switch to the next window on macOS, Windows, and more.

I've mimicked the approach of sending one key at a time used by the existing Ctrl+Alt+Delete shortcut to more accurately represent how a user would enter these shortcuts on a physical keyboard.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1839"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>