### PR TITLE
Add a success dialog variant

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -38,6 +38,7 @@
   --brand-green-dark: hsl(var(--brand-hue-green), 43%, 33%);
   --brand-green-light: hsl(var(--brand-hue-green), 34%, 70%);
   --brand-green-bright: hsl(var(--brand-hue-green), 70%, 45%);
+  --brand-green-background: hsl(var(--brand-hue-green), 54%, 95%);
 
   /* This is the green color that is used in the logo. It should only be
      scarcely used outside the logo, for example for brand- or marketing-related

--- a/app/static/js/events.js
+++ b/app/static/js/events.js
@@ -49,6 +49,22 @@ export class DialogCloseStateChangedEvent extends CustomEvent {
   }
 }
 
+export class DialogVariantChangedEvent extends CustomEvent {
+  /**
+   * Event that advises a visual variant style change of the dialog.
+   * @param {("default"|"danger"|"success")} variant
+   */
+  constructor(variant) {
+    super("dialog-variant-changed", {
+      detail: {
+        variant,
+      },
+      bubbles: true,
+      composed: true,
+    });
+  }
+}
+
 export class VideoStreamingModeChangedEvent extends CustomEvent {
   /**
    * Event, which indicates that the video streaming mode has changed.

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -85,6 +85,10 @@
             dialog: this.shadowRoot.querySelector("#panel"),
           };
           this.show = this.show.bind(this);
+          this._initialAttributes = {
+            variant: this.getAttribute("variant") || "default",
+            showCloseButton: this.hasAttribute("show-close-button") || true,
+          };
 
           this.shadowRoot.addEventListener("dialog-closed", () =>
             this.show(false)
@@ -99,12 +103,9 @@
               this.toggleAttribute("show-close-button", evt.detail.canBeClosed);
             }
           );
-          this.shadowRoot.addEventListener(
-            "dialog-variant-changed",
-            (evt) => {
-              this.setAttribute("variant", evt.detail.variant);
-            }
-          );
+          this.shadowRoot.addEventListener("dialog-variant-changed", (evt) => {
+            this.setAttribute("variant", evt.detail.variant);
+          });
           this.shadowRoot
             .querySelector("#close-button")
             .addEventListener("click", () => this.show(false));
@@ -116,14 +117,14 @@
         }
 
         show(isShown = true) {
-          this.setAttribute(
-            "variant",
-            this.getAttribute("variant") || "default"
-          );
+          // Restore element's initial attributes that might have been changed
+          // programmatically.
+          this.setAttribute("variant", this._initialAttributes.variant);
           this.toggleAttribute(
             "show-close-button",
-            !this.hasAttribute("show-close-button")
+            this._initialAttributes.showCloseButton
           );
+
           if (isShown) {
             this._elements.dialog.showModal();
             this._injectEvent(

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -95,14 +95,14 @@
           );
           this.shadowRoot.addEventListener(
             "dialog-close-state-changed",
-            ({ detail: { canBeClosed } }) => {
-              this.toggleAttribute("show-close-button", canBeClosed);
+            (evt) => {
+              this.toggleAttribute("show-close-button", evt.detail.canBeClosed);
             }
           );
           this.shadowRoot.addEventListener(
             "dialog-variant-changed",
-            ({ detail: { variant } }) => {
-              this.setAttribute("variant", variant);
+            (evt) => {
+              this.setAttribute("variant", evt.detail.variant);
             }
           );
           this.shadowRoot

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -50,6 +50,11 @@
       border-top: 0.4rem solid var(--brand-red-bright);
       background-color: var(--brand-red-background);
     }
+
+    :host([variant="success"]) #panel {
+      border-top: 0.4rem solid var(--brand-green-bright);
+      background-color: var(--brand-green-background);
+    }
   </style>
 
   <dialog id="panel">
@@ -80,6 +85,7 @@
             dialog: this.shadowRoot.querySelector("#panel"),
           };
           this.show = this.show.bind(this);
+
           this.shadowRoot.addEventListener("dialog-closed", () =>
             this.show(false)
           );
@@ -87,16 +93,16 @@
             // This event is further handled in `app.js`.
             this.show(false)
           );
-
-          this.setAttribute("show-close-button", "");
           this.shadowRoot.addEventListener(
             "dialog-close-state-changed",
-            (e) => {
-              if (e.detail.canBeClosed) {
-                this.setAttribute("show-close-button", "");
-              } else {
-                this.removeAttribute("show-close-button");
-              }
+            ({ detail: canBeClosed }) => {
+              this.toggleAttribute("show-close-button", canBeClosed);
+            }
+          );
+          this.shadowRoot.addEventListener(
+            "dialog-variant-changed",
+            ({ detail: { variant } }) => {
+              this.setAttribute("variant", variant);
             }
           );
           this.shadowRoot
@@ -110,6 +116,8 @@
         }
 
         show(isShown = true) {
+          this.setAttribute("variant", "default");
+          this.toggleAttribute("show-close-button", false);
           if (isShown) {
             this._elements.dialog.showModal();
             this._injectEvent(

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -116,8 +116,14 @@
         }
 
         show(isShown = true) {
-          this.setAttribute("variant", "default");
-          this.toggleAttribute("show-close-button", false);
+          this.setAttribute(
+            "variant",
+            this.getAttribute("variant") || "default"
+          );
+          this.toggleAttribute(
+            "show-close-button",
+            !this.hasAttribute("show-close-button")
+          );
           if (isShown) {
             this._elements.dialog.showModal();
             this._injectEvent(

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -95,7 +95,7 @@
           );
           this.shadowRoot.addEventListener(
             "dialog-close-state-changed",
-            ({ detail: canBeClosed }) => {
+            ({ detail: { canBeClosed } }) => {
               this.toggleAttribute("show-close-button", canBeClosed);
             }
           );

--- a/app/templates/custom-elements/shutdown-dialog.html
+++ b/app/templates/custom-elements/shutdown-dialog.html
@@ -61,6 +61,7 @@
     DialogClosedEvent,
     DialogFailedEvent,
     DialogCloseStateChangedEvent,
+    DialogVariantChangedEvent,
   } from "/js/events.js";
   import { shutdown } from "/js/controllers.js";
 
@@ -134,6 +135,7 @@
                 // that it's done after 30 seconds.
                 setTimeout(() => {
                   this._state = this._states.SHUTDOWN_COMPLETE;
+                  this.dispatchEvent(new DialogVariantChangedEvent("success"));
                 }, 30 * 1000);
               }
             })

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -117,6 +117,7 @@
     DialogClosedEvent,
     DialogFailedEvent,
     DialogCloseStateChangedEvent,
+    DialogVariantChangedEvent,
   } from "/js/events.js";
   import { UpdateLogsStreamer } from "/js/updatelogs.js";
   import {
@@ -289,6 +290,7 @@
               this._state = this._states.UPDATE_FINISHED;
               this._elements.updateLogs.textContent +=
                 "Update is now complete.\n";
+              this.dispatchEvent(new DialogVariantChangedEvent("success"));
             })
             .catch((error) => {
               this.dispatchEvent(

--- a/app/templates/custom-elements/wifi-dialog.html
+++ b/app/templates/custom-elements/wifi-dialog.html
@@ -153,6 +153,7 @@
     DialogClosedEvent,
     DialogFailedEvent,
     DialogCloseStateChangedEvent,
+    DialogVariantChangedEvent,
   } from "/js/events.js";
   import {
     getNetworkStatus,
@@ -334,6 +335,7 @@
             return;
           }
           this._state = this._states.SUCCESS_ENABLED;
+          this.dispatchEvent(new DialogVariantChangedEvent("success"));
         }
 
         async _disable() {
@@ -350,6 +352,7 @@
             return;
           }
           this._state = this._states.SUCCESS_DISABLED;
+          this.dispatchEvent(new DialogVariantChangedEvent("success"));
         }
       }
     );

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -143,6 +143,10 @@
           class="colorcard"
           style="background-color: var(--brand-green-light)"
         ></div>
+        <div
+          class="colorcard"
+          style="background-color: var(--brand-green-background)"
+        ></div>
         <br style="clear: both" />
         <div
           class="colorcard"
@@ -560,6 +564,32 @@
                 "  fooBarBaz\n".repeat(80),
             });
             document.getElementById("error-overlay").show();
+          });
+      </script>
+      <!-- Success overlay: -->
+      <overlay-panel id="success-overlay" variant="success">
+        <h3>Example Success Message</h3>
+        <p>
+          This overlay style is used for when the user reaches a successful
+          state.
+        </p>
+        <button id="close-success-overlay-btn">Close</button>
+      </overlay-panel>
+      <button id="show-success-overlay-btn" class="btn-success">
+        Open Success Overlay
+      </button>
+      <script type="module">
+        import { DialogClosedEvent } from "/js/events.js";
+
+        document
+          .getElementById("show-success-overlay-btn")
+          .addEventListener("click", () => {
+            document.getElementById("success-overlay").show();
+          });
+        document
+          .getElementById("close-success-overlay-btn")
+          .addEventListener("click", (evt) => {
+            evt.target.dispatchEvent(new DialogClosedEvent());
           });
       </script>
       <h3>Loading States</h3>


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1639

Based on a [PR review discussion](https://codeapprove.com/pr/tiny-pilot/tinypilot/1833#thread-59475250-2fc2-4e74-9b4f-359067e9a3c8), this PR adds an event (i.e., `DialogVariantChangedEvent`) that allows us to change the dialog's visual variant style in order to make it more engaging for the user.

For example, we can now change the dialog variant when a successful state is reached:

<img width="556" alt="Screen Shot 2024-08-14 at 16 44 18" src="https://github.com/user-attachments/assets/dd9c4597-45ba-4a1b-b3b7-2d97e6c5760c">


<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1841"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>