### PR TITLE
Update README with more specific requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![License](http://img.shields.io/:license-mit-blue.svg?style=flat-square)](LICENSE)
 [![Contributors](https://img.shields.io/github/contributors/tiny-pilot/tinypilot)](https://github.com/tiny-pilot/tinypilot/graphs/contributors)
 [![CircleCI](https://circleci.com/gh/tiny-pilot/tinypilot.svg?style=svg)](https://circleci.com/gh/tiny-pilot/tinypilot)
-[![Reddit](https://img.shields.io/badge/reddit-join-orange?logo=reddit)](https://www.reddit.com/r/tinypilot)
 [![Twitter](https://img.shields.io/twitter/follow/tinypilotkvm?label=Twitter&style=social)](https://twitter.com/tinypilotkvm)
 
 ## Overview
@@ -51,12 +50,11 @@ Voyager 2a is TinyPilot's professional-grade KVM over IP device. Its quiet, comp
 
 See ["TinyPilot: Build a KVM Over IP for Under \$100"](https://mtlynch.io/tinypilot/#how-to-build-your-own-tinypilot) for a more detailed tutorial on how to assemble these parts to create a TinyPilot.
 
-## Pre-requisites
-
-- Raspberry Pi OS Bullseye (32-bit)
-- python3-venv
-
 ## Simple installation
+
+### Requirements
+
+- A Raspberry Pi 4 running Raspberry Pi OS Bullseye (32-bit)
 
 You can install TinyPilot on a compatible Raspberry Pi in just two commands.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Voyager 2a is TinyPilot's professional-grade KVM over IP device. Its quiet, comp
 
 ## Build your own
 
-- [Raspberry Pi 4](https://smile.amazon.com/dp/B07TD42S27) (all variants work)
+- [Raspberry Pi 4B](https://smile.amazon.com/dp/B07TD42S27)
 - [HDMI to USB dongle](https://smile.amazon.com/dp/B08CXWPYQ8/)
   - They have no brand name, and there are several variants, but they're all built on the same MacroSilicon 2109 chip.
   - They're available for \$10-15 on eBay and AliExpress.
@@ -54,7 +54,7 @@ See ["TinyPilot: Build a KVM Over IP for Under \$100"](https://mtlynch.io/tinypi
 
 ### Requirements
 
-- A Raspberry Pi 4 running Raspberry Pi OS Bullseye (32-bit)
+- A Raspberry Pi 4B running Raspberry Pi OS Bullseye (32-bit)
 
 You can install TinyPilot on a compatible Raspberry Pi in just two commands.
 


### PR DESCRIPTION
Resolves #1855

This change updates our README to be more clear with installation requirements. The "pre-requisites" section is now a "requirements" under the "Simple installation" heading.

This change also removes the Reddit link shield that links to the unused TinyPilot subreddit.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1856"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>