### PR TITLE
Show fancier version comparison in update dialog

### DIFF
--- a/app/static/css/icons.css
+++ b/app/static/css/icons.css
@@ -18,3 +18,30 @@
   border-right: var(--width) solid transparent;
   border-top: var(--height) solid var(--brand-creme-light);
 }
+
+.icon-long-arrow {
+  position: relative;
+  width: 20px;
+}
+
+.icon-long-arrow:before {
+  position: absolute;
+  content: "";
+  top: -1px;
+  left: 0;
+  width: 90%;
+  height: 2px;
+  background: #000;
+}
+
+.icon-long-arrow:after {
+  position: absolute;
+  content: "";
+  top: -5px;
+  right: 0;
+  width: 0;
+  height: 0;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 10px solid #000;
+}

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -1,6 +1,7 @@
 <template id="update-dialog-template">
   <style>
     @import "css/style.css";
+    @import "css/icons.css";
 
     #checking,
     #update-available,


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot-pro/issues/1620

This PR backports the version comparison UI from Pro's update-dialog (based on our [discussion here](https://github.com/tiny-pilot/tinypilot/pull/1914#issuecomment-3318652530)).

Note that Community version strings look something like this `0.0.0-0+aaaaaaa` (where `aaaaaaa` is the git commit short hash). We purposefully strip the commit hash from being displayed because it doesn't look as nice. 

End result:
- <img width="522" height="339" alt="Screenshot 2025-09-23 at 16 41 11" src="https://github.com/user-attachments/assets/6dfc5e11-424b-46e7-96a1-7fa234e53df8" />
- <img width="380" height="301" alt="Screenshot 2025-09-23 at 16 40 53" src="https://github.com/user-attachments/assets/b7824acf-0ca0-42c3-a81e-69e1e248f68d" />
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1916"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>