### PR TITLE
Update network-status-interface elements in-place

### DIFF
--- a/app/templates/custom-elements/network-status-dialog.html
+++ b/app/templates/custom-elements/network-status-dialog.html
@@ -27,7 +27,7 @@
   <div id="display">
     <h3>Network Status</h3>
     <div class="info-container" id="interfaces-container">
-      <!-- Filled programmatically -->
+      <!-- Populated dynamically -->
     </div>
     <div class="button-container">
       <button id="close-button" type="button">Close</button>


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot-pro/issues/1648

This PR updates each network-status-interface element in-place, on the network-status-dialog, to avoid a brief flash of unstyled content (FOUC) that seems to be an [issue with native Web Components](https://stackoverflow.com/questions/62683430/how-to-stop-fouc-from-happening-with-native-web-components).

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1923"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>