### PR TITLE
Fix typo in WiFi dialog

### DIFF
--- a/app/templates/custom-elements/wifi-dialog.html
+++ b/app/templates/custom-elements/wifi-dialog.html
@@ -73,7 +73,7 @@
       credentials.
     </p>
     <inline-message variant="warning" id="no-ethernet-warning">
-      <strong>Warning:</strong>: You are currently connected to your TinyPilot
+      <strong>Warning:</strong> You are currently connected to your TinyPilot
       device using Wi-Fi. If you change your settings, you might get
       disconnected. Consider connecting an Ethernet cable before proceeding.
     </inline-message>


### PR DESCRIPTION
Resolves #1852

This change removes the second colon in the Wi-Fi dialog when it warns there's no Ethernet connection.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1853"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>