### PR TITLE
Rename pip dev requirements file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,9 @@ jobs:
           name: Install requirements and run lint script
           command: |
             . venv/bin/activate
-            pip install --requirement dev_requirements.txt
+            pip install \
+              --requirement requirements.txt \
+              --requirement requirements_dev.txt
             ./dev-scripts/check-sql
   check_style:
     executor: node
@@ -136,7 +138,9 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install --requirement dev_requirements.txt
+            pip install \
+              --requirement requirements.txt \
+              --requirement requirements_dev.txt
       - run:
           name: Run check script
           command: |
@@ -163,7 +167,9 @@ jobs:
           name: Install requirements
           command: |
             . venv/bin/activate
-            pip install --requirement dev_requirements.txt
+            pip install \
+              --requirement requirements.txt \
+              --requirement requirements_dev.txt
       - run:
           name: Run Static Application Security Testing (SAST) on files
           command: |
@@ -188,7 +194,9 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install --requirement dev_requirements.txt
+            pip install \
+              --requirement requirements.txt \
+              --requirement requirements_dev.txt
       - run:
           name: Install node dependencies
           command: npm install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,9 @@ To install TinyPilot's dev packages, run the following command:
 ```bash
 python3 -m venv venv && \
   . venv/bin/activate && \
-  pip install --requirement dev_requirements.txt && \
+  pip install \
+    --requirement requirements.txt \
+    --requirement requirements_dev.txt && \
   npm install && \
   sudo npx playwright install-deps && \
   ./dev-scripts/enable-multiarch-docker
@@ -275,7 +277,7 @@ We don't use any Python package management tools because we want to limit comple
 1. `awk '/^\s*$/ || !a[tolower($0)]++' requirements.txt | tee requirements.txt` to delete duplicate lines.
 1. Update `app/license_notice.py` to match any changes in `requirements.txt`.
 
-We don't track indirect dependencies for our dev dependencies (in `dev_requirements.txt`), so you can update those by simply changing the version number for any package.
+We don't track indirect dependencies for our dev dependencies (in `requirements_dev.txt`), so you can update those by simply changing the version number for any package.
 
 ### Building an ARMv7 bundle on a dev system
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,3 @@
---requirement requirements.txt
-
 bandit==1.8.6
 coverage==7.2.7
 pylint==2.14.2


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot-pro/issues/1731

This PR renames the pip `dev_requirements.txt` file to `requirements_dev.txt` so that it appears nearer to the `requirements.txt` file in the file explorer. Also, `requirements_dev.txt` now only holds the dev requirements instead of including/importing the main `requirements.txt` file.

This change is needed to simplify working with multiple Python virtual environments in the Pro repo:
- https://github.com/tiny-pilot/tinypilot-pro/pull/1755#pullrequestreview-3759337705

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1938"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>