### PR TITLE
Delete dump-logs dev script

### DIFF
--- a/dev-scripts/dump-logs
+++ b/dev-scripts/dump-logs
@@ -1,9 +1,0 @@
-#!/bin/bash
-#
-# The canonical way to dump logs is through the script below,
-# but this file is here for backwards compatibility.
-#
-# Without this file, we have no way of giving users a dump logs command
-# that will work regardless of TinyPilot version.
-
-sudo /opt/tinypilot-privileged/scripts/collect-debug-logs


### PR DESCRIPTION
Resolves #1799 

This change removes the deprecated `dump-logs` dev script that hasn't been used for years.

The canonical way for users to share debug logs is via the web UI (“System” → “Logs”).

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1887"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>