### PR TITLE
Fix install blocks

### DIFF
--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -20,12 +20,14 @@ if grep -q "boot=overlay" /proc/cmdline ; then
 fi
 
 # Check if the user is forcing an install.
-if [[ -z "${FORCE_INSTALL+x}" ]]; then
+if [[ -n "${FORCE_INSTALL+x}" ]]; then
+  echo 'Forcing installation on unsupported setup.'
+else
   # Restrict installation to only specific configurations.
 
   # Install only on Raspberry Pi 4 Model B.
   if ! grep --quiet "^Model\s*: Raspberry Pi 4 Model B" /proc/cpuinfo ; then
-    echo 'You are trying to install on incompatible hardware.' >&2
+    echo 'You are trying to install on unsupported hardware.' >&2
     echo 'Visit https://github.com/tiny-pilot/tinypilot/ for more details.' >&2
     exit 1
   fi
@@ -36,8 +38,8 @@ if [[ -z "${FORCE_INSTALL+x}" ]]; then
   # open-source project). Similarly, the the 64-bit version of the Raspberry Pi
   # operating system is based on Debian and its distro ID would be "Debian".
   if [[ "$(lsb_release --id --short)" != 'Raspbian' ]]; then
-    echo "TinyPilot currently only supports the 32-bit version of Raspberry Pi OS 11 \"Bullseye\" " >&2
-    echo "To install TinyPilot, you'll need to install Raspberry Pi OS 11 \"Bullseye\" (32-bit)." >&2
+    echo "TinyPilot currently only supports the 32-bit version of Raspberry Pi OS 11 \"Bullseye\"." >&2
+    echo "To install TinyPilot, you'll need Raspberry Pi OS 11 \"Bullseye\" (32-bit)." >&2
     exit 1
   fi
 
@@ -55,8 +57,6 @@ if [[ -z "${FORCE_INSTALL+x}" ]]; then
     echo "To install TinyPilot, you'll need to downgrade your operating system to Raspberry Pi OS 11 \"Bullseye\" (32-bit)." >&2
     exit 1
   fi
-elif (( "${FORCE_INSTALL}" == 1 )); then
-  echo 'Forcing installation on unsupported setup.'
 fi
 
 # Get the filename of the Janus Debian package.

--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -11,45 +11,52 @@ set -u
 # Echo commands before executing them, by default to stderr.
 set -x
 
-# Prevent installation on the Raspberry Pi 3.
-if grep -q "^Model *: Raspberry Pi 3" /proc/cpuinfo ; then
-  echo 'You are trying to install on incompatible hardware.' >&2
-  echo 'Visit https://github.com/tiny-pilot/tinypilot/ for more details.' >&2
-  exit 1
-fi
-
-# Prevent installation on 64-bit operating systems.
-# Note: the distro ID is called "Raspbian" because the 32-bit version of the
-# Raspberry Pi operating system is based on Raspbian repos (an independent
-# open-source project). Similarly, the the 64-bit version of the Raspberry Pi
-# operating system is based on Debian and its distro ID would be "Debian".
-if [[ "$(lsb_release --id --short)" != 'Raspbian' ]]; then
-  echo "TinyPilot currently only supports the 32-bit version of Raspberry Pi OS 11 \"Bullseye\" " >&2
-  echo "To install TinyPilot, you'll need to install Raspberry Pi OS 11 \"Bullseye\" (32-bit)." >&2
-  exit 1
-fi
-
-# Prevent installation on OS versions lower than Raspberry Pi OS 11 "Bullseye".
-if (( "$(lsb_release --release --short)" < 11 )); then
-  echo "TinyPilot no longer supports Raspberry Pi OS 10 \"Buster\" or lower." >&2
-  echo "To install TinyPilot, you'll need to upgrade your operating system to Raspberry Pi OS 11 \"Bullseye\" (32-bit)." >&2
-  exit 1
-fi
-
-# Prevent installation on Raspberry Pi OS 12 "Bookworm".
-if (( "$(lsb_release --release --short)" > 11 )); then
-  echo "TinyPilot is not yet compatible with Raspberry Pi OS 12 \"Bookworm\"." >&2
-  echo "You can track our progress by visiting https://github.com/tiny-pilot/tinypilot/issues/1668" >&2
-  echo "To install TinyPilot, you'll need to downgrade your operating system to Raspberry Pi OS 11 \"Bullseye\" (32-bit)." >&2
-  exit 1
-fi
-
-# Abort installation if the read-only filesystem is enabled
+# Abort installation if the read-only filesystem is enabled.
 if grep -q "boot=overlay" /proc/cmdline ; then
   echo 'The read-only filesystem is enabled.' >&2
   echo 'Disable the read-only filesystem before proceeding.' >&2
   echo 'See https://tinypilotkvm.com/faq/read-only-filesystem for details.' >&2
   exit 1
+fi
+
+# Check if the user is forcing an install.
+if [[ -z "${FORCE_INSTALL+x}" ]]; then
+  # Restrict installation to only specific configurations.
+
+  # Install only on Raspberry Pi 4 Model B.
+  if ! grep --quiet "^Model\s*: Raspberry Pi 4 Model B" /proc/cpuinfo ; then
+    echo 'You are trying to install on incompatible hardware.' >&2
+    echo 'Visit https://github.com/tiny-pilot/tinypilot/ for more details.' >&2
+    exit 1
+  fi
+
+  # Prevent installation on 64-bit operating systems.
+  # Note: the distro ID is called "Raspbian" because the 32-bit version of the
+  # Raspberry Pi operating system is based on Raspbian repos (an independent
+  # open-source project). Similarly, the the 64-bit version of the Raspberry Pi
+  # operating system is based on Debian and its distro ID would be "Debian".
+  if [[ "$(lsb_release --id --short)" != 'Raspbian' ]]; then
+    echo "TinyPilot currently only supports the 32-bit version of Raspberry Pi OS 11 \"Bullseye\" " >&2
+    echo "To install TinyPilot, you'll need to install Raspberry Pi OS 11 \"Bullseye\" (32-bit)." >&2
+    exit 1
+  fi
+
+  # Prevent installation on OS versions lower than Raspberry Pi OS 11 "Bullseye".
+  if (( "$(lsb_release --release --short)" < 11 )); then
+    echo "TinyPilot no longer supports Raspberry Pi OS 10 \"Buster\" or lower." >&2
+    echo "To install TinyPilot, you'll need to upgrade your operating system to Raspberry Pi OS 11 \"Bullseye\" (32-bit)." >&2
+    exit 1
+  fi
+
+  # Prevent installation on Raspberry Pi OS 12 "Bookworm".
+  if (( "$(lsb_release --release --short)" > 11 )); then
+    echo "TinyPilot is not yet compatible with Raspberry Pi OS 12 \"Bookworm\"." >&2
+    echo "You can track our progress by visiting https://github.com/tiny-pilot/tinypilot/issues/1668" >&2
+    echo "To install TinyPilot, you'll need to downgrade your operating system to Raspberry Pi OS 11 \"Bullseye\" (32-bit)." >&2
+    exit 1
+  fi
+elif (( "${FORCE_INSTALL}" == 1 )); then
+  echo 'Forcing installation on unsupported setup.'
 fi
 
 # Get the filename of the Janus Debian package.

--- a/bundler/bundle/install
+++ b/bundler/bundle/install
@@ -18,24 +18,29 @@ if grep -q "^Model *: Raspberry Pi 3" /proc/cpuinfo ; then
   exit 1
 fi
 
-# Prevent installation on OS versions lower than Raspberry Pi OS 11 "Bullseye".
+# Prevent installation on 64-bit operating systems.
 # Note: the distro ID is called "Raspbian" because the 32-bit version of the
 # Raspberry Pi operating system is based on Raspbian repos (an independent
 # open-source project). Similarly, the the 64-bit version of the Raspberry Pi
 # operating system is based on Debian and its distro ID would be "Debian".
-if [[ "$(lsb_release --id --short)" == 'Raspbian' ]] \
-    && (( "$(lsb_release --release --short)" < 11 )); then
+if [[ "$(lsb_release --id --short)" != 'Raspbian' ]]; then
+  echo "TinyPilot currently only supports the 32-bit version of Raspberry Pi OS 11 \"Bullseye\" " >&2
+  echo "To install TinyPilot, you'll need to install Raspberry Pi OS 11 \"Bullseye\" (32-bit)." >&2
+  exit 1
+fi
+
+# Prevent installation on OS versions lower than Raspberry Pi OS 11 "Bullseye".
+if (( "$(lsb_release --release --short)" < 11 )); then
   echo "TinyPilot no longer supports Raspberry Pi OS 10 \"Buster\" or lower." >&2
-  echo "To install TinyPilot, you'll need to upgrade your operating system to Raspberry Pi OS 11 \"Bullseye\"." >&2
+  echo "To install TinyPilot, you'll need to upgrade your operating system to Raspberry Pi OS 11 \"Bullseye\" (32-bit)." >&2
   exit 1
 fi
 
 # Prevent installation on Raspberry Pi OS 12 "Bookworm".
-if [[ "$(lsb_release --id --short)" == 'Raspbian' ]] \
-    && (( "$(lsb_release --release --short)" > 11 )); then
+if (( "$(lsb_release --release --short)" > 11 )); then
   echo "TinyPilot is not yet compatible with Raspberry Pi OS 12 \"Bookworm\"." >&2
   echo "You can track our progress by visiting https://github.com/tiny-pilot/tinypilot/issues/1668" >&2
-  echo "To install TinyPilot, you'll need to downgrade your operating system to Raspberry Pi OS 11 \"Bullseye\"." >&2
+  echo "To install TinyPilot, you'll need to downgrade your operating system to Raspberry Pi OS 11 \"Bullseye\" (32-bit)." >&2
   exit 1
 fi
 


### PR DESCRIPTION
Resolves #1857

This change refactors our installation blocks to use single conditions, fixing a bug when checking for Raspbian-based systems that allowed installations to proceed on 64-bit systems regardless of the OS version.

This also adds a check for a `FORCE_INSTALL` flag - setting the `FORCE_INSTALL` environment variable allows you to bypass the system checks to attempt an install on unsupported systems.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1858"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>