### PR TITLE
Fix FORCE_INSTALL when using simple install commands

### DIFF
--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -160,7 +160,7 @@ fi
 # Run install.
 pushd "${INSTALLER_DIR}"
 sudo \
-  TMPDIR="${TMPDIR}" \
+  --preserve-env=TMPDIR,FORCE_INSTALL \
   ./install
 
 } # Prevent the script from executing until the client downloads the full file.


### PR DESCRIPTION
Resolves #1864 

This change updates `get-install.sh` to preserve the `FORCE_INSTALL` environment variable when running `sudo ./install`.

This allows users to set `FORCE_INSTALL` before running the simple install commands.

To test live on a device, install Raspberry Pi OS Bullseye 32-bit and run:

```bash
export FORCE_INSTALL=1
```

And then:

```bash
curl \
  --silent \
  --show-error \
  https://raw.githubusercontent.com/tiny-pilot/tinypilot/refs/heads/1864-force_install-doesnt-work-as-expected/get-tinypilot.sh | \
    bash - && \
  sudo reboot
```

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1865"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>