### PR TITLE
Backport changes from Pro

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,6 @@
 GATEKEEPER_BASE_URL="http://localhost:2001"
 
 # For developmenet, use /dev/null to avoid errors when the environment
-# cannot access the real /dev/hidg0 and /dev/hidg1 devices.
+# cannot access the real /dev/hid... devices.
 KEYBOARD_PATH="/dev/null"
-MOUSE_PATH="/dev/null"
+MOUSE_ABSOLUTE_PATH="/dev/null"

--- a/.github/workflows/merge-pro.yml
+++ b/.github/workflows/merge-pro.yml
@@ -7,7 +7,7 @@ jobs:
   updateFork:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
         with:
           repository: tiny-pilot/tinypilot-pro
           token: ${{ secrets.PR_BOT_PAT }}
@@ -29,7 +29,7 @@ jobs:
           readonly COMMUNITY_PR_URL
           echo "COMMUNITY_PR_URL=${COMMUNITY_PR_URL}" >> "${GITHUB_ENV}"
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4
         with:
           token: ${{ secrets.PR_BOT_PAT }}
           branch: community-changes-${{ github.sha }}

--- a/app/db/migrations/011-mouse-mode-add-col.sql
+++ b/app/db/migrations/011-mouse-mode-add-col.sql
@@ -1,0 +1,4 @@
+-- Add column for storing the relative/absolute mouse mode setting.
+
+ALTER TABLE settings
+ADD COLUMN mouse_mode TEXT NOT NULL DEFAULT 'ABSOLUTE';

--- a/app/db/settings.py
+++ b/app/db/settings.py
@@ -45,7 +45,7 @@ class Settings:
         """Retrieves the preferred streaming mode for the remote screen.
 
         Returns:
-            A `StreamingMode` value.
+            A `StreamingMode` instance.
         """
         cursor = self._db_connection.execute(
             'SELECT streaming_mode FROM settings WHERE id=?', [_ROW_ID])
@@ -56,7 +56,7 @@ class Settings:
         """Stores the preferred streaming mode.
 
         Args:
-            streaming_mode: `StreamingMode` value.
+            streaming_mode: `StreamingMode` instance.
         """
         self._db_connection.execute(
             'UPDATE settings SET streaming_mode=? WHERE id=?',

--- a/app/env.py
+++ b/app/env.py
@@ -8,7 +8,7 @@ _config = dotenv.dotenv_values('.env')
 GATEKEEPER_BASE_URL = _config.get('GATEKEEPER_BASE_URL',
                                   'https://gk.tinypilotkvm.com')
 KEYBOARD_PATH = _config.get('KEYBOARD_PATH', '/dev/hidg0')
-MOUSE_PATH = _config.get('MOUSE_PATH', '/dev/hidg1')
+MOUSE_ABSOLUTE_PATH = _config.get('MOUSE_ABSOLUTE_PATH', '/dev/hidg1')
 
 _TINYPILOT_HOME_PATH = pathlib.Path(
     os.environ.get('TINYPILOT_HOME_DIR', '/home/tinypilot'))

--- a/app/hid/mouse_test.py
+++ b/app/hid/mouse_test.py
@@ -1,19 +1,19 @@
 import tempfile
 import unittest
 
-from hid import mouse
+from hid import mouse as fake_mouse
 
 
 class MouseTest(unittest.TestCase):
 
     def test_sends_mouse_click_to_hid_interface(self):
         with tempfile.NamedTemporaryFile() as input_file:
-            mouse.send_mouse_event(mouse_path=input_file.name,
-                                   buttons=0x01,
-                                   relative_x=0.5,
-                                   relative_y=0.75,
-                                   vertical_wheel_delta=0,
-                                   horizontal_wheel_delta=0)
+            fake_mouse.send_mouse_event(mouse_path=input_file.name,
+                                        buttons=0x01,
+                                        relative_x=0.5,
+                                        relative_y=0.75,
+                                        vertical_wheel_delta=0,
+                                        horizontal_wheel_delta=0)
             input_file.seek(0)
             # Byte 0   = Button 1 pressed
             # Byte 1-2 = 32767 * 0.5 = 16383.5 = 0x3fff (little-endian)
@@ -22,12 +22,12 @@ class MouseTest(unittest.TestCase):
 
     def test_sends_mouse_move_to_hid_interface(self):
         with tempfile.NamedTemporaryFile() as input_file:
-            mouse.send_mouse_event(mouse_path=input_file.name,
-                                   buttons=0,
-                                   relative_x=0.0,
-                                   relative_y=1.0,
-                                   vertical_wheel_delta=0,
-                                   horizontal_wheel_delta=0)
+            fake_mouse.send_mouse_event(mouse_path=input_file.name,
+                                        buttons=0,
+                                        relative_x=0.0,
+                                        relative_y=1.0,
+                                        vertical_wheel_delta=0,
+                                        horizontal_wheel_delta=0)
             input_file.seek(0)
             # Byte 0   = No buttons pressed
             # Byte 1-2 = 32767 * 0.0 = 0 = 0x0000

--- a/app/request_parsers/mouse_event_test.py
+++ b/app/request_parsers/mouse_event_test.py
@@ -3,7 +3,7 @@ import unittest
 from request_parsers import mouse_event
 
 
-class MouseEventTest(unittest.TestCase):
+class AbsoluteMouseEventTest(unittest.TestCase):
 
     def test_parses_valid_mouse_event(self):
         self.assertEqual(

--- a/app/socket_api.py
+++ b/app/socket_api.py
@@ -99,13 +99,12 @@ def on_mouse_event(message):
     except mouse_event_request.Error as e:
         logger.error_sensitive('Failed to parse mouse event request: %s', e)
         return {'success': False}
-    mouse_path = env.MOUSE_PATH
     try:
-        fake_mouse.send_mouse_event(mouse_path, mouse_move_event.buttons,
-                                    mouse_move_event.relative_x,
-                                    mouse_move_event.relative_y,
-                                    mouse_move_event.vertical_wheel_delta,
-                                    mouse_move_event.horizontal_wheel_delta)
+        fake_mouse.send_mouse_event(
+            env.MOUSE_ABSOLUTE_PATH, mouse_move_event.buttons,
+            mouse_move_event.relative_x, mouse_move_event.relative_y,
+            mouse_move_event.vertical_wheel_delta,
+            mouse_move_event.horizontal_wheel_delta)
     except hid_write.WriteError as e:
         logger.error_sensitive('Failed to forward mouse event: %s', e)
         return {'success': False}

--- a/app/socket_api.py
+++ b/app/socket_api.py
@@ -100,11 +100,12 @@ def on_mouse_event(message):
         logger.error_sensitive('Failed to parse mouse event request: %s', e)
         return {'success': False}
     try:
-        fake_mouse.send_mouse_event(
-            env.MOUSE_ABSOLUTE_PATH, mouse_move_event.buttons,
-            mouse_move_event.relative_x, mouse_move_event.relative_y,
-            mouse_move_event.vertical_wheel_delta,
-            mouse_move_event.horizontal_wheel_delta)
+        fake_mouse.send_mouse_event(env.MOUSE_ABSOLUTE_PATH,
+                                    mouse_move_event.buttons,
+                                    mouse_move_event.relative_x,
+                                    mouse_move_event.relative_y,
+                                    mouse_move_event.vertical_wheel_delta,
+                                    mouse_move_event.horizontal_wheel_delta)
     except hid_write.WriteError as e:
         logger.error_sensitive('Failed to forward mouse event: %s', e)
         return {'success': False}

--- a/debian-pkg/debian/rules
+++ b/debian-pkg/debian/rules
@@ -15,9 +15,9 @@ export DEB_BUILD_OPTIONS=noddebs
 override_dh_installsystemd:
 	dh_installsystemd --name=load-edid --no-start
 	dh_installsystemd --name=tinypilot
-	dh_installsystemd --name=update-tls-cert-common-name
-	dh_installsystemd --name=tinypilot-updater --no-start --no-enable
-	dh_installsystemd --name=usb-gadget --no-start
+	dh_installsystemd --name=update-tls-cert-common-name --no-start --no-enable
+	dh_installsystemd --name=tinypilot-updater --no-start --no-enable --no-stop-on-upgrade
+	dh_installsystemd --name=usb-gadget --no-start --no-stop-on-upgrade
 	dh_installsystemd --name=ustreamer
 	dh_installsystemd --name=janus
 

--- a/debian-pkg/debian/tinypilot.service
+++ b/debian-pkg/debian/tinypilot.service
@@ -1,7 +1,13 @@
 [Unit]
 Description=TinyPilot - RPi-based virtual KVM
-BindsTo=nginx.service
-After=syslog.target network.target nginx.service
+# TinyPilot binds 127.0.0.1 and relies on nginx to proxy it to the network.
+# Wants= (rather than BindsTo=) prevents an nginx restart (e.g., TLS cert
+# cycling) from stopping TinyPilot and dropping the user's session. Not using
+# After=nginx keeps TinyPilot from inheriting nginx's wait on
+# network-online.target, so it can start in parallel and is usually ready to
+# serve before nginx accepts connections, avoiding 502 errors.
+Wants=nginx.service
+After=syslog.target
 StartLimitIntervalSec=0
 
 [Service]

--- a/debian-pkg/opt/tinypilot-privileged/init-usb-gadget
+++ b/debian-pkg/opt/tinypilot-privileged/init-usb-gadget
@@ -101,11 +101,11 @@ if [[ -f "${USB_KEYBOARD_FUNCTIONS_DIR}/no_out_endpoint" ]]; then
   echo 1 > "${USB_KEYBOARD_FUNCTIONS_DIR}/no_out_endpoint"
 fi
 
-# Mouse
-mkdir -p "$USB_MOUSE_FUNCTIONS_DIR"
-echo 0 > "${USB_MOUSE_FUNCTIONS_DIR}/protocol"
-echo 0 > "${USB_MOUSE_FUNCTIONS_DIR}/subclass"
-echo 7 > "${USB_MOUSE_FUNCTIONS_DIR}/report_length"
+# Absolute mouse
+mkdir -p "$USB_MOUSE_ABSOLUTE_FUNCTIONS_DIR"
+echo 0 > "${USB_MOUSE_ABSOLUTE_FUNCTIONS_DIR}/protocol"
+echo 0 > "${USB_MOUSE_ABSOLUTE_FUNCTIONS_DIR}/subclass"
+echo 7 > "${USB_MOUSE_ABSOLUTE_FUNCTIONS_DIR}/report_length"
 # Write the report descriptor
 D=$(mktemp)
 {
@@ -147,7 +147,7 @@ echo -ne \\x95\\x01      #   REPORT_COUNT (1)
 echo -ne \\x81\\x06      #   INPUT (Data,Var,Rel)
 echo -ne \\xC0           # END_COLLECTION
 } >> "$D"
-cp "$D" "${USB_MOUSE_FUNCTIONS_DIR}/report_desc"
+cp "$D" "${USB_MOUSE_ABSOLUTE_FUNCTIONS_DIR}/report_desc"
 
 mkdir -p "${USB_CONFIG_DIR}"
 echo 250 > "${USB_CONFIG_DIR}/MaxPower"
@@ -157,6 +157,6 @@ mkdir -p "${CONFIGS_STRINGS_DIR}"
 echo "Config ${USB_CONFIG_INDEX}: ECM network" > "${CONFIGS_STRINGS_DIR}/configuration"
 
 ln -s "${USB_KEYBOARD_FUNCTIONS_DIR}" "${USB_CONFIG_DIR}/"
-ln -s "${USB_MOUSE_FUNCTIONS_DIR}" "${USB_CONFIG_DIR}/"
+ln -s "${USB_MOUSE_ABSOLUTE_FUNCTIONS_DIR}" "${USB_CONFIG_DIR}/"
 
 usb_gadget_activate

--- a/debian-pkg/opt/tinypilot-privileged/lib/usb-gadget.sh
+++ b/debian-pkg/opt/tinypilot-privileged/lib/usb-gadget.sh
@@ -14,8 +14,8 @@ export USB_STRINGS_DIR="strings/0x409"
 readonly USB_STRINGS_DIR
 export USB_KEYBOARD_FUNCTIONS_DIR="functions/hid.keyboard"
 readonly USB_KEYBOARD_FUNCTIONS_DIR
-export USB_MOUSE_FUNCTIONS_DIR="functions/hid.mouse"
-readonly USB_MOUSE_FUNCTIONS_DIR
+export USB_MOUSE_ABSOLUTE_FUNCTIONS_DIR="functions/hid.mouse_absolute"
+readonly USB_MOUSE_ABSOLUTE_FUNCTIONS_DIR
 export USB_MASS_STORAGE_NAME="mass_storage.0"
 readonly USB_MASS_STORAGE_NAME
 export USB_MASS_STORAGE_FUNCTIONS_DIR="functions/${USB_MASS_STORAGE_NAME}"

--- a/docs/usb-gadget-driver.md
+++ b/docs/usb-gadget-driver.md
@@ -18,7 +18,7 @@ Examples for possible operations:
 
 ```bash
 # Set up config for a USB mouse.
-mkdir -p functions/hid.mouse
+mkdir -p functions/hid.mouse_absolute
 
 # Make mass storage behave like a CD-ROM drive.
 echo 1 > functions/mass_storage.0/lun.0/cdrom
@@ -31,14 +31,14 @@ The `configfs` files and folders must be in line with a specific, predefined str
 - `/sys/kernel/config/usb_gadget/`: Contains a sub-folder per gadget configuration.
   - `g1/`: We have a single gadget registered right now, which is identified by `g1`. Among other items, this folder contains:
     - `UDC`: While the gadget is activated, this contains the name of the USB device controller (hence the acronym). If the gadget is deactivated, this file is empty. That means, the active-state of the gadget can be controlled through the value in this file.
-    - `functions/`: Contains the actual configurations for the USB interface features. Creating a sub-folder (e.g. `hid.mouse` for the USB mouse) will automatically set up the internal file structure of that new folder. These functions need to be symlinked from the `configs/c.1` folder, otherwise they won’t have any effect. Example items:
-      - `hid.mouse/`: USB mouse config
+    - `functions/`: Contains the actual configurations for the USB interface features. Creating a sub-folder (e.g. `hid.mouse_absolute` for the USB mouse) will automatically set up the internal file structure of that new folder. These functions need to be symlinked from the `configs/c.1` folder, otherwise they won’t have any effect. Example items:
+      - `hid.mouse_absolute/`: USB mouse config (absolute positioning, on `/dev/hidg1`)
       - `hid.keyboard/`: USB keyboard config
       - `mass_storage.0`: USB mass storage config
     - `configs/`: This folder contains the complete and authoritative configurations for the USB gadget. There could be multiple ones, but we only use one right now, which is identified by `c.1`.
       - `c.1/`: Among others:
         - `strings/`: Device info, like the serial number or the manufacturer name.
-        - `hid.mouse/`: Example of a symlink to the `functions/hid.mouse` folder. It only allows a symlink here, you can’t create the configuration in place.
+        - `hid.mouse_absolute/`: Example of a symlink to the `functions/hid.mouse_absolute` folder. It only allows a symlink here, you can’t create the configuration in place.
 
 ## Behaviour
 

--- a/scripts/render-template
+++ b/scripts/render-template
@@ -4,7 +4,7 @@
 To test:
   $ PYTHONPATH="${PWD}/app" ./scripts/render-template <<'EOF'
 KEYBOARD_PATH = '{{ tinypilot_keyboard_interface }}'
-MOUSE_PATH = '{{ tinypilot_mouse_interface }}'
+MOUSE_ABSOLUTE_PATH = '{{ tinypilot_mouse_interface }}'
 EOF
 """
 


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/tinypilot-pro/issues/1925

The PR backports outstanding changes from Pro into Community.

### Notes

- I followed a mostly manual process of:
  1. Copying the Pro `.git` directory in the Community repo
  1. Using VSCode to accept/reject Pro changes into the Community repo
  1. Restoring the Community `.git` directory
  1. Commit and push changes
  1. Installing the bundle on a Raspberry Pi device
     - keyboard, video, and mouse works
 - These changes include:
    - Pin GitHub actions to a commit SHA instead of a tag because tags can silently change to a new commit without us knowing
    - Non-functional changes to absolute mouse related code
    - Severing the bind between nginx and tinypilot systemd services:
       - https://github.com/tiny-pilot/tinypilot-pro/pull/1920
    - Prevent TLS certs from cycling twice on first install:
       - https://github.com/tiny-pilot/tinypilot-pro/pull/1924
    - Prevent `tinypilot-updater` from stopping itself during an upgrade:
       - https://github.com/tiny-pilot/tinypilot-pro/pull/1916
- Merging this PR should generate an empty diff when merging back into Pro

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/tinypilot/1957"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>