### PR TITLE
Remove temporary workarounds since reaching next checkpoint release

### DIFF
--- a/debian-pkg/debian/tinypilot.postinst
+++ b/debian-pkg/debian/tinypilot.postinst
@@ -60,16 +60,6 @@ runuser tinypilot \
 deactivate
 popd
 
-# Workaround to restore the default NGINX config that has been previously
-# modified by ansible-role-nginx. We can remove this on TinyPilot's next
-# checkpoint release.
-# https://github.com/tiny-pilot/tinypilot-pro/issues/978
-if grep --silent 'tinypilot' /etc/nginx/nginx.conf; then
-  cp \
-    /usr/share/tinypilot/nginx.conf \
-    /etc/nginx/nginx.conf
-fi
-
 tc358743_overlay_enabled='false'
 if grep --silent '^dtoverlay=tc358743$' "${BOOT_CONFIG_PATH}" ; then
   tc358743_overlay_enabled='true'
@@ -117,24 +107,6 @@ acap: {
 }
 EOF
 fi
-
-# Clean up the legacy TinyPilot-specific config file for uStreamer. We can
-# remove this on TinyPilot's next checkpoint release.
-# https://github.com/tiny-pilot/tinypilot-pro/issues/978
-readonly USTREAMER_ANSIBLE_CONFIG='/home/ustreamer/config.yml'
-if [[ -f "${USTREAMER_ANSIBLE_CONFIG}" ]]; then
-  rm "${USTREAMER_ANSIBLE_CONFIG}"
-fi
-
-# Workaround to remove settings that are not user-configurable to avoid
-# inconsistent config. We can remove this on TinyPilot's next checkpoint
-# release.
-# https://github.com/tiny-pilot/tinypilot-pro/issues/978
-sed \
-  --in-place \
-  --expression '/ustreamer_port/d' \
-  --expression '/ustreamer_persistent/d' \
-  "${TINYPILOT_SETTINGS_FILE}"
 
 # Create a directory for uStreamer launcher configs.
 readonly USTREAMER_LAUNCHER_BASE_DIR='/opt/ustreamer-launcher'

--- a/debian-pkg/debian/tinypilot.preinst
+++ b/debian-pkg/debian/tinypilot.preinst
@@ -9,10 +9,4 @@ if [[ -d /opt/tinypilot/.git ]]; then
   rm -rf /opt/tinypilot
 fi
 
-# Workaround to remove TinyPilot's legacy NGINX config. We can remove this on
-# TinyPilot's next checkpoint release.
-# https://github.com/tiny-pilot/tinypilot-pro/issues/978
-rm -f \
-  /etc/nginx/sites-enabled/tinypilot.conf
-
 #DEBHELPER#


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot-pro/issues/978

This PR removes the temporary workarounds no longer needed since reaching the next checkpoint release after 2.6.0 (i.e., the 2.7.0 checkpoint release).

Notes
1. We're removing all the workarounds marked with the following issue URL:
    - [`https://github.com/tiny-pilot/tinypilot-pro/issues/978`](https://github.com/tiny-pilot/tinypilot-pro/issues/978)

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1888"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>