### PR TITLE
Remove unused lintian overrides

### DIFF
--- a/debian-pkg/debian/tinypilot.lintian-overrides
+++ b/debian-pkg/debian/tinypilot.lintian-overrides
@@ -1,10 +1,7 @@
 # Suppress complaints about third-party dependencies we don't control.
-tinypilot: embedded-javascript-library opt/tinypilot/venv/lib/python*/site-packages/werkzeug/debug/shared/jquery.js please use libjs-jquery
 tinypilot: script-not-executable [opt/tinypilot/venv/lib/python*/site-packages/greenlet/tests/test_version.py]
 tinypilot: script-not-executable [opt/tinypilot/venv/lib/python*/site-packages/pkg_resources/_vendor/appdirs.py]
 tinypilot: script-not-executable [opt/tinypilot/venv/lib/python*/site-packages/setuptools/command/easy_install.py]
-tinypilot: embedded-library libyaml opt/tinypilot/venv/lib/python*/site-packages/yaml/*.so
-tinypilot: hardening-no-relro [opt/tinypilot/venv/lib/python*/site-packages/yaml/*.so]
 tinypilot: national-encoding opt/tinypilot/venv/lib/python*/site-packages/passlib/tests/sample1c.cfg
 
 # Lintian doesn't recognize the Python interpreter when it's within the


### PR DESCRIPTION
I noticed that lintian reports 3 unused overrides, see e.g. [the “Run lintian” step of this CI build](https://app.circleci.com/pipelines/github/tiny-pilot/tinypilot/4891/workflows/2b7f55b2-d2f8-4085-ac30-6a4676ecb083/jobs/37639):

```
N: 21 hints overridden (21 warnings); 3 unused overrides
```

I haven’t investigated this, but I assume the issues just went away at some point when we upgraded the offending packages.

With this PR, [the unused overrides go back to `0`](https://app.circleci.com/pipelines/github/tiny-pilot/tinypilot/4897/workflows/3d482ece-5100-4ee6-934f-b82184386438/jobs/37701):

```
N: 21 hints overridden (21 warnings); 0 unused overrides
```

This PR is succeeds https://github.com/tiny-pilot/tinypilot-pro/pull/1719.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1931"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>