### PR TITLE
Fix wifi-dialog

### DIFF
--- a/app/templates/custom-elements/wifi-dialog.html
+++ b/app/templates/custom-elements/wifi-dialog.html
@@ -289,10 +289,13 @@
             wifiSettings.countryCode || "US";
           this._elements.pskInput.value = "";
           this._initialWiFiSettings = { psk: "", ...wifiSettings };
-
+          // Show ethernet warning when no ethernet interfaces are connected.
           this._elements.noEthernetWarning.hide();
           this._elements.inputError.hide();
-          if (!networkStatus.ethernet.isConnected) {
+          const noEthernetConnected = networkStatus
+            .filter((iface) => iface.name.startsWith("eth"))
+            .every((iface) => !iface.isConnected);
+          if (noEthernetConnected) {
             this._elements.noEthernetWarning.show();
           }
 


### PR DESCRIPTION
As [discovered here](https://github.com/tiny-pilot/tinypilot-pro/issues/1618#issuecomment-3361292481), we've broken the wifi-dialog via https://github.com/tiny-pilot/tinypilot/pull/1902.

The issue is that we've previously changed the output of the `/api/network/status` endpoint to return a list of network interfaces, but we forgot to update the endpoint's usage in wifi-dialog.

This PR fixes the usage of the `/api/network/status` endpoint in wifi-dialog.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1921"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>