### PR TITLE
Clear about page credits before populating them

### DIFF
--- a/app/templates/custom-elements/about-dialog.html
+++ b/app/templates/custom-elements/about-dialog.html
@@ -111,6 +111,7 @@
         }
 
         _populateCredits() {
+          this.shadowRoot.querySelector(".credits").innerHTML = "";
           getLicensingMetadata().then((metadata) => {
             // Sort credits by project name.
             metadata.sort((a, b) => a.name.localeCompare(b.name, "en"));

--- a/app/templates/custom-elements/about-dialog.html
+++ b/app/templates/custom-elements/about-dialog.html
@@ -111,12 +111,12 @@
         }
 
         _populateCredits() {
-          this.shadowRoot.querySelector(".credits").innerHTML = "";
           getLicensingMetadata().then((metadata) => {
             // Sort credits by project name.
             metadata.sort((a, b) => a.name.localeCompare(b.name, "en"));
 
             const creditsDiv = this.shadowRoot.querySelector(".credits");
+            creditsDiv.innerHTML = "";
             for (const project of metadata) {
               // Skip displaying TinyPilot in the list of dependencies, since we
               // display the TinyPilot license in a special way.


### PR DESCRIPTION
While working on https://github.com/tiny-pilot/tinypilot/pull/1835, I noticed a bug in the "About" dialog where the list of credits keep growing each time the dialog gets opened.

Demo of the issue:

https://github.com/user-attachments/assets/dd4cb4e9-9406-4d50-b42f-149684181d7b


This PR clears the credits before populating them.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1840"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>