### PR TITLE
Add Bandit to CircleCI

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -9,6 +9,7 @@ select = [
   "F", # Enable pyflakes rules.
   "I", # Enable isort rules.
   "Q", # Enable flake8-quotes rules.
+  "S", # Enable flake8-bandit rules.
   ]
 ignore = [
   # Disable rules that require everything to have a docstring.

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,9 @@
 src = ["app"]
 
+# Assume Python 3.9.
+target-version = "py39"
+
+[lint]
 select = [
   "D", # Enable pydocstyle rules.
   "F", # Enable pyflakes rules.
@@ -26,10 +30,7 @@ exclude = [
     "venv",
 ]
 
-# Assume Python 3.9
-target-version = "py39"
-
-[flake8-quotes]
+[lint.flake8-quotes]
 # Use consistent quotes regardless of whether it allows us to minimize escape
 # sequences.
 avoid-escape = false
@@ -38,9 +39,9 @@ docstring-quotes = "double"
 inline-quotes = "single"
 multiline-quotes = "double"
 
-[isort]
+[lint.isort]
 force-single-line = true
 force-to-top = ["log"]
 
-[pydocstyle]
+[lint.pydocstyle]
 convention = "google"

--- a/app/debug_logs.py
+++ b/app/debug_logs.py
@@ -18,7 +18,8 @@ def collect():
     """
     try:
         return subprocess.check_output([
-            'sudo', '/opt/tinypilot-privileged/scripts/collect-debug-logs', '-q'
+            '/usr/bin/sudo',
+            '/opt/tinypilot-privileged/scripts/collect-debug-logs', '-q'
         ])
     except subprocess.CalledProcessError as e:
         raise LogCollectionScriptFailedError(str(e)) from e

--- a/app/hostname.py
+++ b/app/hostname.py
@@ -43,8 +43,8 @@ def change(new_hostname):
     """
     try:
         return subprocess.check_output([
-            'sudo', '/opt/tinypilot-privileged/scripts/change-hostname',
-            new_hostname
+            '/usr/bin/sudo',
+            '/opt/tinypilot-privileged/scripts/change-hostname', new_hostname
         ],
                                        stderr=subprocess.STDOUT,
                                        universal_newlines=True)

--- a/app/hostname.py
+++ b/app/hostname.py
@@ -42,11 +42,15 @@ def change(new_hostname):
         new_hostname: The new hostname as string.
     """
     try:
-        return subprocess.check_output([
-            '/usr/bin/sudo',
-            '/opt/tinypilot-privileged/scripts/change-hostname', new_hostname
-        ],
-                                       stderr=subprocess.STDOUT,
-                                       universal_newlines=True)
+        # The command arguments are trusted because the new hostname is
+        # validated by the caller.
+        return subprocess.check_output(  # noqa: S603
+            [
+                '/usr/bin/sudo',
+                '/opt/tinypilot-privileged/scripts/change-hostname',
+                new_hostname
+            ],
+            stderr=subprocess.STDOUT,
+            universal_newlines=True)
     except subprocess.CalledProcessError as e:
         raise HostnameChangeError(str(e.output).strip()) from e

--- a/app/local_system.py
+++ b/app/local_system.py
@@ -29,10 +29,11 @@ def _exec_shutdown(restart_after):
         param = '--poweroff'
 
     try:
-        result = subprocess.run(['sudo', '/sbin/shutdown', param, 'now'],
-                                capture_output=True,
-                                text=True,
-                                check=True)
+        result = subprocess.run(
+            ['/usr/bin/sudo', '/sbin/shutdown', param, 'now'],
+            capture_output=True,
+            text=True,
+            check=True)
     except subprocess.CalledProcessError as e:
         raise ShutdownError(e) from e
     if 'failed' in result.stderr.lower():

--- a/app/local_system.py
+++ b/app/local_system.py
@@ -29,7 +29,9 @@ def _exec_shutdown(restart_after):
         param = '--poweroff'
 
     try:
-        result = subprocess.run(
+        # The command arguments are trusted because they aren't based on user
+        # input.
+        result = subprocess.run(  # noqa: S603
             ['/usr/bin/sudo', '/sbin/shutdown', param, 'now'],
             capture_output=True,
             text=True,

--- a/app/network.py
+++ b/app/network.py
@@ -148,7 +148,8 @@ def determine_wifi_settings():
         # We cannot read the wpa_supplicant.conf file directly, because it is
         # owned by the root user.
         config_lines = subprocess.check_output([
-            'sudo', '/opt/tinypilot-privileged/scripts/print-marker-sections',
+            '/usr/bin/sudo',
+            '/opt/tinypilot-privileged/scripts/print-marker-sections',
             '/etc/wpa_supplicant/wpa_supplicant.conf'
         ],
                                                stderr=subprocess.STDOUT,
@@ -182,8 +183,8 @@ def enable_wifi(wifi_settings):
         NetworkError
     """
     args = [
-        'sudo', '/opt/tinypilot-privileged/scripts/enable-wifi', '--country',
-        wifi_settings.country_code, '--ssid', wifi_settings.ssid
+        '/usr/bin/sudo', '/opt/tinypilot-privileged/scripts/enable-wifi',
+        '--country', wifi_settings.country_code, '--ssid', wifi_settings.ssid
     ]
     try:
         # Ignore pylint since we're not managing the child process.
@@ -212,7 +213,7 @@ def disable_wifi():
         # Ignore pylint since we're not managing the child process.
         # pylint: disable=consider-using-with
         subprocess.Popen([
-            'sudo',
+            '/usr/bin/sudo',
             '/opt/tinypilot-privileged/scripts/disable-wifi',
         ])
     except subprocess.CalledProcessError as e:

--- a/app/network.py
+++ b/app/network.py
@@ -101,15 +101,18 @@ def inspect_interface(interface_name):
     status = InterfaceStatus(interface_name, False, None, None)
 
     try:
-        ip_cmd_out_raw = subprocess.check_output([
-            '/usr/bin/ip',
-            '-json',
-            'address',
-            'show',
-            interface_name,
-        ],
-                                                 stderr=subprocess.STDOUT,
-                                                 universal_newlines=True)
+        # The command arguments are trusted because they aren't based on user
+        # input.
+        ip_cmd_out_raw = subprocess.check_output(  # noqa: S603
+            [
+                '/usr/bin/ip',
+                '-json',
+                'address',
+                'show',
+                interface_name,
+            ],
+            stderr=subprocess.STDOUT,
+            universal_newlines=True)
     except subprocess.CalledProcessError as e:
         logger.error('Failed to run `ip` command: %s', str(e))
         return status
@@ -182,6 +185,8 @@ def enable_wifi(wifi_settings):
     Raises:
         NetworkError
     """
+    # The command arguments are trusted because the WiFi settings are validated
+    # by the caller.
     args = [
         '/usr/bin/sudo', '/opt/tinypilot-privileged/scripts/enable-wifi',
         '--country', wifi_settings.country_code, '--ssid', wifi_settings.ssid
@@ -191,10 +196,11 @@ def enable_wifi(wifi_settings):
         # pylint: disable=consider-using-with
         if wifi_settings.psk:
             args.append('--psk')
-            process = subprocess.Popen(args, stdin=subprocess.PIPE, text=True)
+            process = subprocess.Popen(  # noqa: S603
+                args, stdin=subprocess.PIPE, text=True)
             process.communicate(input=wifi_settings.psk)
         else:
-            subprocess.Popen(args)
+            subprocess.Popen(args)  # noqa: S603
 
     except subprocess.CalledProcessError as e:
         raise NetworkError(str(e.output).strip()) from e

--- a/app/network.py
+++ b/app/network.py
@@ -102,7 +102,7 @@ def inspect_interface(interface_name):
 
     try:
         ip_cmd_out_raw = subprocess.check_output([
-            'ip',
+            '/usr/bin/ip',
             '-json',
             'address',
             'show',

--- a/app/update/launcher.py
+++ b/app/update/launcher.py
@@ -36,4 +36,4 @@ def start_async():
     # Ignore pylint since we're not managing the child process.
     # pylint: disable=consider-using-with
     subprocess.Popen(
-        ('sudo', '/usr/sbin/service', 'tinypilot-updater', 'start'))
+        ('/usr/bin/sudo', '/usr/sbin/service', 'tinypilot-updater', 'start'))

--- a/app/update/launcher_test.py
+++ b/app/update/launcher_test.py
@@ -21,7 +21,8 @@ class LauncherTest(unittest.TestCase):
 
         mock_clear.assert_called()
         mock_popen.assert_called_once_with(
-            ('sudo', '/usr/sbin/service', 'tinypilot-updater', 'start'))
+            ('/usr/bin/sudo', '/usr/sbin/service', 'tinypilot-updater',
+             'start'))
 
     @mock.patch.object(launcher.subprocess, 'Popen')
     @mock.patch.object(launcher.update.result_store, 'clear')
@@ -34,7 +35,8 @@ class LauncherTest(unittest.TestCase):
 
         mock_clear.assert_called()
         mock_popen.assert_called_once_with(
-            ('sudo', '/usr/sbin/service', 'tinypilot-updater', 'start'))
+            ('/usr/bin/sudo', '/usr/sbin/service', 'tinypilot-updater',
+             'start'))
 
     @mock.patch.object(launcher.subprocess, 'Popen')
     @mock.patch.object(launcher.update.result_store, 'clear')
@@ -48,7 +50,8 @@ class LauncherTest(unittest.TestCase):
 
         mock_clear.assert_called_once()
         mock_popen.assert_called_once_with(
-            ('sudo', '/usr/sbin/service', 'tinypilot-updater', 'start'))
+            ('/usr/bin/sudo', '/usr/sbin/service', 'tinypilot-updater',
+             'start'))
 
     @mock.patch.object(launcher.subprocess, 'Popen')
     @mock.patch.object(launcher.update.result_store, 'clear')

--- a/app/update_logs.py
+++ b/app/update_logs.py
@@ -33,7 +33,7 @@ def read():
     """
     logger.info('Running read-update-log')
     try:
-        output = subprocess.check_output(['sudo', _READ_SCRIPT_PATH],
+        output = subprocess.check_output(['/usr/bin/sudo', _READ_SCRIPT_PATH],
                                          stderr=subprocess.STDOUT,
                                          universal_newlines=True)
     except subprocess.CalledProcessError as e:

--- a/app/update_logs.py
+++ b/app/update_logs.py
@@ -33,9 +33,12 @@ def read():
     """
     logger.info('Running read-update-log')
     try:
-        output = subprocess.check_output(['/usr/bin/sudo', _READ_SCRIPT_PATH],
-                                         stderr=subprocess.STDOUT,
-                                         universal_newlines=True)
+        # The command arguments are trusted because they aren't based on user
+        # input.
+        output = subprocess.check_output(  # noqa: S603
+            ['/usr/bin/sudo', _READ_SCRIPT_PATH],
+            stderr=subprocess.STDOUT,
+            universal_newlines=True)
     except subprocess.CalledProcessError as e:
         raise UpdateLogsReadError(str(e.output).strip()) from e
     logger.info('read-update-log completed successfully')

--- a/app/version.py
+++ b/app/version.py
@@ -83,7 +83,8 @@ def latest_version():
             to the Gatekeeper API.
     """
     try:
-        with urllib.request.urlopen(
+        # The URL is trusted because it's not based on user input.
+        with urllib.request.urlopen(  # noqa: S310
                 f'{env.GATEKEEPER_BASE_URL}/community/available-update',
                 timeout=10) as response:
             response_bytes = response.read()

--- a/app/video_service.py
+++ b/app/video_service.py
@@ -33,7 +33,7 @@ def _restart_ustreamer():
     logger.info('Triggering ustreamer restart...')
     try:
         subprocess.check_output(
-            ['sudo', '/usr/sbin/service', 'ustreamer', 'restart'],
+            ['/usr/bin/sudo', '/usr/sbin/service', 'ustreamer', 'restart'],
             stderr=subprocess.STDOUT,
             universal_newlines=True)
     except subprocess.CalledProcessError as e:
@@ -53,10 +53,11 @@ def _restart_janus():
     """
     logger.info('Writing janus configuration...')
     try:
-        subprocess.check_output(
-            ['sudo', '/opt/tinypilot-privileged/scripts/configure-janus'],
-            stderr=subprocess.STDOUT,
-            universal_newlines=True)
+        subprocess.check_output([
+            '/usr/bin/sudo', '/opt/tinypilot-privileged/scripts/configure-janus'
+        ],
+                                stderr=subprocess.STDOUT,
+                                universal_newlines=True)
     except subprocess.CalledProcessError as e:
         logger.error('Failed to configure janus: %s', e)
         return
@@ -64,7 +65,7 @@ def _restart_janus():
     logger.info('Triggering janus restart...')
     try:
         subprocess.check_output(
-            ['sudo', '/usr/sbin/service', 'janus', 'restart'],
+            ['/usr/bin/sudo', '/usr/sbin/service', 'janus', 'restart'],
             stderr=subprocess.STDOUT,
             universal_newlines=True)
     except subprocess.CalledProcessError as e:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,6 +2,6 @@
 
 coverage==7.2.7
 pylint==2.14.2
-ruff==0.0.290
+ruff==0.12.10
 sqlfluff==1.3.2
 yapf==0.40.1

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,6 @@
 --requirement requirements.txt
 
+bandit==1.8.6
 coverage==7.2.7
 pylint==2.14.2
 ruff==0.12.10

--- a/scripts/update-service
+++ b/scripts/update-service
@@ -36,7 +36,7 @@ def run_update_script():
     logger.info('Launching update script: %s',
                 update.launcher.UPDATE_SCRIPT_PATH)
     try:
-        subprocess.run(['sudo', update.launcher.UPDATE_SCRIPT_PATH],
+        subprocess.run(['/usr/bin/sudo', update.launcher.UPDATE_SCRIPT_PATH],
                        check=True,
                        timeout=_UPDATE_TIMEOUT_SECONDS)
     except subprocess.TimeoutExpired:

--- a/scripts/update-service
+++ b/scripts/update-service
@@ -36,9 +36,12 @@ def run_update_script():
     logger.info('Launching update script: %s',
                 update.launcher.UPDATE_SCRIPT_PATH)
     try:
-        subprocess.run(['/usr/bin/sudo', update.launcher.UPDATE_SCRIPT_PATH],
-                       check=True,
-                       timeout=_UPDATE_TIMEOUT_SECONDS)
+        # The command arguments are trusted because they aren't based on user
+        # input.
+        subprocess.run(  # noqa: S603
+            ['/usr/bin/sudo', update.launcher.UPDATE_SCRIPT_PATH],
+            check=True,
+            timeout=_UPDATE_TIMEOUT_SECONDS)
     except subprocess.TimeoutExpired:
         logger.error('Update process timed out')
         return make_update_result(update_error='The update timed out')


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot-pro/issues/1594

This PR updates `ruff`, [migrates our ruff config to the newer format](https://docs.astral.sh/ruff/editors/migration/#migrating-from-ruff-lsp), enables [ruff's `flake8-bandit` rules](https://docs.astral.sh/ruff/rules/#flake8-bandit-s), and addresses the [Bandit security warnings raised](https://app.circleci.com/pipelines/github/tiny-pilot/tinypilot/4829/workflows/5ef2a71e-986a-4dd2-b2e3-8b440caa47f0/jobs/36695?invite=true#step-103-14222_64), namely:
- [suspicious-url-open-usage (S310)](https://docs.astral.sh/ruff/rules/suspicious-url-open-usage/#suspicious-url-open-usage-s310)
- [subprocess-without-shell-equals-true (S603)](https://docs.astral.sh/ruff/rules/subprocess-without-shell-equals-true/#subprocess-without-shell-equals-true-s603)
- [start-process-with-partial-path (S607)](https://docs.astral.sh/ruff/rules/start-process-with-partial-path/#start-process-with-partial-path-s607)

A note on [how Bandit works](https://github.com/PyCQA/bandit/issues/333#issuecomment-404103697):
> Unfortunately bandit isn't a code-flow analysis tool so it can't reason about what `args` is. It just flags a warning. You manually check the warning and decide to either add `# nosec` at the end of the line or to turn off this B603 test if you find it unhelpful.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1907"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>