### PR TITLE
Backport changes from get-tinypilot-pro.sh

### DIFF
--- a/get-tinypilot.sh
+++ b/get-tinypilot.sh
@@ -126,7 +126,7 @@ readonly INSTALLER_DIR
 # that we take advantage of RAMdisk if we're using one.
 readonly TMPDIR="${INSTALLER_DIR}/tmp"
 export TMPDIR
-sudo mkdir "${TMPDIR}"
+sudo mkdir --mode=1777 "${TMPDIR}"
 
 #######################################
 # Executes a curl command that returns a non-zero exit code based on the HTTP


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot/issues/1878

This PR backports the relevant changes to `get-tinypilot-pro.sh` (introduced by https://github.com/tiny-pilot/gatekeeper/pull/301) back into `get-tinypilot.sh`.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1880"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>