### PR TITLE
Static IP address scripts Bookworm compatibility

### DIFF
--- a/debian-pkg/opt/tinypilot-privileged/scripts/apply-static-ip
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/apply-static-ip
@@ -13,12 +13,13 @@ set -u
 
 # Determine which version of the OS is running.
 OS_VERSION="$(lsb_release --release --short)"
+readonly OS_VERSION
 
 # Ignore hangup signals to avoid exiting the shell when the network interface
 # is flushed and a new IP is assigned. This was an issue when running the script
 # manually via a remote shell.
 trap '' HUP
-if [[ "${OS_VERSION}" == 11 ]]; then
+if (( "${OS_VERSION}" == 11 )); then
   ip address flush dev eth0
   systemctl restart \
     dhcpcd.service

--- a/debian-pkg/opt/tinypilot-privileged/scripts/set-static-ip
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/set-static-ip
@@ -139,8 +139,9 @@ set -u
 
 # Determine which version of the OS is running.
 OS_VERSION="$(lsb_release --release --short)"
+readonly OS_VERSION
 
-if [[ "${OS_VERSION}" == 11 ]]; then
+if (( "${OS_VERSION}" == 11 )); then
   # Remove any existing automated configuration.
   "${SCRIPT_DIR}/strip-marker-sections" "${CONFIG_FILE}"
 

--- a/debian-pkg/opt/tinypilot-privileged/scripts/unset-static-ip
+++ b/debian-pkg/opt/tinypilot-privileged/scripts/unset-static-ip
@@ -60,8 +60,9 @@ set -u
 
 # Determine which version of the OS is running.
 OS_VERSION="$(lsb_release --release --short)"
+readonly OS_VERSION
 
-if [[ "${OS_VERSION}" == 11 ]]; then
+if (( "${OS_VERSION}" == 11 )); then
   # Remove any existing marker sections from the config file.
   "${SCRIPT_DIR}/strip-marker-sections" /etc/dhcpcd.conf
 else


### PR DESCRIPTION
Resolves #1680

This change updates our static IP scripts to conditionally use `nmcli` for compatibility with Raspberry Pi Bookworm, retaining the previous implementation for Bullseye.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1843"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>