### PR TITLE
Add default ustreamer_desired_fps to hdmi-to-usb config

### DIFF
--- a/debian-pkg/opt/ustreamer-launcher/config-library/hdmi-to-usb.yml
+++ b/debian-pkg/opt/ustreamer-launcher/config-library/hdmi-to-usb.yml
@@ -3,3 +3,4 @@
 ustreamer_encoder: hw
 ustreamer_format: jpeg
 ustreamer_resolution: "1920x1080"
+ustreamer_desired_fps: 30


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot-pro/issues/1528

This change sets the default `ustreamer_desired_fps` value for USB capture devices for better performance with the newer version of ustreamer.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1890"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>