### PR TITLE
Remove assignment of unused “href” attribute

### DIFF
--- a/app/templates/custom-elements/menu-bar.html
+++ b/app/templates/custom-elements/menu-bar.html
@@ -431,7 +431,6 @@
           const cursorList = this.shadowRoot.getElementById("cursor-list");
           for (const cursorOption of screenCursorOptions.splice(1)) {
             const cursorLink = document.createElement("a");
-            cursorLink.setAttribute("href", "#");
             cursorLink.setAttribute("role", "menuitem");
             cursorLink.innerText = cursorOption;
             cursorLink.addEventListener("click", (evt) => {


### PR DESCRIPTION
While working on the [user script frontend](https://github.com/tiny-pilot/tinypilot-pro/pull/1406), I stumbled across a tiny refactoring opportunity in the cursor submenu: in contrast to any of our other link elements in the menu, the cursor menu items are assigned an `href` attribute set to `#`. We don’t need to do this, as `href` isn’t a mandatory attribute. The presence of `href="#"` causes the link URL to be shown in the lower right corner of the browser window, which is slightly distracting because the menu elements are not supposed to be links in the actual sense.

<img width="370" alt="Screenshot 2024-10-04 at 13 06 53" src="https://github.com/user-attachments/assets/16694912-e85f-48b4-947f-456b1ccec0cc">

This PR therefore removes the `href` attribute assignment, so that the browser doesn’t show a URL preview tooltip on hover.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1849"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>