### PR TITLE
Make restart behavior of ustreamer systemd service more resilient

### DIFF
--- a/debian-pkg/debian/tinypilot.ustreamer.service
+++ b/debian-pkg/debian/tinypilot.ustreamer.service
@@ -1,6 +1,9 @@
 [Unit]
 Description=uStreamer - Lightweight, optimized video encoder
 After=syslog.target network.target
+# Give up if we restart on failure 20 times within 5 minutes (300 seconds).
+StartLimitIntervalSec=300
+StartLimitBurst=20
 
 [Service]
 Type=simple
@@ -8,6 +11,10 @@ User=ustreamer
 WorkingDirectory=/opt/ustreamer-launcher
 ExecStart=/opt/ustreamer-launcher/launch
 Restart=always
+# ustreamer sometimes fails to start. Introducing extra restart time and
+# start limits works around this problem. More details and investigation in this
+# issue: https://github.com/tiny-pilot/tinypilot-pro/issues/1487
+RestartSec=2
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot-pro/issues/1487

This change introduces new restart behavior in `ustreamer.service` to allow ustreamer to start more consistently.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1891"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>