### PR TITLE
Fix connect-src of Content Security Policy HTTP header

### DIFF
--- a/debian-pkg/usr/share/tinypilot/nginx_response_headers.conf
+++ b/debian-pkg/usr/share/tinypilot/nginx_response_headers.conf
@@ -1,6 +1,6 @@
 # Set Content Security Policy (CSP).
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'";
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://logs.tinypilotkvm.com";
 
 # Prevent clickjacking.
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot-pro/issues/1593

We accidentally broke the sharing of debug logs via the "Get Shareable URL" button on the "Debug Logs" dialog, when adding the Content Security Policy (CSP) HTTP header:
- https://github.com/tiny-pilot/tinypilot/blob/027c35a31309d98b6088e6ab6be742a362683574/debian-pkg/usr/share/tinypilot/nginx_response_headers.conf#L1-L3

Screenshot of the issue:

<img width="755" height="775" alt="Screenshot 2025-09-12 at 15 03 09" src="https://github.com/user-attachments/assets/15817739-d324-4e36-829e-f1e047f69aa3" />

This PR updates the [`connect-src`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/connect-src) value of the Content Security Policy (CSP) header to allow requests to `https://logs.tinypilotkvm.com`.
