### PR TITLE
Update language around updating branch with latest master

### DIFF
--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -45,6 +45,7 @@ jobs:
             @${{ github.actor }}, please merge [your changes from the Community repository](https://github.com/tiny-pilot/tinypilot/commit/${{ github.sha }}):
 
             1. Update this branch with latest `master`
+               - Generally, you can use GitHub’s “Update with merge commit”.
                - If there are merge conflicts, it’s best to resolve them locally.
             1. Check whether you need to make any Pro-specific adjustments to the code
             1. Review and approve your changes


### PR DESCRIPTION
Resolves #1884 

In a recent community commit merge to Pro, we had [a question](https://github.com/tiny-pilot/tinypilot-pro/pull/1509#issuecomment-2901315522) around which style of merge to use (regular or rebase) when updating the branch with Pro's `master`.

This change updates the body text of community-changes PRs to suggest using "Update with merge commit" when updating the branch.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1885"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>