### PR TITLE
Fix regex for git short hashes

### DIFF
--- a/dev-scripts/build-debian-pkg
+++ b/dev-scripts/build-debian-pkg
@@ -27,8 +27,10 @@ EOF
 
 print_tinypilot_version() {
   # Format build hash suffix according to SemVer (`-ghhhhhhh` -> `+hhhhhhh`).
+  # Note that git short hashes are variable in length, so they can contain more
+  # than 7 characters, depending of the overall number of commits.
   git describe --tags --long |
-  sed --expression 's/\(-g\([0-9a-f]\{7\}\)\)$/+\2/g'
+  sed --expression 's/\(-g\([0-9a-f]\{7,\}\)\)$/+\2/g'
 }
 
 # Parse command-line arguments.


### PR DESCRIPTION
Follow up of https://github.com/tiny-pilot/tinypilot/pull/1871.

Git short hashes can be longer than 7 characters, see the [“Short SHA-1” section of the git docs](https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection).

That’s relevant in our Pro repo, as you can [see in our latest build](https://app.circleci.com/pipelines/github/tiny-pilot/tinypilot-pro/4799/workflows/4ed6c793-a8f1-458e-b29c-434005e5ae0f/jobs/50173), where the output of `git describe --tags --long` yields `2.7.0-rc.4-5-g0bfe1e1f`, i.e. with 8 characters following the `-g`. Therefore, the regex replacement didn’t match.

Contrary to [my assumption about config protection](https://github.com/tiny-pilot/tinypilot-pro/pull/1475#issuecomment-2743993957) ([which wasn’t correct](https://github.com/tiny-pilot/tinypilot-pro/pull/1475#issuecomment-2744245946)), this seems to be the actual reason why the change didn’t have any effect in the PR build.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1872"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>