### PR TITLE
Remove AMD64 build option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,8 +230,7 @@ jobs:
       - run:
           name: Build Debian package
           command: |
-            ./dev-scripts/build-debian-pkg \
-              --build-targets linux/arm64
+            ./dev-scripts/build-debian-pkg
       - run:
           name: Print Debian package contents
           command: dpkg --contents debian-pkg/releases/tinypilot*.deb

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -300,10 +300,8 @@ To build a TinyPilot install bundle on your dev system, you first need to config
 Once your dev system is configured for multi-architecture Docker builds, you can build install ARM64 TinyPilot bundles with the following commands:
 
 ```bash
-TARGET_PLATFORM='linux/arm64'
-
 (rm debian-pkg/releases/tinypilot*.deb || true) && \
-  ./dev-scripts/build-debian-pkg --build-targets "${TARGET_PLATFORM}" && \
+  ./dev-scripts/build-debian-pkg && \
   mv debian-pkg/releases/tinypilot*.deb bundler/bundle && \
   ./bundler/create-bundle
 ```

--- a/bundler/create-bundle
+++ b/bundler/create-bundle
@@ -24,9 +24,6 @@ cd ./bundler
 readonly BUNDLE_DIR='bundle'
 readonly OUTPUT_DIR='dist'
 
-# Exclude the AMD64 package from the production bundle.
-rm -f "${BUNDLE_DIR}/tinypilot"*amd64.deb
-
 # Ensure that a TinyPilot Debian package exists.
 if ! ls "${BUNDLE_DIR}/tinypilot"*arm64.deb 1> /dev/null 2>&1; then
   echo 'Failed to create bundle: no TinyPilot Debian package found.' >&2

--- a/debian-pkg/Dockerfile
+++ b/debian-pkg/Dockerfile
@@ -35,9 +35,6 @@ ARG PKG_BUILD_NUMBER='1'
 RUN cat | bash <<'EOF'
 set -exu
 case "${TARGETPLATFORM}" in
-  'linux/amd64')
-    PKG_ARCH='amd64'
-    ;;
   'linux/arm64')
     PKG_ARCH='arm64'
     ;;

--- a/dev-scripts/build-debian-pkg
+++ b/dev-scripts/build-debian-pkg
@@ -10,14 +10,9 @@ set -u
 
 print_help() {
   cat <<EOF
-Usage: ${0##*/} [--help] [--build-targets BUILD_TARGETS] [--tinypilot-version TINYPILOT_VERSION]
+Usage: ${0##*/} [--help] [--tinypilot-version TINYPILOT_VERSION]
 Build a TinyPilot Debian package.
   --help                                  Optional. Display this help and exit.
-  --build-targets BUILD_TARGETS           Optional. A comma-separated list of architectures
-                                          that Docker accepts for its --platform argument.
-                                          If omitted, defaults to "linux/arm64,linux/amd64".
-                                          The only supported targets are "linux/arm64" and
-                                          "linux/amd64".
   --tinypilot-version TINYPILOT_VERSION   Optional. The version identifier that shall be
                                           assigned. If omitted, determines the version string
                                           automatically, in the "x.y.z-i+hhhhhhh" format that
@@ -34,18 +29,12 @@ print_tinypilot_version() {
 }
 
 # Parse command-line arguments.
-BUILD_TARGETS='linux/arm64,linux/amd64'
 TINYPILOT_VERSION="$(print_tinypilot_version)"
 while (( "$#" > 0 )); do
   case "$1" in
     --help)
       print_help
       exit
-      ;;
-    --build-targets)
-      BUILD_TARGETS="$2"
-      shift # For flag name.
-      shift # For flag value.
       ;;
     --tinypilot-version)
       TINYPILOT_VERSION="$2"
@@ -59,7 +48,6 @@ while (( "$#" > 0 )); do
       ;;
   esac
 done
-readonly BUILD_TARGETS
 readonly TINYPILOT_VERSION
 
 # Echo commands before executing them, by default to stderr.
@@ -77,7 +65,7 @@ readonly DOCKER_PROGRESS
 
 DOCKER_BUILDKIT=1 docker buildx build \
   --file debian-pkg/Dockerfile \
-  --platform "${BUILD_TARGETS}" \
+  --platform 'linux/arm64' \
   --build-arg TINYPILOT_VERSION="${TINYPILOT_VERSION}" \
   --build-arg PKG_VERSION="${PKG_VERSION}" \
   --target=artifact \

--- a/dev-scripts/device/install-from-source
+++ b/dev-scripts/device/install-from-source
@@ -22,7 +22,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 readonly SCRIPT_DIR
 cd "${SCRIPT_DIR}/../.."
 
-./dev-scripts/build-debian-pkg --build-targets 'linux/arm64'
+./dev-scripts/build-debian-pkg
 
 # Shellcheck recommends find instead of ls for non-alphanumeric filenames, but
 # we don't expect non-alphanumeric filenames, and the find equivalent is more


### PR DESCRIPTION
Resolves #1950

This change removes the architecture options from `build-debian-pkg`, leaving `arm64` as the only build platform.