### PR TITLE
Backport changes from Pro: Re-issue session cookie when switching between HTTP<>HTTPS

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -693,6 +693,16 @@ def settings_requires_https_put():
     flask.current_app.config.update(
         SESSION_COOKIE_SECURE=is_session_cookie_secure)
 
+    # Force the session cookie to be re-issued with the updated Secure flag.
+    # This is important when HTTPS is being disabled: the browser will reject
+    # a non-Secure Set-Cookie sent from an HTTP origin if a Secure cookie with
+    # the same name already exists. By re-issuing the cookie, while the request
+    # is still over HTTPS, the browser accepts the new non-Secure cookie and
+    # replaces the old Secure one. Without this, every subsequent HTTP request
+    # would arrive with no session cookie, causing CSRF validation to fail with
+    # "CSRF session token is missing".
+    flask.session.modified = True
+
     return json_response.success()
 
 


### PR DESCRIPTION
This PR backports the changes from https://github.com/tiny-pilot/tinypilot-pro/pull/1857, Re-issue session cookie when switching between HTTP<>HTTPS – see https://github.com/tiny-pilot/tinypilot-pro/issues/1848 for details.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1948"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>