### PR TITLE
Security: Add auth rate limits, fix username existence timing leak

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -261,7 +261,8 @@ def auth_post():
     try:
         login_rate_limit.check(source_ip, username)
     except login_rate_limit.TooManyAttemptsError as e:
-        logger.info_sensitive(  # nosemgrep: python-logger-credential-disclosure
+        # nosemgrep: python-logger-credential-disclosure
+        logger.info_sensitive(
             'Rejecting login for user %s from IP %s: rate-limited', username,
             source_ip)
         return json_response.error(e), 429

--- a/app/api.py
+++ b/app/api.py
@@ -11,6 +11,7 @@ import execute
 import hostname
 import json_response
 import local_system
+import login_rate_limit
 import network
 import request_parsers.create_user
 import request_parsers.credentials
@@ -242,17 +243,33 @@ def auth_post():
     Returns:
         Empty response on success, error object otherwise.
     """
-    logger.info_sensitive(
-        'Login request from IP %s',
-        flask.request.headers.get('X-Forwarded-For', flask.request.remote_addr))
+    source_ip = flask.request.headers.get('X-Forwarded-For',
+                                          flask.request.remote_addr)
+    # X-Forwarded-For may contain a comma-separated list; the left-most entry
+    # is the original client. Use only that entry as the rate-limit key.
+    if source_ip:
+        source_ip = source_ip.split(',')[0].strip()
+    logger.info_sensitive('Login request from IP %s', source_ip)
     try:
         username, password = request_parsers.credentials.parse_credentials(
             flask.request)
     except request_parsers.errors.Error as e:
         return json_response.error(e), 400
+    # Enforce rate-limit/lockout *before* checking the password, so we don’t
+    # leak signal about valid usernames or correct passwords once the limiter
+    # has tripped.
+    try:
+        login_rate_limit.check(source_ip, username)
+    except login_rate_limit.TooManyAttemptsError as e:
+        logger.info_sensitive(  # nosemgrep: python-logger-credential-disclosure
+            'Rejecting login for user %s from IP %s: rate-limited', username,
+            source_ip)
+        return json_response.error(e), 429
     if auth.can_authenticate(username, password):
+        login_rate_limit.record_success(username)
         session.login(username)
         return json_response.success()
+    login_rate_limit.record_failure(source_ip, username)
     return json_response.error(
         NotAuthenticatedError('Invalid username and password')), 401
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -222,6 +222,11 @@ def can_authenticate(username, password):
     password_hash = db.users.Users().get_password_hash(username)
 
     if not password_hash:
+        # Run a dummy hash verification so the response time matches that of
+        # a real authentication attempt. Otherwise, an attacker could probe
+        # the system to enumerate valid usernames by observing how long the
+        # response takes.
+        password_check.dummy_verify(password)
         logger.info_sensitive('Cannot authenticate, no such user %s', username)
         return False
 

--- a/app/login_rate_limit.py
+++ b/app/login_rate_limit.py
@@ -117,7 +117,8 @@ def record_failure(ip_address, username):
                 # We're knowingly logging a user's username, which is
                 # sensitive, but we've also marked the log as sensitive so it
                 # can later be scrubbed.
-                logger.info_sensitive(  # nosemgrep: python-logger-credential-disclosure
+                # nosemgrep: python-logger-credential-disclosure
+                logger.info_sensitive(
                     'Locking out user %s for %d seconds after %d failed'
                     ' login attempts', username, _USERNAME_LOCKOUT_SECONDS,
                     count)

--- a/app/login_rate_limit.py
+++ b/app/login_rate_limit.py
@@ -1,0 +1,138 @@
+"""Rate limiter for the login endpoint to mitigate online brute-force attacks.
+
+This module enforces two complementary limits on failed login attempts:
+
+  1. Per-source-IP throttling: limits how many failed attempts a single client
+     IP can make in a sliding window.
+  2. Per-username lockout: after a small number of consecutive failed attempts
+     against a given username, that username is temporarily locked out from
+     authenticating, regardless of the source IP.
+
+A successful login resets the per-username failure counter, but does not reset
+the per-IP limit (so a legitimate user repeatedly failing then succeeding does
+not unlock the IP for a different attacker on the same network).
+
+The state is kept in-process. This is acceptable because TinyPilot runs as a
+single Flask process and the attacker would be defeated by the rate limit even
+if the process restarts (each restart resets the counters but the attacker’s
+gain is bounded). For higher assurance, this state could be moved to the
+database in the future.
+"""
+import logging
+import threading
+import time
+
+logger = logging.getLogger(__name__)
+
+# Per-source-IP limits.
+_IP_WINDOW_SECONDS = 60 * 5  # 5 minutes.
+_IP_MAX_FAILURES = 10
+
+# Per-username limits.
+_USERNAME_LOCKOUT_SECONDS = 60 * 15  # 15 minutes.
+_USERNAME_MAX_FAILURES = 5
+
+
+class TooManyAttemptsError(Exception):
+    """Raised when the caller is currently rate-limited."""
+
+
+_lock = threading.Lock()
+# Maps source IP (str) -> list of failure timestamps (float, seconds since
+# epoch) that fall within the sliding window.
+_ip_failures = {}
+# Maps username (str) -> (failure_count, lockout_until_timestamp).
+_username_failures = {}
+
+
+def _now():
+    return time.monotonic()
+
+
+def _prune_ip_failures(ip_address, now):
+    """Drops failure timestamps older than the sliding window."""
+    cutoff = now - _IP_WINDOW_SECONDS
+    timestamps = _ip_failures.get(ip_address, [])
+    fresh = [t for t in timestamps if t >= cutoff]
+    if fresh:
+        _ip_failures[ip_address] = fresh
+    elif ip_address in _ip_failures:
+        del _ip_failures[ip_address]
+    return fresh
+
+
+def check(ip_address, username):
+    """Raises TooManyAttemptsError if the caller is currently rate-limited.
+
+    Must be called *before* validating the password, so that we don’t leak
+    information about whether the username exists or the password is correct
+    when the caller is locked out.
+
+    Args:
+        ip_address: (str) The source IP of the request.
+        username: (str) The username being authenticated.
+
+    Raises:
+        TooManyAttemptsError: If the IP or the username is currently
+            rate-limited.
+    """
+    now = _now()
+    with _lock:
+        # Per-IP check.
+        if ip_address:
+            fresh = _prune_ip_failures(ip_address, now)
+            if len(fresh) >= _IP_MAX_FAILURES:
+                raise TooManyAttemptsError(
+                    'Too many failed login attempts from this address.'
+                    ' Please wait a few minutes and try again.')
+
+        # Per-username check.
+        if username:
+            entry = _username_failures.get(username)
+            if entry is not None:
+                _, locked_until = entry
+                if locked_until and now < locked_until:
+                    raise TooManyAttemptsError(
+                        'This account is temporarily locked due to too many'
+                        ' failed login attempts. Please try again later.')
+
+
+def record_failure(ip_address, username):
+    """Records a failed login attempt for the given IP and username."""
+    now = _now()
+    with _lock:
+        if ip_address:
+            timestamps = _ip_failures.setdefault(ip_address, [])
+            timestamps.append(now)
+
+        if username:
+            count, locked_until = _username_failures.get(username, (0, 0.0))
+            # If the previous lockout has expired, start counting afresh.
+            if locked_until and now >= locked_until:
+                count = 0
+                locked_until = 0.0
+            count += 1
+            if count >= _USERNAME_MAX_FAILURES:
+                locked_until = now + _USERNAME_LOCKOUT_SECONDS
+                # We're knowingly logging a user's username, which is
+                # sensitive, but we've also marked the log as sensitive so it
+                # can later be scrubbed.
+                logger.info_sensitive(  # nosemgrep: python-logger-credential-disclosure
+                    'Locking out user %s for %d seconds after %d failed'
+                    ' login attempts', username, _USERNAME_LOCKOUT_SECONDS,
+                    count)
+            _username_failures[username] = (count, locked_until)
+
+
+def record_success(username):
+    """Clears the per-username failure counter after a successful login."""
+    with _lock:
+        if username in _username_failures:
+            del _username_failures[username]
+
+
+def reset_for_testing():
+    """Test-only helper to reset all rate-limiter state."""
+    with _lock:
+        _ip_failures.clear()
+        _username_failures.clear()

--- a/app/login_rate_limit_test.py
+++ b/app/login_rate_limit_test.py
@@ -1,0 +1,54 @@
+import unittest
+
+# Importing `log` configures the custom logger class that the module under
+# test relies on for `info_sensitive`.
+import log  # noqa: F401  pylint: disable=unused-import
+import login_rate_limit
+
+
+class LoginRateLimitTest(unittest.TestCase):
+
+    def setUp(self):
+        login_rate_limit.reset_for_testing()
+
+    def test_allows_attempts_below_limit(self):
+        for _ in range(3):
+            login_rate_limit.check('1.2.3.4', 'alice')
+            login_rate_limit.record_failure('1.2.3.4', 'alice')
+
+    def test_locks_username_after_threshold(self):
+        for _ in range(5):
+            login_rate_limit.check('1.2.3.4', 'alice')
+            login_rate_limit.record_failure('1.2.3.4', 'alice')
+        # The 6th attempt — even from a different IP — must be rejected.
+        with self.assertRaises(login_rate_limit.TooManyAttemptsError):
+            login_rate_limit.check('5.6.7.8', 'alice')
+
+    def test_locks_ip_after_threshold(self):
+        # Different usernames, same IP. The IP must get locked once enough
+        # failures accumulate, regardless of the username.
+        for i in range(10):
+            login_rate_limit.check('1.2.3.4', f'user{i}')
+            login_rate_limit.record_failure('1.2.3.4', f'user{i}')
+        with self.assertRaises(login_rate_limit.TooManyAttemptsError):
+            login_rate_limit.check('1.2.3.4', 'someone-new')
+
+    def test_success_resets_username_failures(self):
+        for _ in range(4):
+            login_rate_limit.check('1.2.3.4', 'alice')
+            login_rate_limit.record_failure('1.2.3.4', 'alice')
+        login_rate_limit.record_success('alice')
+        # After a successful login, the username counter is reset and the
+        # account is no longer near a lockout.
+        for _ in range(4):
+            login_rate_limit.check('1.2.3.4', 'alice')
+            login_rate_limit.record_failure('1.2.3.4', 'alice')
+
+    def test_check_without_username_or_ip_is_noop(self):
+        # An empty username/IP must not raise and must not poison shared state.
+        login_rate_limit.check('', '')
+        login_rate_limit.record_failure('', '')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/password.py
+++ b/app/password.py
@@ -14,3 +14,21 @@ def generate_hash(password):
 
 def verify(password, password_hash):
     return _CUSTOM_PBKDF2.verify(password, password_hash)
+
+
+# A pre-computed hash of a value that no real password can match. We use it
+# in `dummy_verify` to keep the timing of authentication constant for users
+# that don’t exist on the system, so that an attacker cannot enumerate
+# valid usernames by measuring response times.
+_DUMMY_HASH = _CUSTOM_PBKDF2.hash('tinypilot-dummy-password-for-timing-only')
+
+
+def dummy_verify(password):
+    """Performs the same work as `verify` but always returns False.
+
+    This exists solely to equalise the response time of authentication
+    attempts when the requested username doesn’t exist on the system.
+    """
+    # We deliberately ignore the result of `verify` and always return False.
+    _CUSTOM_PBKDF2.verify(password, _DUMMY_HASH)
+    return False


### PR DESCRIPTION
This PR includes a few minor security improvements:
- Implement IP-based rate limiting for authentication attempts
- Always use left-most X-Forwarded-For address for IP checks
- Avoid username existence timing leak via dummy auth path

Feel free to use this patch, close it without review, or extract out only specific bits.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1949"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>