### PR TITLE
Update README with Trixie details

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ See ["TinyPilot: Build a KVM Over IP for Under \$100"](https://mtlynch.io/tinypi
 
 ### Requirements
 
-- A Raspberry Pi 4B running Raspberry Pi OS Bullseye (32-bit)
+- A Raspberry Pi 4B running Raspberry Pi OS Trixie (64-bit)
 
 You can install TinyPilot on a compatible Raspberry Pi in just two commands.
 


### PR DESCRIPTION
Resolves #1954 

This change updates the README with the new base OS details that TinyPilot runs on.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1955"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>