### PR TITLE
Remove AMD64 build option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,8 +227,7 @@ jobs:
       - run:
           name: Build Debian package
           command: |
-            ./dev-scripts/build-debian-pkg \
-              --build-targets linux/arm/v7
+            ./dev-scripts/build-debian-pkg
       - run:
           name: Print Debian package contents
           command: dpkg --contents debian-pkg/releases/tinypilot*.deb

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,7 +294,7 @@ Once your dev system is configured for multi-architecture Docker builds, you can
 TARGET_PLATFORM='linux/arm/v7'
 
 (rm debian-pkg/releases/tinypilot*.deb || true) && \
-  ./dev-scripts/build-debian-pkg --build-targets "${TARGET_PLATFORM}" && \
+  ./dev-scripts/build-debian-pkg && \
   mv debian-pkg/releases/tinypilot*.deb bundler/bundle && \
   ./bundler/create-bundle
 ```

--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -24,11 +24,8 @@ cd ./bundler
 readonly BUNDLE_DIR='bundle'
 readonly OUTPUT_DIR='dist'
 
-# Exclude the AMD64 package from the production bundle.
-rm -f "${BUNDLE_DIR}/tinypilot"*amd64.deb
-
 # Ensure that a TinyPilot Debian package exists.
-if ! ls "${BUNDLE_DIR}/tinypilot"*armhf.deb 1> /dev/null 2>&1; then
+if ! ls "${BUNDLE_DIR}/tinypilot"*arm64.deb 1> /dev/null 2>&1; then
   echo 'Failed to create bundle: no TinyPilot Debian package found.' >&2
   exit 1
 fi
@@ -50,7 +47,7 @@ print_tinypilot_version() {
   dpkg-deb \
     --show \
     --showformat '${Tinypilot-Version}' \
-    "${BUNDLE_DIR}/tinypilot"*armhf.deb
+    "${BUNDLE_DIR}/tinypilot"*arm64.deb
 }
 
 # Compose bundle file name, which consists of these hyphen-separated parts:

--- a/bundler/verify-bundle
+++ b/bundler/verify-bundle
@@ -42,4 +42,4 @@ if [[ ! -f install ]]; then
 fi
 
 # List Debian package contents.
-dpkg --contents tinypilot*armhf.deb
+dpkg --contents tinypilot*arm64.deb

--- a/debian-pkg/Dockerfile
+++ b/debian-pkg/Dockerfile
@@ -35,8 +35,8 @@ ARG PKG_BUILD_NUMBER='1'
 RUN cat | bash <<'EOF'
 set -exu
 case "${TARGETPLATFORM}" in
-  'linux/arm/v7')
-    PKG_ARCH='armhf'
+  'linux/arm64')
+    PKG_ARCH='arm64'
     ;;
   *)
     echo "Unrecognized target platform: ${TARGETPLATFORM}" >&2

--- a/debian-pkg/Dockerfile
+++ b/debian-pkg/Dockerfile
@@ -35,9 +35,6 @@ ARG PKG_BUILD_NUMBER='1'
 RUN cat | bash <<'EOF'
 set -exu
 case "${TARGETPLATFORM}" in
-  'linux/amd64')
-    PKG_ARCH='amd64'
-    ;;
   'linux/arm/v7')
     PKG_ARCH='armhf'
     ;;

--- a/debian-pkg/debian/tinypilot.lintian-overrides
+++ b/debian-pkg/debian/tinypilot.lintian-overrides
@@ -4,6 +4,7 @@ tinypilot: script-not-executable [opt/tinypilot/venv/lib/python*/site-packages/p
 tinypilot: script-not-executable [opt/tinypilot/venv/lib/python*/site-packages/pkg_resources/_vendor/appdirs.py]
 tinypilot: script-not-executable [opt/tinypilot/venv/lib/python*/site-packages/setuptools/command/easy_install.py]
 tinypilot: national-encoding opt/tinypilot/venv/lib/python*/site-packages/passlib/tests/sample1c.cfg
+tinypilot: embedded-library libyaml [opt/tinypilot/venv/lib/python*/site-packages/yaml/_yaml.cpython-*-linux-gnu.so]
 
 # Lintian doesn't recognize the Python interpreter when it's within the
 # virtualenv.

--- a/debian-pkg/debian/tinypilot.lintian-overrides
+++ b/debian-pkg/debian/tinypilot.lintian-overrides
@@ -4,7 +4,7 @@ tinypilot: script-not-executable [opt/tinypilot/venv/lib/python*/site-packages/p
 tinypilot: script-not-executable [opt/tinypilot/venv/lib/python*/site-packages/pkg_resources/_vendor/appdirs.py]
 tinypilot: script-not-executable [opt/tinypilot/venv/lib/python*/site-packages/setuptools/command/easy_install.py]
 tinypilot: national-encoding opt/tinypilot/venv/lib/python*/site-packages/passlib/tests/sample1c.cfg
-tinypilot: embedded-library libyaml [opt/tinypilot/venv/lib/python*/site-packages/yaml/_yaml.cpython-*-linux-gnu.so]
+tinypilot: embedded-library libyaml opt/tinypilot/venv/lib/python3.9/site-packages/yaml/_yaml.cpython-39-aarch64-linux-gnu.so
 
 # Lintian doesn't recognize the Python interpreter when it's within the
 # virtualenv.

--- a/dev-scripts/build-debian-pkg
+++ b/dev-scripts/build-debian-pkg
@@ -10,14 +10,9 @@ set -u
 
 print_help() {
   cat <<EOF
-Usage: ${0##*/} [--help] [--build-targets BUILD_TARGETS] [--tinypilot-version TINYPILOT_VERSION]
+Usage: ${0##*/} [--help] [--tinypilot-version TINYPILOT_VERSION]
 Build a TinyPilot Debian package.
   --help                                  Optional. Display this help and exit.
-  --build-targets BUILD_TARGETS           Optional. A comma-separated list of architectures
-                                          that Docker accepts for its --platform argument.
-                                          If omitted, defaults to "linux/arm/v7,linux/amd64".
-                                          The only supported targets are "linux/arm/v7" and
-                                          "linux/amd64".
   --tinypilot-version TINYPILOT_VERSION   Optional. The version identifier that shall be
                                           assigned. If omitted, determines the version string
                                           automatically, in the "x.y.z-i+hhhhhhh" format that
@@ -34,18 +29,12 @@ print_tinypilot_version() {
 }
 
 # Parse command-line arguments.
-BUILD_TARGETS='linux/arm/v7,linux/amd64'
 TINYPILOT_VERSION="$(print_tinypilot_version)"
 while (( "$#" > 0 )); do
   case "$1" in
     --help)
       print_help
       exit
-      ;;
-    --build-targets)
-      BUILD_TARGETS="$2"
-      shift # For flag name.
-      shift # For flag value.
       ;;
     --tinypilot-version)
       TINYPILOT_VERSION="$2"
@@ -59,7 +48,6 @@ while (( "$#" > 0 )); do
       ;;
   esac
 done
-readonly BUILD_TARGETS
 readonly TINYPILOT_VERSION
 
 # Echo commands before executing them, by default to stderr.
@@ -77,7 +65,7 @@ readonly DOCKER_PROGRESS
 
 DOCKER_BUILDKIT=1 docker buildx build \
   --file debian-pkg/Dockerfile \
-  --platform "${BUILD_TARGETS}" \
+  --platform 'linux/arm/v7' \
   --build-arg TINYPILOT_VERSION="${TINYPILOT_VERSION}" \
   --build-arg PKG_VERSION="${PKG_VERSION}" \
   --target=artifact \

--- a/dev-scripts/build-debian-pkg
+++ b/dev-scripts/build-debian-pkg
@@ -65,7 +65,7 @@ readonly DOCKER_PROGRESS
 
 DOCKER_BUILDKIT=1 docker buildx build \
   --file debian-pkg/Dockerfile \
-  --platform 'linux/arm/v7' \
+  --platform 'linux/arm64' \
   --build-arg TINYPILOT_VERSION="${TINYPILOT_VERSION}" \
   --build-arg PKG_VERSION="${PKG_VERSION}" \
   --target=artifact \

--- a/dev-scripts/device/install-from-source
+++ b/dev-scripts/device/install-from-source
@@ -22,7 +22,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 readonly SCRIPT_DIR
 cd "${SCRIPT_DIR}/../.."
 
-./dev-scripts/build-debian-pkg --build-targets 'linux/arm/v7'
+./dev-scripts/build-debian-pkg
 
 # Shellcheck recommends find instead of ls for non-alphanumeric filenames, but
 # we don't expect non-alphanumeric filenames, and the find equivalent is more


### PR DESCRIPTION
Resolves: #1950
Related: https://github.com/tiny-pilot/tinypilot-pro/issues/1829

This change removes the architecture options from `build-debian-pkg`, leaving `arm64` as the only build platform.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1951"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>