### PR TITLE
Update hostname error message to avoid adding .local suffix

### DIFF
--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -58,7 +58,8 @@
       <inline-message variant="error" id="input-error">
         <strong>Invalid hostname:</strong> it can only contain the letters a-z,
         digits and dashes (it cannot start with a dash, though). It must contain
-        1-63 characters and cannot be "localhost". You don't need to include ".local"
+        1-63 characters and cannot be "localhost". You don't need to include
+        ".local"
       </inline-message>
     </div>
     <button id="change-and-restart" class="btn-success" type="button">


### PR DESCRIPTION
Resolves #1879

This change updates the error message related to changing the hostname with a `.local` suffix. The previous message was misleading, as users do not need to add `.local` explicitly. The updated message now clearly instructs users to avoid adding `.local`, making the guidance more accurate and user-friendly.

![Screenshot 2025-05-21 at 11 30 12 PM](https://github.com/user-attachments/assets/8d40a816-f314-4c8a-ab13-5324dfdce2aa)

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1883"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>